### PR TITLE
perf: port pyrx optimization stack and benchmark on PyTorch

### DIFF
--- a/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
+++ b/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
@@ -96,7 +96,9 @@ export class BackgroundAnalysisProgram {
         this._backgroundAnalysis?.setImportResolver(importResolver);
 
         this._program.setImportResolver(importResolver);
-        this.configOptions.getExecutionEnvironments().forEach((e) => this._ensurePartialStubPackages(e));
+        for (const e of this.configOptions.getExecutionEnvironments()) {
+            this._ensurePartialStubPackages(e);
+        }
     }
 
     setTrackedFiles(fileUris: Uri[]) {

--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -322,7 +322,7 @@ export class Binder extends ParseTreeWalker {
 
         // Use the __all__ list to determine whether any potential private
         // symbols should be made externally hidden or private.
-        this._potentialHiddenSymbols.forEach((symbol, name) => {
+        for (const [name, symbol] of this._potentialHiddenSymbols) {
             if (!this._dunderAllNames?.some((sym) => sym === name)) {
                 if (this._fileInfo.isStubFile) {
                     symbol.setIsExternallyHidden();
@@ -330,22 +330,22 @@ export class Binder extends ParseTreeWalker {
                     symbol.setPrivatePyTypedImport();
                 }
             }
-        });
+        }
 
         // Wildcard imports are considered a re-export form, but if this module defines
         // __all__, that list determines the public interface and should restrict which
         // wildcard-imported symbols are exposed.
-        this._potentialWildcardReexportSymbols.forEach((symbol, name) => {
+        for (const [name, symbol] of this._potentialWildcardReexportSymbols) {
             if (this._dunderAllNames && !this._dunderAllNames.some((sym) => sym === name)) {
                 symbol.setPrivatePyTypedImport();
             }
-        });
+        }
 
-        this._potentialPrivateSymbols.forEach((symbol, name) => {
+        for (const [name, symbol] of this._potentialPrivateSymbols) {
             if (!this._dunderAllNames?.some((sym) => sym === name)) {
                 symbol.setIsPrivateMember();
             }
-        });
+        }
 
         if (this._dunderAllNames) {
             AnalyzerNodeInfo.setDunderAllInfo(node, {
@@ -524,11 +524,11 @@ export class Binder extends ParseTreeWalker {
         AnalyzerNodeInfo.setDeclaration(node, functionDeclaration);
 
         // Walk the default values prior to the type parameters.
-        node.d.params.forEach((param) => {
+        for (const param of node.d.params) {
             if (param.d.defaultValue) {
                 this.walk(param.d.defaultValue);
             }
-        });
+        }
 
         let typeParamScope: Scope | undefined;
         if (node.d.typeParams) {
@@ -538,7 +538,7 @@ export class Binder extends ParseTreeWalker {
 
         this.walkMultiple(node.d.decorators);
 
-        node.d.params.forEach((param) => {
+        for (const param of node.d.params) {
             if (param.d.annotation) {
                 this.walk(param.d.annotation);
             }
@@ -546,7 +546,7 @@ export class Binder extends ParseTreeWalker {
             if (param.d.annotationComment) {
                 this.walk(param.d.annotationComment);
             }
-        });
+        }
 
         if (node.d.returnAnnotation) {
             this.walk(node.d.returnAnnotation);
@@ -576,7 +576,7 @@ export class Binder extends ParseTreeWalker {
                     this._currentFlowNode = this._createStartFlowNode();
                     this._codeFlowComplexity = 0;
 
-                    node.d.params.forEach((paramNode) => {
+                    for (const paramNode of node.d.params) {
                         if (paramNode.d.name) {
                             const symbol = this._bindNameToScope(this._currentScope, paramNode.d.name);
 
@@ -596,7 +596,7 @@ export class Binder extends ParseTreeWalker {
 
                             this._createFlowAssignment(paramNode.d.name);
                         }
-                    });
+                    }
 
                     this._targetFunctionDeclaration = functionDeclaration;
                     this._currentReturnTarget = this._createBranchLabel();
@@ -636,11 +636,11 @@ export class Binder extends ParseTreeWalker {
 
         // Analyze the parameter defaults in the context of the parent's scope
         // before we add any names from the function's scope.
-        node.d.params.forEach((param) => {
+        for (const param of node.d.params) {
             if (param.d.defaultValue) {
                 this.walk(param.d.defaultValue);
             }
-        });
+        }
 
         this._createNewScope(ScopeType.Function, this._getNonClassParentScope(), /* proxyScope */ undefined, () => {
             AnalyzerNodeInfo.setScope(node, this._currentScope);
@@ -649,7 +649,7 @@ export class Binder extends ParseTreeWalker {
                 // Create a start node for the lambda.
                 this._currentFlowNode = this._createStartFlowNode();
 
-                node.d.params.forEach((paramNode) => {
+                for (const paramNode of node.d.params) {
                     if (paramNode.d.name) {
                         const symbol = this._bindNameToScope(this._currentScope, paramNode.d.name);
                         if (symbol) {
@@ -670,7 +670,7 @@ export class Binder extends ParseTreeWalker {
                         this.walk(paramNode.d.name);
                         AnalyzerNodeInfo.setFlowNode(paramNode, this._currentFlowNode!);
                     }
-                });
+                }
 
                 // Walk the expression that make up the lambda body.
                 this.walk(node.d.expr);
@@ -689,12 +689,12 @@ export class Binder extends ParseTreeWalker {
 
             const sortedArgs = ParseTreeUtils.getArgsByRuntimeOrder(node);
 
-            sortedArgs.forEach((argNode) => {
+            for (const argNode of sortedArgs) {
                 if (this._currentFlowNode) {
                     AnalyzerNodeInfo.setFlowNode(argNode, this._currentFlowNode);
                 }
                 this.walk(argNode);
-            });
+            }
         });
 
         // Create a call flow node. We'll skip this if the call is part of
@@ -751,9 +751,9 @@ export class Binder extends ParseTreeWalker {
                     // Is this a call to "__all__.extend(<mod>.__all__)"?
                     const namesToAdd = this._getDunderAllNamesFromImport(argExpr.d.leftExpr.d.value);
                     if (namesToAdd && namesToAdd.length > 0) {
-                        namesToAdd.forEach((name) => {
+                        for (const name of namesToAdd) {
                             this._dunderAllNames?.push(name);
-                        });
+                        }
                     }
                     emitDunderAllWarning = false;
                 }
@@ -803,15 +803,15 @@ export class Binder extends ParseTreeWalker {
     override visitTypeParameterList(node: TypeParameterListNode): boolean {
         const typeParamScope = new Scope(ScopeType.TypeParameter, this._getNonClassParentScope(), this._currentScope);
 
-        node.d.params.forEach((param) => {
+        for (const param of node.d.params) {
             if (param.d.boundExpr) {
                 this.walk(param.d.boundExpr);
             }
-        });
+        }
 
         const typeParamsSeen = new Set<string>();
 
-        node.d.params.forEach((param) => {
+        for (const param of node.d.params) {
             const name = param.d.name;
             const symbol = typeParamScope.addSymbol(name.d.value, SymbolFlags.None);
             const paramDeclaration: TypeParamDeclaration = {
@@ -834,13 +834,13 @@ export class Binder extends ParseTreeWalker {
             } else {
                 typeParamsSeen.add(name.d.value);
             }
-        });
+        }
 
-        node.d.params.forEach((param) => {
+        for (const param of node.d.params) {
             if (param.d.defaultExpr) {
                 this.walk(param.d.defaultExpr);
             }
-        });
+        }
 
         AnalyzerNodeInfo.setScope(node, typeParamScope);
 
@@ -959,7 +959,7 @@ export class Binder extends ParseTreeWalker {
                 let emitDunderAllWarning = false;
 
                 if (expr.nodeType === ParseNodeType.List) {
-                    expr.d.items.forEach((listEntryNode) => {
+                    for (const listEntryNode of expr.d.items) {
                         if (
                             listEntryNode.nodeType === ParseNodeType.StringList &&
                             listEntryNode.d.strings.length === 1 &&
@@ -970,9 +970,9 @@ export class Binder extends ParseTreeWalker {
                         } else {
                             emitDunderAllWarning = true;
                         }
-                    });
+                    }
                 } else if (expr.nodeType === ParseNodeType.Tuple) {
-                    expr.d.items.forEach((tupleEntryNode) => {
+                    for (const tupleEntryNode of expr.d.items) {
                         if (
                             tupleEntryNode.nodeType === ParseNodeType.StringList &&
                             tupleEntryNode.d.strings.length === 1 &&
@@ -983,7 +983,7 @@ export class Binder extends ParseTreeWalker {
                         } else {
                             emitDunderAllWarning = true;
                         }
-                    });
+                    }
                 } else {
                     emitDunderAllWarning = true;
                 }
@@ -1015,7 +1015,7 @@ export class Binder extends ParseTreeWalker {
                 if (expr.nodeType === ParseNodeType.StringList) {
                     this._dunderSlotsEntries.push(expr);
                 } else if (expr.nodeType === ParseNodeType.List) {
-                    expr.d.items.forEach((listEntryNode) => {
+                    for (const listEntryNode of expr.d.items) {
                         if (
                             listEntryNode.nodeType === ParseNodeType.StringList &&
                             listEntryNode.d.strings.length === 1 &&
@@ -1025,9 +1025,9 @@ export class Binder extends ParseTreeWalker {
                         } else {
                             isExpressionUnderstood = false;
                         }
-                    });
+                    }
                 } else if (expr.nodeType === ParseNodeType.Tuple) {
-                    expr.d.items.forEach((tupleEntryNode) => {
+                    for (const tupleEntryNode of expr.d.items) {
                         if (
                             tupleEntryNode.nodeType === ParseNodeType.StringList &&
                             tupleEntryNode.d.strings.length === 1 &&
@@ -1037,7 +1037,7 @@ export class Binder extends ParseTreeWalker {
                         } else {
                             isExpressionUnderstood = false;
                         }
-                    });
+                    }
                 } else {
                     isExpressionUnderstood = false;
                 }
@@ -1117,7 +1117,7 @@ export class Binder extends ParseTreeWalker {
 
             if (expr.nodeType === ParseNodeType.List) {
                 // Is this the form __all__ += ["a", "b"]?
-                expr.d.items.forEach((listEntryNode) => {
+                for (const listEntryNode of expr.d.items) {
                     if (
                         listEntryNode.nodeType === ParseNodeType.StringList &&
                         listEntryNode.d.strings.length === 1 &&
@@ -1126,7 +1126,7 @@ export class Binder extends ParseTreeWalker {
                         this._dunderAllNames?.push(listEntryNode.d.strings[0].d.value);
                         this._dunderAllStringNodes.push(listEntryNode.d.strings[0]);
                     }
-                });
+                }
                 emitDunderAllWarning = false;
             } else if (
                 expr.nodeType === ParseNodeType.MemberAccess &&
@@ -1136,9 +1136,9 @@ export class Binder extends ParseTreeWalker {
                 // Is this using the form "__all__ += <mod>.__all__"?
                 const namesToAdd = this._getDunderAllNamesFromImport(expr.d.leftExpr.d.value);
                 if (namesToAdd) {
-                    namesToAdd.forEach((name) => {
+                    for (const name of namesToAdd) {
                         this._dunderAllNames?.push(name);
-                    });
+                    }
 
                     emitDunderAllWarning = false;
                 }
@@ -1159,11 +1159,11 @@ export class Binder extends ParseTreeWalker {
     }
 
     override visitDel(node: DelNode) {
-        node.d.targets.forEach((expr) => {
+        for (const expr of node.d.targets) {
             this._bindPossibleTupleNamedTarget(expr);
             this.walk(expr);
             this._createAssignmentTargetFlowNodes(expr, /* walkTargets */ false, /* unbound */ true);
-        });
+        }
 
         return false;
     }
@@ -1198,10 +1198,10 @@ export class Binder extends ParseTreeWalker {
         // is unbound.
         const expressionList: CodeFlowReferenceExpressionNode[] = [];
         if (this._isNarrowingExpression(node.d.valueExpr, expressionList)) {
-            expressionList.forEach((expr) => {
+            for (const expr of expressionList) {
                 const referenceKey = createKeyForReference(expr);
                 this._currentScopeCodeFlowExpressions!.add(referenceKey);
-            });
+            }
         }
 
         this.walk(node.d.valueExpr);
@@ -1231,9 +1231,9 @@ export class Binder extends ParseTreeWalker {
             this._addAntecedent(preForLabel, this._currentFlowNode!);
 
             // Add any target expressions since they are modified in the loop.
-            targetExpressions.forEach((value) => {
+            for (const value of targetExpressions) {
                 this._currentScopeCodeFlowExpressions?.add(value);
-            });
+            }
         });
 
         this._currentFlowNode = this._finishFlowLabel(preElseLabel);
@@ -1293,9 +1293,9 @@ export class Binder extends ParseTreeWalker {
         if (this._currentReturnTarget) {
             this._addAntecedent(this._currentReturnTarget, this._currentFlowNode!);
         }
-        this._finallyTargets.forEach((target) => {
+        for (const target of this._finallyTargets) {
             this._addAntecedent(target, this._currentFlowNode!);
-        });
+        }
         this._currentFlowNode = Binder._unreachableStructuralFlowNode;
         return false;
     }
@@ -1340,9 +1340,9 @@ export class Binder extends ParseTreeWalker {
             this._isInAnnotatedAnnotation = true;
         }
 
-        node.d.items.forEach((argNode) => {
+        for (const argNode of node.d.items) {
             this.walk(argNode);
-        });
+        }
 
         this._isInAnnotatedAnnotation = wasInAnnotatedAnnotation;
 
@@ -1506,9 +1506,9 @@ export class Binder extends ParseTreeWalker {
             this.walk(node.d.fromExpr);
         }
 
-        this._finallyTargets.forEach((target) => {
+        for (const target of this._finallyTargets) {
             this._addAntecedent(target, this._currentFlowNode!);
-        });
+        }
 
         this._currentFlowNode = Binder._unreachableStructuralFlowNode;
         return false;
@@ -1582,9 +1582,9 @@ export class Binder extends ParseTreeWalker {
             // An exception may be generated before the first flow node
             // added by the try block, so all of the exception targets
             // must have the pre-try flow node as an antecedent.
-            curExceptTargets.forEach((exceptLabel) => {
+            for (const exceptLabel of curExceptTargets) {
                 this._addAntecedent(exceptLabel, this._currentFlowNode!);
-            });
+            }
 
             // We don't perfectly handle nested finally clauses, which are not
             // possible to model fully within a static analyzer, but we do handle
@@ -1611,14 +1611,15 @@ export class Binder extends ParseTreeWalker {
             }
 
             // Handle the except blocks.
-            node.d.exceptClauses.forEach((exceptNode, index) => {
+            for (let index = 0; index < node.d.exceptClauses.length; index++) {
+                const exceptNode = node.d.exceptClauses[index];
                 this._currentFlowNode = this._finishFlowLabel(curExceptTargets[index]);
                 this.walk(exceptNode);
                 this._addAntecedent(preFinallyLabel, this._currentFlowNode);
                 if (!this._isCodeUnreachable()) {
                     isAfterElseAndExceptsReachable = true;
                 }
-            });
+            }
 
             if (node.d.finallySuite) {
                 this._finallyTargets.pop();
@@ -1677,7 +1678,7 @@ export class Binder extends ParseTreeWalker {
     override visitGlobal(node: GlobalNode): boolean {
         const globalScope = this._currentScope.getGlobalScope().scope;
 
-        node.d.targets.forEach((name) => {
+        for (const name of node.d.targets) {
             const nameValue = name.d.value;
 
             // Is the binding inconsistent?
@@ -1698,7 +1699,7 @@ export class Binder extends ParseTreeWalker {
             if (this._currentScope !== globalScope) {
                 this._currentScope.setBindingType(nameValue, NameBindingType.Global);
             }
-        });
+        }
 
         return true;
     }
@@ -1709,7 +1710,7 @@ export class Binder extends ParseTreeWalker {
         if (this._currentScope === globalScope) {
             this._addSyntaxError(LocMessage.nonLocalInModule(), node);
         } else {
-            node.d.targets.forEach((name) => {
+            for (const name of node.d.targets) {
                 const nameValue = name.d.value;
 
                 // Is the binding inconsistent?
@@ -1729,7 +1730,7 @@ export class Binder extends ParseTreeWalker {
                 if (valueWithScope) {
                     this._currentScope.setBindingType(nameValue, NameBindingType.Nonlocal);
                 }
-            });
+            }
         }
 
         return true;
@@ -1856,7 +1857,7 @@ export class Binder extends ParseTreeWalker {
                         }
                     }
 
-                    wildcardNames.forEach((name) => {
+                    for (const name of wildcardNames) {
                         const localSymbol = this._bindNameValueToScope(this._currentScope, name);
 
                         if (localSymbol) {
@@ -1931,21 +1932,21 @@ export class Binder extends ParseTreeWalker {
                                 localSymbol.setTypingSymbolAlias(name);
                             }
                         }
-                    });
+                    }
                 }
 
                 this._createFlowWildcardImport(node, names);
 
                 if (isTypingImport) {
-                    typingSymbolsOfInterest.forEach((s) => {
+                    for (const s of typingSymbolsOfInterest) {
                         this._typingSymbolAliases.set(s, s);
-                    });
+                    }
                 }
 
                 if (isDataclassesImport) {
-                    dataclassesSymbolsOfInterest.forEach((s) => {
+                    for (const s of dataclassesSymbolsOfInterest) {
                         this._dataclassesSymbolAliases.set(s, s);
-                    });
+                    }
                 }
             }
         } else {
@@ -1953,7 +1954,7 @@ export class Binder extends ParseTreeWalker {
                 this._addImplicitFromImport(node, importInfo);
             }
 
-            node.d.imports.forEach((importSymbolNode) => {
+            for (const importSymbolNode of node.d.imports) {
                 const importedName = importSymbolNode.d.name.d.value;
                 const nameNode = importSymbolNode.d.alias || importSymbolNode.d.name;
 
@@ -2051,21 +2052,21 @@ export class Binder extends ParseTreeWalker {
                         }
                     }
                 }
-            });
+            }
         }
 
         return true;
     }
 
     override visitWith(node: WithNode): boolean {
-        node.d.withItems.forEach((item) => {
+        for (const item of node.d.withItems) {
             this.walk(item.d.expr);
             if (item.d.target) {
                 this._bindPossibleTupleNamedTarget(item.d.target);
                 this._addInferredTypeAssignmentForVariable(item.d.target, item);
                 this._createAssignmentTargetFlowNodes(item.d.target, /* walkTargets */ true, /* unbound */ false);
             }
-        });
+        }
 
         // We need to treat the "with" body as though it is wrapped in a try/except
         // block because some context managers catch and suppress exceptions.
@@ -2104,9 +2105,9 @@ export class Binder extends ParseTreeWalker {
             !!node.d.isAsync,
             /* blockIfSwallowsExceptions */ true
         );
-        this._currentExceptTargets.forEach((exceptionTarget) => {
+        for (const exceptionTarget of this._currentExceptTargets) {
             this._addAntecedent(exceptionTarget, contextManagerForwardExceptionTarget);
-        });
+        }
 
         const preWithSuiteNode = this._currentFlowNode!;
         const postContextManagerLabel = this._createBranchLabel(preWithSuiteNode);
@@ -2301,18 +2302,18 @@ export class Binder extends ParseTreeWalker {
         // We also support narrowing of individual tuple entries found within a
         // match subject expression, so add those here as well.
         if (node.d.expr.nodeType === ParseNodeType.Tuple) {
-            node.d.expr.d.items.forEach((itemExpr) => {
+            for (const itemExpr of node.d.expr.d.items) {
                 if (this._isNarrowingExpression(itemExpr, expressionList)) {
                     isSubjectNarrowable = true;
                 }
-            });
+            }
         }
 
         if (isSubjectNarrowable) {
-            expressionList.forEach((expr) => {
+            for (const expr of expressionList) {
                 const referenceKey = createKeyForReference(expr);
                 this._currentScopeCodeFlowExpressions!.add(referenceKey);
-            });
+            }
         }
 
         const postMatchLabel = this._createBranchLabel();
@@ -2321,7 +2322,7 @@ export class Binder extends ParseTreeWalker {
         // Model the match statement as a series of if/elif clauses
         // each of which tests for the specified pattern (and optionally
         // for the guard condition).
-        node.d.cases.forEach((caseStatement) => {
+        for (const caseStatement of node.d.cases) {
             const postCaseLabel = this._createBranchLabel();
             const preGuardLabel = this._createBranchLabel();
             const preSuiteLabel = this._createBranchLabel();
@@ -2366,7 +2367,7 @@ export class Binder extends ParseTreeWalker {
             this._addAntecedent(postMatchLabel, this._currentFlowNode);
 
             this._currentFlowNode = this._finishFlowLabel(postCaseLabel);
-        });
+        }
 
         // Add a final narrowing step for the subject expression for the entire
         // match statement. This will compute the narrowed type if no case
@@ -2390,10 +2391,10 @@ export class Binder extends ParseTreeWalker {
     override visitPatternAs(node: PatternAsNode) {
         const postOrLabel = this._createBranchLabel();
 
-        node.d.orPatterns.forEach((orPattern) => {
+        for (const orPattern of node.d.orPatterns) {
             this.walk(orPattern);
             this._addAntecedent(postOrLabel, this._currentFlowNode!);
-        });
+        }
 
         this._currentFlowNode = this._finishFlowLabel(postOrLabel);
 
@@ -2443,12 +2444,12 @@ export class Binder extends ParseTreeWalker {
         }
 
         const symbolTable = this._fileInfo.builtinsScope.symbolTable;
-        symbolTable.forEach((symbol, name) => {
+        for (const [name, symbol] of symbolTable) {
             const typingImportAlias = symbol.getTypingSymbolAlias();
             if (typingImportAlias && !symbol.isExternallyHidden()) {
                 this._typingSymbolAliases.set(name, typingImportAlias);
             }
-        });
+        }
     }
 
     private _formatModuleName(node: ModuleNameNode): string {
@@ -3029,10 +3030,10 @@ export class Binder extends ParseTreeWalker {
             return antecedent;
         }
 
-        expressionList.forEach((expr) => {
+        for (const expr of expressionList) {
             const referenceKey = createKeyForReference(expr);
             this._currentScopeCodeFlowExpressions!.add(referenceKey);
-        });
+        }
 
         // Select the first name expression.
         const filteredExprList = expressionList.filter((expr) => expr.nodeType === ParseNodeType.Name);
@@ -3315,9 +3316,9 @@ export class Binder extends ParseTreeWalker {
             }
 
             case ParseNodeType.Tuple: {
-                target.d.items.forEach((expr) => {
+                for (const expr of target.d.items) {
                     this._createAssignmentTargetFlowNodes(expr, walkTargets, unbound);
-                });
+                }
                 break;
             }
 
@@ -3338,9 +3339,9 @@ export class Binder extends ParseTreeWalker {
             }
 
             case ParseNodeType.List: {
-                target.d.items.forEach((entry) => {
+                for (const entry of target.d.items) {
                     this._createAssignmentTargetFlowNodes(entry, walkTargets, unbound);
-                });
+                }
                 break;
             }
 
@@ -3466,9 +3467,9 @@ export class Binder extends ParseTreeWalker {
         // If there are any except targets, then we're in a try block, and we
         // have to assume that an exception can be raised after every assignment.
         if (this._currentExceptTargets) {
-            this._currentExceptTargets.forEach((label) => {
+            for (const label of this._currentExceptTargets) {
                 this._addAntecedent(label, flowNode);
-            });
+            }
         }
     }
 
@@ -3480,9 +3481,9 @@ export class Binder extends ParseTreeWalker {
         const scopedExpressions = this._currentScopeCodeFlowExpressions;
 
         if (savedExpressions) {
-            this._currentScopeCodeFlowExpressions.forEach((value) => {
+            for (const value of this._currentScopeCodeFlowExpressions) {
                 savedExpressions.add(value);
-            });
+            }
         }
 
         this._currentScopeCodeFlowExpressions = savedExpressions;
@@ -3578,16 +3579,16 @@ export class Binder extends ParseTreeWalker {
             }
 
             case ParseNodeType.Tuple: {
-                target.d.items.forEach((expr) => {
+                for (const expr of target.d.items) {
                     this._bindPossibleTupleNamedTarget(expr, addedSymbols);
-                });
+                }
                 break;
             }
 
             case ParseNodeType.List: {
-                target.d.items.forEach((expr) => {
+                for (const expr of target.d.items) {
                     this._bindPossibleTupleNamedTarget(expr, addedSymbols);
-                });
+                }
                 break;
             }
 
@@ -3756,9 +3757,9 @@ export class Binder extends ParseTreeWalker {
             }
 
             case ParseNodeType.Tuple: {
-                target.d.items.forEach((expr) => {
+                for (const expr of target.d.items) {
                     this._addInferredTypeAssignmentForVariable(expr, source);
-                });
+                }
                 break;
             }
 
@@ -3773,9 +3774,9 @@ export class Binder extends ParseTreeWalker {
             }
 
             case ParseNodeType.List: {
-                target.d.items.forEach((entry) => {
+                for (const entry of target.d.items) {
                     this._addInferredTypeAssignmentForVariable(entry, source);
-                });
+                }
                 break;
             }
         }
@@ -4174,24 +4175,26 @@ export class Binder extends ParseTreeWalker {
     }
 
     private _addImplicitImportsToLoaderActions(importResult: ImportResult, loaderActions: ModuleLoaderActions) {
-        importResult.filteredImplicitImports?.forEach((implicitImport) => {
-            const existingLoaderAction = loaderActions.implicitImports
-                ? loaderActions.implicitImports.get(implicitImport.name)
-                : undefined;
-            if (existingLoaderAction) {
-                existingLoaderAction.uri = implicitImport.uri;
-                existingLoaderAction.loadSymbolsFromPath = true;
-            } else {
-                if (!loaderActions.implicitImports) {
-                    loaderActions.implicitImports = new Map<string, ModuleLoaderActions>();
+        if (importResult.filteredImplicitImports) {
+            for (const implicitImport of importResult.filteredImplicitImports.values()) {
+                const existingLoaderAction = loaderActions.implicitImports
+                    ? loaderActions.implicitImports.get(implicitImport.name)
+                    : undefined;
+                if (existingLoaderAction) {
+                    existingLoaderAction.uri = implicitImport.uri;
+                    existingLoaderAction.loadSymbolsFromPath = true;
+                } else {
+                    if (!loaderActions.implicitImports) {
+                        loaderActions.implicitImports = new Map<string, ModuleLoaderActions>();
+                    }
+                    loaderActions.implicitImports.set(implicitImport.name, {
+                        uri: implicitImport.uri,
+                        loadSymbolsFromPath: true,
+                        implicitImports: new Map<string, ModuleLoaderActions>(),
+                    });
                 }
-                loaderActions.implicitImports.set(implicitImport.name, {
-                    uri: implicitImport.uri,
-                    loadSymbolsFromPath: true,
-                    implicitImports: new Map<string, ModuleLoaderActions>(),
-                });
             }
-        });
+        }
     }
 
     // Handles some special-case assignment statements that are found

--- a/packages/pyright-internal/src/analyzer/cacheManager.ts
+++ b/packages/pyright-internal/src/analyzer/cacheManager.ts
@@ -71,7 +71,7 @@ export class CacheManager {
     }
 
     unregisterCacheOwner(provider: CacheOwner) {
-        const index = this._cacheOwners.findIndex((p) => p === provider);
+        const index = this._cacheOwners.indexOf(provider);
         if (index < 0) {
             fail('Specified cache provider not found');
         } else {
@@ -96,9 +96,9 @@ export class CacheManager {
 
         let totalUsage = 0;
 
-        this._cacheOwners.forEach((p) => {
+        for (const p of this._cacheOwners) {
             totalUsage += p.getCacheUsage();
-        });
+        }
 
         return totalUsage;
     }
@@ -114,9 +114,9 @@ export class CacheManager {
             );
         }
 
-        this._cacheOwners.forEach((p) => {
+        for (const p of this._cacheOwners) {
             p.emptyCache();
-        });
+        }
     }
 
     // Returns a ratio of used bytes to total bytes.
@@ -178,7 +178,11 @@ export class CacheManager {
         if (buffer) {
             const view = new Float64Array(buffer);
             view[this._sharedUsagePosition] = heapStats.used_heap_size;
-            return view.reduce((a, b) => a + b, 0);
+            let total = 0;
+            for (let i = 0; i < view.length; i++) {
+                total += view[i];
+            }
+            return total;
         }
 
         return heapStats.used_heap_size;

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -87,7 +87,7 @@ import {
     isExpressionNode,
 } from '../parser/parseNodes';
 import { ParserOutput } from '../parser/parser';
-import { UnescapeError, UnescapeErrorType, getUnescapedString } from '../parser/stringTokenUtils';
+import { UnescapeErrorType, getUnescapedString } from '../parser/stringTokenUtils';
 import { OperatorType, StringTokenFlags, TokenType } from '../parser/tokenizerTypes';
 import { AnalyzerFileInfo } from './analyzerFileInfo';
 import * as AnalyzerNodeInfo from './analyzerNodeInfo';
@@ -6171,7 +6171,7 @@ export class Checker extends ParseTreeWalker {
     // are decorated. For example, if the first overload is not marked @final
     // but subsequent ones are, an error should be reported.
     private _validateOverloadDecoratorConsistency(classType: ClassType) {
-        for (const [name, symbol] of ClassType.getSymbolTable(classType)) {
+        for (const symbol of ClassType.getSymbolTable(classType).values()) {
             const primaryDecl = getLastTypedDeclarationForSymbol(symbol);
 
             if (!primaryDecl || primaryDecl.type !== DeclarationType.Function) {

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -214,6 +214,18 @@ interface TypeVarUsageInfo {
 // functions to be emitted.
 const isPrintCodeComplexityEnabled = false;
 
+// Pre-allocated constant sets for hot-path membership checks.
+const simpleUnusedExpressionTypes = new Set([
+    ParseNodeType.UnaryOperation,
+    ParseNodeType.BinaryOperation,
+    ParseNodeType.Number,
+    ParseNodeType.Constant,
+    ParseNodeType.Name,
+    ParseNodeType.Tuple,
+]);
+const varianceExemptMethods = new Set(['__init__', '__new__']);
+const lspExemptMethods = new Set(['__init__', '__new__', '__init_subclass__', '__post_init__']);
+
 export class Checker extends ParseTreeWalker {
     private readonly _moduleNode: ModuleNode;
     private readonly _fileInfo: AnalyzerFileInfo;
@@ -600,15 +612,13 @@ export class Checker extends ParseTreeWalker {
                 const annotationNode = param.d.annotation || param.d.annotationComment;
                 if (annotationNode && index < functionTypeResult.functionType.shared.parameters.length) {
                     const paramType = FunctionType.getParamType(functionTypeResult.functionType, index);
-                    const exemptMethods = ['__init__', '__new__'];
-
                     if (
                         containingClassNode &&
                         isTypeVar(paramType) &&
                         paramType.priv.scopeType === TypeVarScopeType.Class &&
                         paramType.shared.declaredVariance === Variance.Covariant &&
                         !paramType.shared.isSynthesized &&
-                        !exemptMethods.some((name) => name === functionTypeResult.functionType.shared.name)
+                        !varianceExemptMethods.has(functionTypeResult.functionType.shared.name)
                     ) {
                         this._evaluator.addDiagnostic(
                             DiagnosticRule.reportGeneralTypeIssues,
@@ -1942,18 +1952,9 @@ export class Checker extends ParseTreeWalker {
             return;
         }
 
-        const simpleExpressionTypes = [
-            ParseNodeType.UnaryOperation,
-            ParseNodeType.BinaryOperation,
-            ParseNodeType.Number,
-            ParseNodeType.Constant,
-            ParseNodeType.Name,
-            ParseNodeType.Tuple,
-        ];
-
         let reportAsUnused = false;
 
-        if (simpleExpressionTypes.some((nodeType) => nodeType === node.nodeType)) {
+        if (simpleUnusedExpressionTypes.has(node.nodeType)) {
             reportAsUnused = true;
         } else if (
             node.nodeType === ParseNodeType.List ||
@@ -6526,8 +6527,7 @@ export class Checker extends ParseTreeWalker {
 
     // Determines whether the name is exempt from Liskov Substitution Principle rules.
     private _isMethodExemptFromLsp(name: string): boolean {
-        const exemptMethods = ['__init__', '__new__', '__init_subclass__', '__post_init__'];
-        return exemptMethods.some((n) => n === name);
+        return lspExemptMethods.has(name);
     }
 
     // Determines whether the type is a function or overloaded function with an @override

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -309,7 +309,7 @@ export class Checker extends ParseTreeWalker {
     }
 
     override visitStatementList(node: StatementListNode) {
-        node.d.statements.forEach((statement) => {
+        for (const statement of node.d.statements) {
             if (isExpressionNode(statement)) {
                 // Evaluate the expression in case it wasn't otherwise evaluated
                 // through lazy analysis. This will mark referenced symbols as
@@ -318,7 +318,7 @@ export class Checker extends ParseTreeWalker {
 
                 this._reportUnusedExpression(statement);
             }
-        });
+        }
 
         return true;
     }
@@ -336,7 +336,7 @@ export class Checker extends ParseTreeWalker {
         if (classTypeResult) {
             // Protocol classes cannot derive from non-protocol classes.
             if (ClassType.isProtocolClass(classTypeResult.classType)) {
-                node.d.arguments.forEach((arg) => {
+                for (const arg of node.d.arguments) {
                     if (!arg.d.name) {
                         const baseClassType = this._evaluator.getType(arg.d.valueExpr);
                         if (
@@ -357,7 +357,7 @@ export class Checker extends ParseTreeWalker {
                             }
                         }
                     }
-                });
+                }
 
                 // If this is a generic protocol class, verify that its type variables
                 // have the proper variance.
@@ -434,7 +434,8 @@ export class Checker extends ParseTreeWalker {
             const paramDetails = getParamListDetails(functionTypeResult.functionType);
 
             // Report any unknown or missing parameter types.
-            node.d.params.forEach((param, index) => {
+            for (let index = 0; index < node.d.params.length; index++) {
+                const param = node.d.params[index];
                 if (param.d.name) {
                     if (param.d.category === ParamCategory.Simple && index >= paramDetails.positionOnlyParamCount) {
                         keywordNames.add(param.d.name.d.value);
@@ -525,7 +526,7 @@ export class Checker extends ParseTreeWalker {
                         }
                     }
                 }
-            });
+            }
 
             // Verify that an unpacked TypedDict doesn't overlap any keyword parameters.
             if (paramDetails.hasUnpackedTypedDict) {
@@ -534,11 +535,11 @@ export class Checker extends ParseTreeWalker {
 
                 if (isClass(kwargsType) && kwargsType.shared.typedDictEntries) {
                     const overlappingEntries = new Set<string>();
-                    kwargsType.shared.typedDictEntries.knownItems.forEach((_, name) => {
+                    for (const [name] of kwargsType.shared.typedDictEntries.knownItems) {
                         if (keywordNames.has(name)) {
                             overlappingEntries.add(name);
                         }
-                    });
+                    }
 
                     if (overlappingEntries.size > 0) {
                         this._evaluator.addDiagnostic(
@@ -594,7 +595,8 @@ export class Checker extends ParseTreeWalker {
             }
         }
 
-        node.d.params.forEach((param, index) => {
+        for (let index = 0; index < node.d.params.length; index++) {
+            const param = node.d.params[index];
             if (param.d.defaultValue) {
                 this.walk(param.d.defaultValue);
             }
@@ -628,7 +630,7 @@ export class Checker extends ParseTreeWalker {
                     }
                 }
             }
-        });
+        }
 
         if (node.d.returnAnnotation) {
             this.walk(node.d.returnAnnotation);
@@ -651,11 +653,11 @@ export class Checker extends ParseTreeWalker {
 
         this.walkMultiple(node.d.decorators);
 
-        node.d.params.forEach((param) => {
+        for (const param of node.d.params) {
             if (param.d.name) {
                 this.walk(param.d.name);
             }
-        });
+        }
 
         const codeComplexity = AnalyzerNodeInfo.getCodeFlowComplexity(node);
         const isTooComplexToAnalyze = codeComplexity > maxCodeComplexity;
@@ -757,7 +759,7 @@ export class Checker extends ParseTreeWalker {
         // Walk the children.
         this.walkMultiple([...node.d.params, node.d.expr]);
 
-        node.d.params.forEach((param) => {
+        for (const param of node.d.params) {
             if (param.d.name) {
                 const paramType = this._evaluator.getType(param.d.name);
                 if (paramType) {
@@ -776,7 +778,7 @@ export class Checker extends ParseTreeWalker {
                     }
                 }
             }
-        });
+        }
 
         const returnType = this._evaluator.getType(node.d.expr);
         if (returnType) {
@@ -917,9 +919,9 @@ export class Checker extends ParseTreeWalker {
     }
 
     override visitWith(node: WithNode): boolean {
-        node.d.withItems.forEach((item) => {
+        for (const item of node.d.withItems) {
             this._evaluator.evaluateTypesForStatement(item);
-        });
+        }
 
         if (node.d.typeComment) {
             this._evaluator.addDiagnosticForTextRange(
@@ -1354,14 +1356,14 @@ export class Checker extends ParseTreeWalker {
             const stringTokens =
                 stringNode.nodeType === ParseNodeType.String ? [stringNode.d.token] : stringNode.d.middleTokens;
 
-            stringTokens.forEach((token) => {
+            for (const token of stringTokens) {
                 const unescapedResult = getUnescapedString(token);
                 let start = token.start;
                 if (token.type === TokenType.String) {
                     start += token.prefixLength + token.quoteMarkLength;
                 }
 
-                unescapedResult.unescapeErrors.forEach((error: UnescapeError) => {
+                for (const error of unescapedResult.unescapeErrors) {
                     if (error.errorType === UnescapeErrorType.InvalidEscapeSequence) {
                         this._evaluator.addDiagnosticForTextRange(
                             this._fileInfo,
@@ -1372,7 +1374,7 @@ export class Checker extends ParseTreeWalker {
                             { start: start + error.offset, length: error.length }
                         );
                     }
-                });
+                }
 
                 // Prior to Python 3.12, it was not allowed to include a slash in an f-string.
                 if (fStringContainers.length > 0) {
@@ -1386,7 +1388,7 @@ export class Checker extends ParseTreeWalker {
                         );
                     }
                 }
-            });
+            }
 
             // Prior to Python 3.12, it was not allowed to nest strings that
             // used the same quote scheme within an f-string.
@@ -1426,24 +1428,24 @@ export class Checker extends ParseTreeWalker {
     }
 
     override visitFormatString(node: FormatStringNode): boolean {
-        node.d.fieldExprs.forEach((expr) => {
+        for (const expr of node.d.fieldExprs) {
             this._evaluator.getType(expr);
-        });
+        }
 
-        node.d.formatExprs.forEach((expr) => {
+        for (const expr of node.d.formatExprs) {
             this._evaluator.getType(expr);
-        });
+        }
 
         return true;
     }
 
     override visitGlobal(node: GlobalNode): boolean {
         this._suppressUnboundCheck(() => {
-            node.d.targets.forEach((name) => {
+            for (const name of node.d.targets) {
                 this._evaluator.getType(name);
 
                 this.walk(name);
-            });
+            }
         });
 
         return false;
@@ -1451,13 +1453,13 @@ export class Checker extends ParseTreeWalker {
 
     override visitNonlocal(node: NonlocalNode): boolean {
         this._suppressUnboundCheck(() => {
-            node.d.targets.forEach((name) => {
+            for (const name of node.d.targets) {
                 this._evaluator.getType(name);
 
                 this.walk(name);
 
                 this._validateNonlocalTypeParam(name);
-            });
+            }
         });
 
         return false;
@@ -1480,11 +1482,11 @@ export class Checker extends ParseTreeWalker {
     }
 
     override visitDel(node: DelNode) {
-        node.d.targets.forEach((expr) => {
+        for (const expr of node.d.targets) {
             this._evaluator.verifyDeleteExpression(expr);
 
             this.walk(expr);
-        });
+        }
 
         return false;
     }
@@ -1538,9 +1540,9 @@ export class Checker extends ParseTreeWalker {
         }
 
         if (!node.d.isWildcardImport) {
-            node.d.imports.forEach((importAs) => {
+            for (const importAs of node.d.imports) {
                 this._evaluator.evaluateTypesForStatement(importAs);
-            });
+            }
         } else {
             this._evaluator.evaluateTypesForStatement(node);
 
@@ -1726,7 +1728,7 @@ export class Checker extends ParseTreeWalker {
     }
 
     private _reportUnusedMultipartImports() {
-        this._multipartImports.forEach((node) => {
+        for (const node of this._multipartImports) {
             const nameParts = node.d.module.d.nameParts;
 
             if (this._isMultipartImportUnused(node)) {
@@ -1747,7 +1749,7 @@ export class Checker extends ParseTreeWalker {
                     textRange
                 );
             }
-        });
+        }
     }
 
     private _isMultipartImportUnused(node: ImportAsNode): boolean {
@@ -2446,13 +2448,13 @@ export class Checker extends ParseTreeWalker {
         });
 
         // Find all of the local type variables in signature.
-        node.d.params.forEach((param) => {
+        for (const param of node.d.params) {
             const annotation = param.d.annotation || param.d.annotationComment;
             if (annotation) {
                 curParamNode = param;
                 nameWalker.walk(annotation);
             }
-        });
+        }
         curParamNode = undefined;
 
         if (node.d.returnAnnotation) {
@@ -2464,9 +2466,9 @@ export class Checker extends ParseTreeWalker {
         }
 
         if (node.d.funcAnnotationComment) {
-            node.d.funcAnnotationComment.d.paramAnnotations.forEach((expr) => {
+            for (const expr of node.d.funcAnnotationComment.d.paramAnnotations) {
                 nameWalker.walk(expr);
-            });
+            }
 
             if (node.d.funcAnnotationComment.d.returnAnnotation) {
                 exemptBoundTypeVar = false;
@@ -2474,7 +2476,7 @@ export class Checker extends ParseTreeWalker {
             }
         }
 
-        localTypeVarUsage.forEach((usage) => {
+        for (const [, usage] of localTypeVarUsage) {
             // Report error for local type variable that appears only once.
             if (usage.nodes.length === 1 && !usage.isExempt) {
                 let altTypeText: string;
@@ -2547,11 +2549,11 @@ export class Checker extends ParseTreeWalker {
                     usage.nodes[0]
                 );
             }
-        });
+        }
 
         // Report error for a class type variable that appears only within
         // constructor parameters that have default values. These may go unsolved.
-        classTypeVarUsage.forEach((usage) => {
+        for (const [, usage] of classTypeVarUsage) {
             if (
                 usage.paramTypeWithEllipsisUsageCount > 0 &&
                 usage.paramTypeUsageCount === usage.paramTypeWithEllipsisUsageCount &&
@@ -2569,7 +2571,7 @@ export class Checker extends ParseTreeWalker {
                     usage.nodes[0]
                 );
             }
-        });
+        }
     }
 
     // Validates that overloads use @staticmethod and @classmethod consistently.
@@ -2588,7 +2590,7 @@ export class Checker extends ParseTreeWalker {
         }
         let totalMethods = overloads.length;
 
-        overloads.forEach((overload) => {
+        for (const overload of overloads) {
             if (FunctionType.isStaticMethod(overload)) {
                 staticMethodCount++;
             }
@@ -2596,7 +2598,7 @@ export class Checker extends ParseTreeWalker {
             if (FunctionType.isClassMethod(overload)) {
                 classMethodCount++;
             }
-        });
+        }
 
         const impl = OverloadedType.getImplementation(functionType);
         if (impl && isFunction(impl)) {
@@ -3012,7 +3014,7 @@ export class Checker extends ParseTreeWalker {
                 }
 
                 if (allowTuple && exceptionSubtype.priv.tupleTypeArgs) {
-                    exceptionSubtype.priv.tupleTypeArgs.forEach((typeArg) => {
+                    for (const typeArg of exceptionSubtype.priv.tupleTypeArgs) {
                         this._validateExceptionTypeRecursive(
                             typeArg.type,
                             diag,
@@ -3021,7 +3023,7 @@ export class Checker extends ParseTreeWalker {
                             /* allowTuple */ false,
                             isExceptGroup
                         );
-                    });
+                    }
                     return;
                 }
 
@@ -3070,7 +3072,7 @@ export class Checker extends ParseTreeWalker {
             return;
         }
 
-        nodes.forEach((node) => {
+        for (const node of nodes) {
             if (!moduleScope.symbolTable.has(node.d.value)) {
                 this._evaluator.addDiagnostic(
                     DiagnosticRule.reportUnsupportedDunderAll,
@@ -3078,7 +3080,7 @@ export class Checker extends ParseTreeWalker {
                     node
                 );
             }
-        });
+        }
     }
 
     private _validateSymbolTables() {
@@ -3087,7 +3089,7 @@ export class Checker extends ParseTreeWalker {
             const scope = AnalyzerNodeInfo.getScope(scopedNode);
 
             if (scope) {
-                scope.symbolTable.forEach((symbol, name) => {
+                for (const [name, symbol] of scope.symbolTable) {
                     this._conditionallyReportUnusedSymbol(name, symbol, scope.type, dependentFileInfo);
 
                     this._reportIncompatibleDeclarations(name, symbol);
@@ -3101,7 +3103,7 @@ export class Checker extends ParseTreeWalker {
                     this._reportMultipleTypeAliasDeclarations(name, symbol);
 
                     this._reportInvalidOverload(name, symbol);
-                });
+                }
             }
         }
 
@@ -3119,9 +3121,9 @@ export class Checker extends ParseTreeWalker {
 
                 if (!accessedSymbolSet.has(symbol.id)) {
                     const decls = symbol.getDeclarations();
-                    decls.forEach((decl) => {
+                    for (const decl of decls) {
                         this._conditionallyReportUnusedDeclaration(decl, /* isPrivate */ false);
-                    });
+                    }
                 }
             }
         }
@@ -3234,7 +3236,9 @@ export class Checker extends ParseTreeWalker {
         }
 
         // Verify that all overload signatures are assignable to implementation signature.
-        OverloadedType.getOverloads(type).forEach((overload, index) => {
+        const overloadsToCheck = OverloadedType.getOverloads(type);
+        for (let index = 0; index < overloadsToCheck.length; index++) {
+            const overload = overloadsToCheck[index];
             const diag = new DiagnosticAddendum();
             if (
                 implementation &&
@@ -3260,7 +3264,7 @@ export class Checker extends ParseTreeWalker {
                     }
                 }
             }
-        });
+        }
     }
 
     private _reportFinalInLoop(symbol: Symbol) {
@@ -3307,7 +3311,7 @@ export class Checker extends ParseTreeWalker {
             return;
         }
 
-        decls.forEach((decl) => {
+        for (const decl of decls) {
             if (decl !== finalImportDecl) {
                 this._evaluator.addDiagnostic(
                     DiagnosticRule.reportGeneralTypeIssues,
@@ -3315,7 +3319,7 @@ export class Checker extends ParseTreeWalker {
                     getNameNodeForDeclaration(decl) ?? decl.node
                 );
             }
-        });
+        }
     }
 
     // If the builtins module (or any implicitly chained module) defines a
@@ -3335,13 +3339,13 @@ export class Checker extends ParseTreeWalker {
         }
 
         const decls = symbol.getDeclarations();
-        decls.forEach((decl) => {
+        for (const decl of decls) {
             this._evaluator.addDiagnostic(
                 DiagnosticRule.reportGeneralTypeIssues,
                 LocMessage.finalReassigned().format({ name }),
                 getNameNodeForDeclaration(decl) ?? decl.node
             );
-        });
+        }
     }
 
     // If a variable is marked Final, it should receive only one assigned value.
@@ -3354,7 +3358,7 @@ export class Checker extends ParseTreeWalker {
         let sawFinal = false;
         let sawAssignment = false;
 
-        decls.forEach((decl) => {
+        for (const decl of decls) {
             if (this._evaluator.isFinalVariableDeclaration(decl)) {
                 if (sawFinal) {
                     this._evaluator.addDiagnostic(
@@ -3401,7 +3405,7 @@ export class Checker extends ParseTreeWalker {
                     getNameNodeForDeclaration(decl) ?? decl.node
                 );
             }
-        });
+        }
 
         // If it's not a stub file, an assignment must be provided.
         if (!sawAssignment && !this._fileInfo.isStubFile) {
@@ -3450,7 +3454,7 @@ export class Checker extends ParseTreeWalker {
 
         // If this is a type alias, there should be only one declaration.
         if (typeAliasDecl && decls.length > 1) {
-            decls.forEach((decl) => {
+            for (const decl of decls) {
                 if (decl !== typeAliasDecl) {
                     this._evaluator.addDiagnostic(
                         DiagnosticRule.reportRedeclaration,
@@ -3458,7 +3462,7 @@ export class Checker extends ParseTreeWalker {
                         decl.node
                     );
                 }
-            });
+            }
         }
     }
 
@@ -3717,9 +3721,9 @@ export class Checker extends ParseTreeWalker {
         }
 
         const decls = symbol.getDeclarations();
-        decls.forEach((decl) => {
+        for (const decl of decls) {
             this._conditionallyReportUnusedDeclaration(decl, this._isSymbolPrivate(name, scopeType));
-        });
+        }
     }
 
     private _conditionallyReportUnusedDeclaration(decl: Declaration, isPrivate: boolean) {
@@ -3946,9 +3950,9 @@ export class Checker extends ParseTreeWalker {
                     ClassType.isTupleClass(arg1Subtype) &&
                     arg1Subtype.priv.tupleTypeArgs
                 ) {
-                    arg1Subtype.priv.tupleTypeArgs.forEach((typeArg) => {
+                    for (const typeArg of arg1Subtype.priv.tupleTypeArgs) {
                         this._validateNotDataProtocol(typeArg.type, diag);
-                    });
+                    }
                 } else {
                     this._validateNotDataProtocol(arg1Subtype, diag);
                 }
@@ -3975,7 +3979,7 @@ export class Checker extends ParseTreeWalker {
         }
 
         // Check for unsafe protocol overlaps.
-        classTypeList.forEach((filterType) => {
+        for (const filterType of classTypeList) {
             if (isInstantiableClass(filterType)) {
                 this._validateUnsafeProtocolOverlap(
                     node.d.args[0].d.valueExpr,
@@ -3983,7 +3987,7 @@ export class Checker extends ParseTreeWalker {
                     isInstanceCheck ? arg0Type : convertToInstance(arg0Type)
                 );
             }
-        });
+        }
 
         // Check for unnecessary isinstance or issubclass calls.
         if (this._fileInfo.diagnosticRuleSet.reportUnnecessaryIsInstance !== 'none') {
@@ -4292,7 +4296,7 @@ export class Checker extends ParseTreeWalker {
                 callTypeResult.overloadsUsedForCall &&
                 callTypeResult.overloadsUsedForCall.length > 0
             ) {
-                callTypeResult.overloadsUsedForCall.forEach((overload) => {
+                for (const overload of callTypeResult.overloadsUsedForCall) {
                     if (overload.shared.deprecatedMessage !== undefined) {
                         if (node.d.value === overload.shared.name) {
                             deprecatedMessage = overload.shared.deprecatedMessage;
@@ -4312,7 +4316,7 @@ export class Checker extends ParseTreeWalker {
                             });
                         }
                     }
-                });
+                }
             }
         }
 
@@ -4577,7 +4581,9 @@ export class Checker extends ParseTreeWalker {
     // Validates that an enum class does not attempt to override another
     // enum class that has already defined values.
     private _validateEnumClassOverride(node: ClassNode, classType: ClassType) {
-        classType.shared.baseClasses.forEach((baseClass, index) => {
+        const baseClasses = classType.shared.baseClasses;
+        for (let index = 0; index < baseClasses.length; index++) {
+            const baseClass = baseClasses[index];
             if (isClass(baseClass) && isEnumClassWithMembers(this._evaluator, baseClass)) {
                 this._evaluator.addDiagnostic(
                     DiagnosticRule.reportGeneralTypeIssues,
@@ -4585,7 +4591,7 @@ export class Checker extends ParseTreeWalker {
                     node.d.arguments[index]
                 );
             }
-        });
+        }
     }
 
     // Verifies the rules specified in PEP 589 about TypedDict classes.
@@ -4596,7 +4602,7 @@ export class Checker extends ParseTreeWalker {
             this._evaluator.addDiagnostic(DiagnosticRule.reportGeneralTypeIssues, LocMessage.typedDictBadVar(), node);
         };
 
-        suiteNode.d.statements.forEach((statement) => {
+        for (const statement of suiteNode.d.statements) {
             if (!AnalyzerNodeInfo.isCodeUnreachable(statement)) {
                 if (statement.nodeType === ParseNodeType.StatementList) {
                     for (const substatement of statement.d.statements) {
@@ -4613,7 +4619,7 @@ export class Checker extends ParseTreeWalker {
                     emitBadStatementError(statement);
                 }
             }
-        });
+        }
     }
 
     private _validateTypeGuardFunction(node: FunctionNode, functionType: FunctionType, isMethod: boolean) {
@@ -4834,7 +4840,7 @@ export class Checker extends ParseTreeWalker {
     // Validates that any overridden member variables are not marked
     // as Final in parent classes.
     private _validateFinalMemberOverrides(classType: ClassType) {
-        ClassType.getSymbolTable(classType).forEach((localSymbol, name) => {
+        for (const [name, localSymbol] of ClassType.getSymbolTable(classType)) {
             const parentSymbol = lookUpClassMember(classType, name, MemberAccessFlags.SkipOriginalClass);
 
             if (parentSymbol && isInstantiableClass(parentSymbol.classType) && !SymbolNameUtils.isPrivateName(name)) {
@@ -4869,7 +4875,7 @@ export class Checker extends ParseTreeWalker {
                     }
                 }
             }
-        });
+        }
     }
 
     // Validates that the values associated with enum members are type compatible.
@@ -4914,7 +4920,7 @@ export class Checker extends ParseTreeWalker {
             }
         }
 
-        ClassType.getSymbolTable(classType).forEach((symbol, name) => {
+        for (const [name, symbol] of ClassType.getSymbolTable(classType)) {
             // Determine whether this is an enum member. We ignore the presence
             // of an annotation in this case because the runtime does. From a
             // type checking perspective, if the runtime treats the assignment
@@ -5039,7 +5045,7 @@ export class Checker extends ParseTreeWalker {
                     }
                 }
             }
-        });
+        }
     }
 
     // If a class is a dataclass with a `__post_init__` method, verify that its
@@ -5067,15 +5073,15 @@ export class Checker extends ParseTreeWalker {
 
         // Collect the list of init-only variables in the order they were declared.
         const initOnlySymbolMap = new Map<string, Symbol>();
-        ClassType.getReverseMro(classType).forEach((mroClass) => {
+        for (const mroClass of ClassType.getReverseMro(classType)) {
             if (isClass(mroClass) && ClassType.isDataClass(mroClass)) {
-                ClassType.getSymbolTable(mroClass).forEach((symbol, name) => {
+                for (const [name, symbol] of ClassType.getSymbolTable(mroClass)) {
                     if (symbol.isInitVar()) {
                         initOnlySymbolMap.set(name, symbol);
                     }
-                });
+                }
             }
-        });
+        }
 
         const postInitType = this._evaluator.getTypeOfMember(postInitMember);
         if (
@@ -5117,9 +5123,9 @@ export class Checker extends ParseTreeWalker {
         // Verify that the parameter types match.
         let paramIndex = 1;
 
-        initOnlySymbolMap.forEach((symbol, fieldName) => {
+        for (const [fieldName, symbol] of initOnlySymbolMap) {
             if (paramIndex >= paramListDetails.params.length) {
-                return;
+                continue;
             }
 
             const param = paramListDetails.params[paramIndex].param;
@@ -5152,7 +5158,7 @@ export class Checker extends ParseTreeWalker {
             }
 
             paramIndex++;
-        });
+        }
     }
 
     // If a class is marked final, it must implement all abstract methods,
@@ -5174,7 +5180,8 @@ export class Checker extends ParseTreeWalker {
         const diagAddendum = new DiagnosticAddendum();
         const errorsToDisplay = 2;
 
-        abstractSymbols.forEach((abstractMethod, index) => {
+        for (let index = 0; index < abstractSymbols.length; index++) {
+            const abstractMethod = abstractSymbols[index];
             if (index === errorsToDisplay) {
                 diagAddendum.addMessage(
                     LocAddendum.memberIsAbstractMore().format({
@@ -5192,7 +5199,7 @@ export class Checker extends ParseTreeWalker {
                     );
                 }
             }
-        });
+        }
 
         this._evaluator.addDiagnostic(
             DiagnosticRule.reportGeneralTypeIssues,
@@ -5240,12 +5247,12 @@ export class Checker extends ParseTreeWalker {
             addInheritedDataClassEntries(classType, dataClassEntries);
         }
 
-        ClassType.getSymbolTable(classType).forEach((localSymbol, name) => {
+        for (const [name, localSymbol] of ClassType.getSymbolTable(classType)) {
             abstractSymbols.delete(name);
 
             // This applies only to instance members.
             if (!localSymbol.isInstanceMember()) {
-                return;
+                continue;
             }
 
             const decls = localSymbol.getDeclarations();
@@ -5294,14 +5301,14 @@ export class Checker extends ParseTreeWalker {
                     return false;
                 })
             ) {
-                return;
+                continue;
             }
 
             // If the symbol is declared by its parent, we can assume it
             // is initialized there.
             const parentSymbol = lookUpClassMember(classType, name, MemberAccessFlags.SkipOriginalClass);
             if (parentSymbol) {
-                return;
+                continue;
             }
 
             // Report the variable as uninitialized only on the first decl.
@@ -5310,20 +5317,20 @@ export class Checker extends ParseTreeWalker {
                 LocMessage.uninitializedInstanceVariable().format({ name: name }),
                 decls[0].node
             );
-        });
+        }
 
         // See if there are any variables from abstract base classes
         // that are not initialized.
         const diagAddendum = new DiagnosticAddendum();
-        abstractSymbols.forEach((member, name) => {
+        for (const [name, member] of abstractSymbols) {
             const decls = member.symbol.getDeclarations();
 
             if (decls.length === 0 || !isClass(member.classType)) {
-                return;
+                continue;
             }
 
             if (decls[0].type !== DeclarationType.Variable) {
-                return;
+                continue;
             }
 
             // Dataclass fields are typically exempted from this check because
@@ -5331,12 +5338,12 @@ export class Checker extends ParseTreeWalker {
             const dcEntry = dataClassEntries?.find((entry) => entry.name === name);
             if (dcEntry) {
                 if (dcEntry.includeInInit) {
-                    return;
+                    continue;
                 }
             } else {
                 // Do one or more declarations involve assignments?
                 if (decls.some((decl) => decl.type === DeclarationType.Variable && !!decl.inferredTypeSource)) {
-                    return;
+                    continue;
                 }
             }
 
@@ -5346,7 +5353,7 @@ export class Checker extends ParseTreeWalker {
                     classType: member.classType.shared.name,
                 })
             );
-        });
+        }
 
         if (!diagAddendum.isEmpty()) {
             this._evaluator.addDiagnostic(
@@ -5384,21 +5391,23 @@ export class Checker extends ParseTreeWalker {
             undefined
         );
 
-        classType.shared.typeParams.forEach((param, paramIndex) => {
+        const typeParams = classType.shared.typeParams;
+        for (let paramIndex = 0; paramIndex < typeParams.length; paramIndex++) {
+            const param = typeParams[paramIndex];
             // Skip TypeVarTuples and ParamSpecs.
             if (isTypeVarTuple(param) || isParamSpec(param)) {
-                return;
+                continue;
             }
 
             // Skip type variables that have been internally synthesized
             // for a variety of reasons.
             if (param.shared.isSynthesized) {
-                return;
+                continue;
             }
 
             // Skip type variables with auto-variance.
             if (param.shared.declaredVariance === Variance.Auto) {
-                return;
+                continue;
             }
 
             // Replace all type arguments with a dummy type except for the
@@ -5454,7 +5463,7 @@ export class Checker extends ParseTreeWalker {
 
                 this._evaluator.addDiagnostic(DiagnosticRule.reportInvalidTypeVarUse, message, errorNode.d.name);
             }
-        });
+        }
     }
 
     // Validates that a class variable doesn't conflict with a __slots__
@@ -5471,14 +5480,14 @@ export class Checker extends ParseTreeWalker {
             return;
         }
 
-        ClassType.getSymbolTable(classType).forEach((symbol, name) => {
+        for (const [name, symbol] of ClassType.getSymbolTable(classType)) {
             const decls = symbol.getDeclarations();
             const isDefinedBySlots = decls.some(
                 (decl) => decl.type === DeclarationType.Variable && decl.isDefinedBySlots
             );
 
             if (isDefinedBySlots) {
-                decls.forEach((decl) => {
+                for (const decl of decls) {
                     if (
                         decl.type === DeclarationType.Variable &&
                         !decl.isDefinedBySlots &&
@@ -5492,9 +5501,9 @@ export class Checker extends ParseTreeWalker {
                             );
                         }
                     }
-                });
+                }
             }
-        });
+        }
     }
 
     // Validates that the __init__ and __new__ method signatures are consistent.
@@ -5742,7 +5751,7 @@ export class Checker extends ParseTreeWalker {
 
         // Filter any unknown base classes. Also remove Generic and Protocol
         // base classes.
-        classType.shared.baseClasses.forEach((baseClass) => {
+        for (const baseClass of classType.shared.baseClasses) {
             if (
                 isClass(baseClass) &&
                 !ClassType.isBuiltIn(baseClass, 'Generic') &&
@@ -5750,7 +5759,7 @@ export class Checker extends ParseTreeWalker {
             ) {
                 baseClasses.push(baseClass);
             }
-        });
+        }
 
         // If there is only one base class, there's nothing to do.
         if (baseClasses.length < 2) {
@@ -6055,7 +6064,7 @@ export class Checker extends ParseTreeWalker {
             ['fdel', (c) => c.priv.fdelInfo?.methodType],
         ];
 
-        propMethodInfo.forEach((info) => {
+        for (const info of propMethodInfo) {
             const diagAddendum = new DiagnosticAddendum();
             const [methodName, methodAccessor] = info;
             const baseClassPropMethod = methodAccessor(overriddenSymbolType as ClassType);
@@ -6155,24 +6164,24 @@ export class Checker extends ParseTreeWalker {
                     }
                 }
             }
-        });
+        }
     }
 
     // Validates that any overloaded methods are consistent in how they
     // are decorated. For example, if the first overload is not marked @final
     // but subsequent ones are, an error should be reported.
     private _validateOverloadDecoratorConsistency(classType: ClassType) {
-        ClassType.getSymbolTable(classType).forEach((symbol, name) => {
+        for (const [name, symbol] of ClassType.getSymbolTable(classType)) {
             const primaryDecl = getLastTypedDeclarationForSymbol(symbol);
 
             if (!primaryDecl || primaryDecl.type !== DeclarationType.Function) {
-                return;
+                continue;
             }
 
             const typeOfSymbol = this._evaluator.getEffectiveTypeOfSymbol(symbol);
 
             if (!isOverloaded(typeOfSymbol)) {
-                return;
+                continue;
             }
 
             const overloads = OverloadedType.getOverloads(typeOfSymbol);
@@ -6181,7 +6190,7 @@ export class Checker extends ParseTreeWalker {
             this._validateOverloadFinalOverride(overloads, implementation);
 
             this._validateOverloadAbstractConsistency(overloads, implementation);
-        });
+        }
     }
 
     private _validateOverloadAbstractConsistency(overloads: FunctionType[], implementation: Type | undefined) {
@@ -6193,7 +6202,7 @@ export class Checker extends ParseTreeWalker {
                 return;
             }
 
-            overloads.forEach((overload) => {
+            for (const overload of overloads) {
                 const decl = overload.shared.declaration;
 
                 if (FunctionType.isAbstractMethod(overload) && decl) {
@@ -6205,7 +6214,7 @@ export class Checker extends ParseTreeWalker {
                         getNameNodeForDeclaration(decl) ?? decl.node
                     );
                 }
-            });
+            }
             return;
         }
 
@@ -6217,7 +6226,8 @@ export class Checker extends ParseTreeWalker {
         // abstract or not abstract.
         const isFirstOverloadAbstract = FunctionType.isAbstractMethod(overloads[0]);
 
-        overloads.slice(1).forEach((overload, index) => {
+        for (let index = 0; index < overloads.length - 1; index++) {
+            const overload = overloads[index + 1];
             if (FunctionType.isAbstractMethod(overload) !== isFirstOverloadAbstract && overload.shared.declaration) {
                 this._evaluator.addDiagnostic(
                     DiagnosticRule.reportInconsistentOverload,
@@ -6227,13 +6237,13 @@ export class Checker extends ParseTreeWalker {
                     getNameNodeForDeclaration(overload.shared.declaration) ?? overload.shared.declaration.node
                 );
             }
-        });
+        }
     }
 
     private _validateOverloadFinalOverride(overloads: FunctionType[], implementation: Type | undefined) {
         // If there's an implementation, the overloads are not allowed to be marked final or override.
         if (implementation) {
-            overloads.forEach((overload) => {
+            for (const overload of overloads) {
                 if (FunctionType.isFinal(overload) && overload.shared.declaration?.node) {
                     this._evaluator.addDiagnostic(
                         DiagnosticRule.reportInconsistentOverload,
@@ -6249,7 +6259,7 @@ export class Checker extends ParseTreeWalker {
                         getNameNodeForDeclaration(overload.shared.declaration) ?? overload.shared.declaration.node
                     );
                 }
-            });
+            }
 
             return;
         }
@@ -6259,7 +6269,8 @@ export class Checker extends ParseTreeWalker {
             return;
         }
 
-        overloads.slice(1).forEach((overload, index) => {
+        for (let i = 1; i < overloads.length; i++) {
+            const overload = overloads[i];
             if (FunctionType.isFinal(overload) && overload.shared.declaration?.node) {
                 this._evaluator.addDiagnostic(
                     DiagnosticRule.reportInconsistentOverload,
@@ -6275,7 +6286,7 @@ export class Checker extends ParseTreeWalker {
                     getNameNodeForDeclaration(overload.shared.declaration) ?? overload.shared.declaration.node
                 );
             }
-        });
+        }
     }
 
     // For a TypedDict class that derives from another TypedDict class
@@ -6406,12 +6417,12 @@ export class Checker extends ParseTreeWalker {
     // types as the original method. Also marks the class as abstract if one
     // or more abstract methods are not overridden.
     private _validateBaseClassOverrides(classType: ClassType) {
-        ClassType.getSymbolTable(classType).forEach((symbol, name) => {
+        for (const [name, symbol] of ClassType.getSymbolTable(classType)) {
             // Private symbols do not need to match in type since their
             // names are mangled, and subclasses can't access the value in
             // the parent class.
             if (SymbolNameUtils.isPrivateName(name)) {
-                return;
+                continue;
             }
 
             // If the symbol has no declaration, and the type is inferred,
@@ -6427,7 +6438,7 @@ export class Checker extends ParseTreeWalker {
 
             // If the type of the override symbol isn't known, stop here.
             if (isAnyOrUnknown(typeOfSymbol)) {
-                return;
+                continue;
             }
 
             let firstOverride: ClassMember | undefined;
@@ -6470,7 +6481,7 @@ export class Checker extends ParseTreeWalker {
             } else {
                 this._validateOverrideDecoratorPresent(symbol, typeOfSymbol, firstOverride);
             }
-        });
+        }
     }
 
     private _validateOverrideDecoratorPresent(symbol: Symbol, overrideType: Type, baseMember: ClassMember) {
@@ -6961,11 +6972,11 @@ export class Checker extends ParseTreeWalker {
 
         // Was this declared with a "def" statement?
         const defDecls: FunctionNode[] = [];
-        symbol.getDeclarations().forEach((decl) => {
+        for (const decl of symbol.getDeclarations()) {
             if (decl.type === DeclarationType.Function && decl.node.nodeType === ParseNodeType.Function) {
                 defDecls.push(decl.node);
             }
-        });
+        }
 
         // Locate all final function declarations.
         const finalDefDecls = defDecls.filter((decl) => {
@@ -6994,7 +7005,7 @@ export class Checker extends ParseTreeWalker {
             ['fdel', (c) => c.priv.fdelInfo?.methodType],
         ];
 
-        propMethodInfo.forEach((info) => {
+        for (const info of propMethodInfo) {
             const diagAddendum = new DiagnosticAddendum();
             const [methodName, methodAccessor] = info;
             const baseClassPropMethod = methodAccessor(baseType as ClassType);
@@ -7009,7 +7020,7 @@ export class Checker extends ParseTreeWalker {
                 );
 
                 if (!isFunction(baseClassMethodType)) {
-                    return;
+                    continue;
                 }
 
                 if (!subclassPropMethod) {
@@ -7049,7 +7060,7 @@ export class Checker extends ParseTreeWalker {
                 );
 
                 if (!isFunction(subclassMethodType)) {
-                    return;
+                    continue;
                 }
 
                 if (
@@ -7060,7 +7071,7 @@ export class Checker extends ParseTreeWalker {
                         diagAddendum.createAddendum()
                     )
                 ) {
-                    return;
+                    continue;
                 }
 
                 diagAddendum.addMessage(
@@ -7087,7 +7098,7 @@ export class Checker extends ParseTreeWalker {
                 ) {
                     const symbolDecls = overrideSymbol.getDeclarations();
                     if (symbolDecls.length === 0) {
-                        return;
+                        continue;
                     }
                     const lastSymbolDecl = symbolDecls[symbolDecls.length - 1];
                     diagLocation = getNameNodeForDeclaration(lastSymbolDecl) ?? lastSymbolDecl.node;
@@ -7107,7 +7118,7 @@ export class Checker extends ParseTreeWalker {
                     diag.addRelatedInfo(LocAddendum.overriddenMethod(), origDecl.uri, origDecl.range);
                 }
             }
-        });
+        }
     }
 
     // Performs checks on a function that is located within a class
@@ -7495,15 +7506,15 @@ export class Checker extends ParseTreeWalker {
         let sawUnknownExceptionType = false;
         const exceptionTypesSoFar: ClassType[] = [];
 
-        node.d.exceptClauses.forEach((except) => {
+        for (const except of node.d.exceptClauses) {
             if (sawUnknownExceptionType || except.d.isExceptGroup || !except.d.typeExpr) {
-                return;
+                continue;
             }
 
             const exceptionType = this._evaluator.getType(except.d.typeExpr);
             if (!exceptionType || isAnyOrUnknown(exceptionType)) {
                 sawUnknownExceptionType = true;
-                return;
+                continue;
             }
 
             const typesOfThisExcept: ClassType[] = [];
@@ -7547,7 +7558,7 @@ export class Checker extends ParseTreeWalker {
                 const diagAddendum = new DiagnosticAddendum();
                 let overriddenExceptionCount = 0;
 
-                typesOfThisExcept.forEach((thisExceptType) => {
+                for (const thisExceptType of typesOfThisExcept) {
                     const subtype = exceptionTypesSoFar.find((previousExceptType) => {
                         return derivesFromClassRecursive(thisExceptType, previousExceptType, /* ignoreUnknown */ true);
                     });
@@ -7561,7 +7572,7 @@ export class Checker extends ParseTreeWalker {
                         );
                         overriddenExceptionCount++;
                     }
-                });
+                }
 
                 // Were all of the exception types overridden?
                 if (typesOfThisExcept.length > 0 && typesOfThisExcept.length === overriddenExceptionCount) {
@@ -7587,7 +7598,7 @@ export class Checker extends ParseTreeWalker {
             }
 
             appendArray(exceptionTypesSoFar, typesOfThisExcept);
-        });
+        }
     }
 
     private _reportDuplicateImports() {
@@ -7595,11 +7606,11 @@ export class Checker extends ParseTreeWalker {
 
         const importModuleMap = new Map<string, ImportAsNode>();
 
-        importStatements.orderedImports.forEach((importStatement) => {
+        for (const importStatement of importStatements.orderedImports) {
             if (importStatement.node.nodeType === ParseNodeType.ImportFrom) {
                 const symbolMap = new Map<string, ImportFromAsNode>();
 
-                importStatement.node.d.imports.forEach((importFromAs) => {
+                for (const importFromAs of importStatement.node.d.imports) {
                     // Ignore duplicates if they're aliased.
                     if (!importFromAs.d.alias) {
                         const prevImport = symbolMap.get(importFromAs.d.name.d.value);
@@ -7613,7 +7624,7 @@ export class Checker extends ParseTreeWalker {
                             symbolMap.set(importFromAs.d.name.d.value, importFromAs);
                         }
                     }
-                });
+                }
             } else if (importStatement.subnode) {
                 // Ignore duplicates if they're aliased.
                 if (!importStatement.subnode.d.alias) {
@@ -7629,6 +7640,6 @@ export class Checker extends ParseTreeWalker {
                     }
                 }
             }
-        });
+        }
     }
 }

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -4940,7 +4940,7 @@ export class Checker extends ParseTreeWalker {
                 !ClassType.isSameGenericClass(symbolType, ClassType.cloneAsInstance(classType)) ||
                 !(symbolType.priv.literalValue instanceof EnumLiteral)
             ) {
-                return;
+                continue;
             }
 
             // Enum members should not have type annotations.
@@ -4953,7 +4953,7 @@ export class Checker extends ParseTreeWalker {
                         typedDecls[0].node
                     );
                 }
-                return;
+                continue;
             }
 
             // Look for a duplicate assignment.
@@ -4965,11 +4965,11 @@ export class Checker extends ParseTreeWalker {
                     decls[1].node
                 );
 
-                return;
+                continue;
             }
 
             if (decls[0].type !== DeclarationType.Variable) {
-                return;
+                continue;
             }
 
             // Look for an enum attribute annotated with "Final".

--- a/packages/pyright-internal/src/analyzer/circularDependency.ts
+++ b/packages/pyright-internal/src/analyzer/circularDependency.ts
@@ -27,11 +27,11 @@ export class CircularDependency {
         // Find the path that is alphabetically first and reorder
         // based on that.
         let firstIndex = 0;
-        this._paths.forEach((path, index) => {
-            if (path < this._paths[firstIndex]) {
+        for (let index = 0; index < this._paths.length; index++) {
+            if (this._paths[index] < this._paths[firstIndex]) {
                 firstIndex = index;
             }
-        });
+        }
 
         if (firstIndex !== 0) {
             this._paths = this._paths.slice(firstIndex).concat(this._paths.slice(0, firstIndex));

--- a/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowEngine.ts
@@ -37,11 +37,12 @@ import {
 } from './codeFlowTypes';
 import { formatControlFlowGraph } from './codeFlowUtils';
 import { getBoundCallMethod, getBoundNewMethod } from './constructors';
+import { Declaration } from './declaration';
 import { isMatchingExpression, isPartialMatchingExpression, printExpression } from './parseTreeUtils';
 import { getPatternSubtypeNarrowingCallback } from './patternMatching';
 import { SpeculativeTypeTracker } from './typeCacheUtils';
 import { narrowForKeyAssignment } from './typedDicts';
-import { EvalFlags, Reachability, TypeEvaluator, TypeResult } from './typeEvaluatorTypes';
+import { ArgWithExpression, EvalFlags, Reachability, TypeEvaluator, TypeResult } from './typeEvaluatorTypes';
 import { getTypeNarrowingCallback } from './typeGuards';
 import {
     ClassType,
@@ -357,11 +358,11 @@ export function getCodeFlowEngine(
                     // types we've accumulated so far.
                     const typesToCombine: Type[] = [];
 
-                    cachedEntry.incompleteSubtypes.forEach((t) => {
+                    for (const t of cachedEntry.incompleteSubtypes) {
                         if (t.type) {
                             typesToCombine.push(t.type);
                         }
-                    });
+                    }
 
                     combinedType = typesToCombine.length > 0 ? combineTypes(typesToCombine) : undefined;
                 }
@@ -414,11 +415,13 @@ export function getCodeFlowEngine(
 
                 const typesToCombine: Type[] = [];
 
-                cacheEntry.incompleteSubtypes?.forEach((entry) => {
-                    if (entry.type && !isIncompleteUnknown(entry.type)) {
-                        typesToCombine.push(cleanIncompleteUnknown(entry.type));
+                if (cacheEntry.incompleteSubtypes) {
+                    for (const entry of cacheEntry.incompleteSubtypes) {
+                        if (entry.type && !isIncompleteUnknown(entry.type)) {
+                            typesToCombine.push(cleanIncompleteUnknown(entry.type));
+                        }
                     }
-                });
+                }
 
                 return combineTypes(typesToCombine);
             }
@@ -637,9 +640,13 @@ export function getCodeFlowEngine(
                             // Determine whether any of the context managers support exception
                             // suppression. If not, none of its antecedents are reachable.
                             const contextMgrNode = curFlowNode as FlowPostContextManagerLabel;
-                            const contextManagerSwallowsExceptions = contextMgrNode.expressions.some((expr) =>
-                                isExceptionContextManager(evaluator, expr, contextMgrNode.isAsync)
-                            );
+                            let contextManagerSwallowsExceptions = false;
+                            for (const expr of contextMgrNode.expressions) {
+                                if (isExceptionContextManager(evaluator, expr, contextMgrNode.isAsync)) {
+                                    contextManagerSwallowsExceptions = true;
+                                    break;
+                                }
+                            }
 
                             if (contextManagerSwallowsExceptions === contextMgrNode.blockIfSwallowsExceptions) {
                                 // Do not explore any further along this code flow path.
@@ -654,10 +661,16 @@ export function getCodeFlowEngine(
                                 subexpressionReferenceKeys = createKeysForReferenceSubexpressions(reference);
                             }
 
+                            let affectsReference = false;
+                            for (const key of subexpressionReferenceKeys) {
+                                if (branchFlowNode.affectedExpressions!.has(key)) {
+                                    affectsReference = true;
+                                    break;
+                                }
+                            }
+
                             if (
-                                !subexpressionReferenceKeys.some((key) =>
-                                    branchFlowNode.affectedExpressions!.has(key)
-                                ) &&
+                                !affectsReference &&
                                 getFlowNodeReachability(curFlowNode, branchFlowNode.preBranchAntecedent) ===
                                     Reachability.Reachable
                             ) {
@@ -680,7 +693,15 @@ export function getCodeFlowEngine(
                                 subexpressionReferenceKeys = createKeysForReferenceSubexpressions(reference);
                             }
 
-                            if (!subexpressionReferenceKeys.some((key) => loopNode.affectedExpressions!.has(key))) {
+                            let loopAffectsRef = false;
+                            for (const key of subexpressionReferenceKeys) {
+                                if (loopNode.affectedExpressions!.has(key)) {
+                                    loopAffectsRef = true;
+                                    break;
+                                }
+                            }
+
+                            if (!loopAffectsRef) {
                                 curFlowNode = loopNode.antecedents[0];
                                 continue;
                             }
@@ -917,7 +938,7 @@ export function getCodeFlowEngine(
                         const wildcardImportFlowNode = curFlowNode as FlowWildcardImport;
                         if (reference && reference.nodeType === ParseNodeType.Name) {
                             const nameValue = reference.d.value;
-                            if (wildcardImportFlowNode.names.some((name) => name === nameValue)) {
+                            if (wildcardImportFlowNode.names.includes(nameValue)) {
                                 return preventRecursion(curFlowNode, () => {
                                     const type = getTypeFromWildcardImport(wildcardImportFlowNode, nameValue);
                                     return setCacheEntry(curFlowNode, type, /* isIncomplete */ false);
@@ -981,38 +1002,58 @@ export function getCodeFlowEngine(
                     );
                 } else if (
                     cacheEntry.incompleteSubtypes &&
-                    cacheEntry.incompleteSubtypes.length === loopNode.antecedents.length &&
-                    cacheEntry.incompleteSubtypes.some((subtype) => subtype.isPending)
+                    cacheEntry.incompleteSubtypes.length === loopNode.antecedents.length
                 ) {
-                    // If entries have been added for all antecedents and there are pending entries
-                    // that have not been evaluated even once, treat it as incomplete. We clean
-                    // any incomplete unknowns from the type here to assist with type convergence.
-                    return FlowNodeTypeResult.create(
-                        cleanIncompleteUnknownForCacheEntry(cacheEntry),
-                        /* isIncomplete */ true
-                    );
+                    let hasPendingSubtype = false;
+                    for (const subtype of cacheEntry.incompleteSubtypes) {
+                        if (subtype.isPending) {
+                            hasPendingSubtype = true;
+                            break;
+                        }
+                    }
+
+                    if (hasPendingSubtype) {
+                        // If entries have been added for all antecedents and there are pending entries
+                        // that have not been evaluated even once, treat it as incomplete. We clean
+                        // any incomplete unknowns from the type here to assist with type convergence.
+                        return FlowNodeTypeResult.create(
+                            cleanIncompleteUnknownForCacheEntry(cacheEntry),
+                            /* isIncomplete */ true
+                        );
+                    }
                 }
+
+                // cacheEntry is guaranteed to be defined: either assigned in the
+                // if-branch or was already non-undefined in the else-if branch.
+                assert(cacheEntry !== undefined);
 
                 let attemptCount = 0;
 
                 while (true) {
                     let sawIncomplete = false;
                     let sawPending = false;
-                    let isProvenReachable =
-                        reference === undefined &&
-                        cacheEntry.incompleteSubtypes?.some((subtype) => subtype.type !== undefined);
+                    let isProvenReachable = false;
+                    if (reference === undefined && cacheEntry!.incompleteSubtypes) {
+                        for (const subtype of cacheEntry!.incompleteSubtypes) {
+                            if (subtype.type !== undefined) {
+                                isProvenReachable = true;
+                                break;
+                            }
+                        }
+                    }
                     let firstAntecedentTypeIsIncomplete = false;
                     let firstAntecedentTypeIsPending = false;
 
-                    loopNode.antecedents.forEach((antecedent, index) => {
+                    for (let index = 0; index < loopNode.antecedents.length; index++) {
+                        const antecedent = loopNode.antecedents[index];
                         // If we've trying to determine reachability and we've already proven
                         // reachability, then we're done.
                         if (reference === undefined && isProvenReachable) {
-                            return;
+                            break;
                         }
 
                         if (firstAntecedentTypeIsPending && index > 0) {
-                            return;
+                            break;
                         }
 
                         cacheEntry = getCacheEntry(loopNode)!;
@@ -1039,7 +1080,7 @@ export function getCodeFlowEngine(
                             } else {
                                 sawIncomplete = true;
                                 sawPending = true;
-                                return;
+                                continue;
                             }
                         }
 
@@ -1061,7 +1102,7 @@ export function getCodeFlowEngine(
                                     console.log('Types failed to converge during code flow analysis');
                                 }
                                 maxConvergenceLimitHit = true;
-                                return;
+                                continue;
                             }
 
                             // Set this entry to "pending" to prevent infinite recursion.
@@ -1113,7 +1154,7 @@ export function getCodeFlowEngine(
                         if (reference === undefined && cacheEntry?.type !== undefined) {
                             isProvenReachable = true;
                         }
-                    });
+                    }
 
                     if (isProvenReachable) {
                         // If we saw a pending entry, do not save over the top of the cache
@@ -1124,7 +1165,7 @@ export function getCodeFlowEngine(
                             : setCacheEntry(loopNode, UnknownType.create(), /* isIncomplete */ false);
                     }
 
-                    let effectiveType = cacheEntry.type;
+                    let effectiveType = cacheEntry!.type;
                     if (sawIncomplete) {
                         // If there is an incomplete "Unknown" type within a union type, remove
                         // it. Otherwise we might end up resolving the cycle with a type
@@ -1423,11 +1464,14 @@ export function getCodeFlowEngine(
                         // Determine whether any of the context managers support exception
                         // suppression. If not, none of its antecedents are reachable.
                         const contextMgrNode = curFlowNode as FlowPostContextManagerLabel;
-                        if (
-                            !contextMgrNode.expressions.some((expr) =>
-                                isExceptionContextManager(evaluator, expr, contextMgrNode.isAsync)
-                            )
-                        ) {
+                        let hasSwallowingExpr = false;
+                        for (const expr of contextMgrNode.expressions) {
+                            if (isExceptionContextManager(evaluator, expr, contextMgrNode.isAsync)) {
+                                hasSwallowingExpr = true;
+                                break;
+                            }
+                        }
+                        if (!hasSwallowingExpr) {
                             return cacheReachabilityResult(Reachability.UnreachableByAnalysis);
                         }
                     }
@@ -1597,9 +1641,15 @@ export function getCodeFlowEngine(
                                         typeVar
                                     );
 
-                                    return priorRemainingConstraints.filter((subtype) =>
-                                        ClassType.isSameGenericClass(subtype, ClassType.cloneAsInstance(classType))
-                                    );
+                                    const filtered: ClassType[] = [];
+                                    for (const subtype of priorRemainingConstraints) {
+                                        if (
+                                            ClassType.isSameGenericClass(subtype, ClassType.cloneAsInstance(classType))
+                                        ) {
+                                            filtered.push(subtype);
+                                        }
+                                    }
+                                    return filtered;
                                 }
                             }
                         }
@@ -1646,13 +1696,19 @@ export function getCodeFlowEngine(
                             ).type;
 
                             if (isInstantiableClass(arg1Type)) {
-                                return priorRemainingConstraints.filter((subtype) => {
+                                const filtered: ClassType[] = [];
+                                for (const subtype of priorRemainingConstraints) {
                                     if (ClassType.isSameGenericClass(subtype, ClassType.cloneAsInstance(arg1Type))) {
-                                        return isPositiveTest;
+                                        if (isPositiveTest) {
+                                            filtered.push(subtype);
+                                        }
                                     } else {
-                                        return !isPositiveTest;
+                                        if (!isPositiveTest) {
+                                            filtered.push(subtype);
+                                        }
                                     }
-                                });
+                                }
+                                return filtered;
                             }
                         }
                     }
@@ -1671,7 +1727,14 @@ export function getCodeFlowEngine(
                         const constraintsToAdd = narrowConstrainedTypeVarRecursive(antecedent, typeVar);
 
                         for (const constraint of constraintsToAdd) {
-                            if (!newConstraints.some((t) => isTypeSame(t, constraint))) {
+                            let isDuplicate = false;
+                            for (const t of newConstraints) {
+                                if (isTypeSame(t, constraint)) {
+                                    isDuplicate = true;
+                                    break;
+                                }
+                            }
+                            if (!isDuplicate) {
                                 newConstraints.push(constraint);
                             }
                         }
@@ -1704,13 +1767,17 @@ export function getCodeFlowEngine(
                     isCompatible = false;
                 }
             } else if (subtype.props?.condition) {
-                if (
-                    !subtype.props.condition.some(
-                        (condition) =>
-                            TypeVarType.hasConstraints(condition.typeVar) &&
-                            condition.typeVar.priv.nameWithScope === typeVar.priv.nameWithScope
-                    )
-                ) {
+                let hasMatchingCondition = false;
+                for (const condition of subtype.props.condition) {
+                    if (
+                        TypeVarType.hasConstraints(condition.typeVar) &&
+                        condition.typeVar.priv.nameWithScope === typeVar.priv.nameWithScope
+                    ) {
+                        hasMatchingCondition = true;
+                        break;
+                    }
+                }
+                if (!hasMatchingCondition) {
                     isCompatible = false;
                 }
             } else {
@@ -1807,13 +1874,13 @@ export function getCodeFlowEngine(
                     let overloadCount = 0;
                     let noReturnOverloadCount = 0;
 
-                    OverloadedType.getOverloads(callSubtype).forEach((overload) => {
+                    for (const overload of OverloadedType.getOverloads(callSubtype)) {
                         overloadCount++;
 
                         if (isFunctionNoReturn(overload, isCallAwaited)) {
                             noReturnOverloadCount++;
                         }
-                    });
+                    }
 
                     // Was at least one of the overloaded return types NoReturn?
                     if (noReturnOverloadCount > 0) {
@@ -1823,9 +1890,13 @@ export function getCodeFlowEngine(
                         } else {
                             // Perform a more complete evaluation to determine whether
                             // the applicable overload returns a NoReturn.
+                            const convertedArgs: ArgWithExpression[] = [];
+                            for (const arg of node.d.args) {
+                                convertedArgs.push(evaluator.convertNodeToArg(arg));
+                            }
                             const callResult = evaluator.validateOverloadedArgTypes(
                                 node,
-                                node.d.args.map((arg) => evaluator.convertNodeToArg(arg)),
+                                convertedArgs,
                                 { type: callSubtype, isIncomplete: callTypeResult.isIncomplete },
                                 /* constraints */ undefined,
                                 /* skipUnknownArgCheck */ false,
@@ -2004,7 +2075,13 @@ export function getCodeFlowEngine(
         const symbolWithScope = evaluator.lookUpSymbolRecursive(flowNode.node, name, /* honorCodeFlow */ false);
         assert(symbolWithScope !== undefined);
         const decls = symbolWithScope!.symbol.getDeclarations();
-        const wildcardDecl = decls.find((decl) => decl.node === flowNode.node);
+        let wildcardDecl: Declaration | undefined;
+        for (const decl of decls) {
+            if (decl.node === flowNode.node) {
+                wildcardDecl = decl;
+                break;
+            }
+        }
 
         if (!wildcardDecl) {
             return UnknownType.create();

--- a/packages/pyright-internal/src/analyzer/codeFlowUtils.ts
+++ b/packages/pyright-internal/src/analyzer/codeFlowUtils.ts
@@ -310,10 +310,22 @@ export function formatControlFlowGraph(flowNode: FlowNode) {
 
     function renderGraph() {
         const columnCount = columnWidths.length;
-        const laneCount = nodes.reduce((x, n) => Math.max(x, n.lane), 0) + 1;
+        let laneCount = 0;
+        for (const n of nodes) {
+            if (n.lane > laneCount) {
+                laneCount = n.lane;
+            }
+        }
+        laneCount += 1;
         const lanes: string[] = fill(Array(laneCount), '');
-        const grid: (FlowGraphNode | undefined)[][] = columnWidths.map(() => Array(laneCount));
-        const connectors: Connection[][] = columnWidths.map(() => fill(Array(laneCount), 0));
+        const grid: (FlowGraphNode | undefined)[][] = [];
+        for (let i = 0; i < columnWidths.length; i++) {
+            grid.push(Array(laneCount));
+        }
+        const connectors: Connection[][] = [];
+        for (let i = 0; i < columnWidths.length; i++) {
+            connectors.push(fill(Array(laneCount), 0));
+        }
 
         // Build connectors.
         for (const node of nodes) {

--- a/packages/pyright-internal/src/analyzer/commentUtils.ts
+++ b/packages/pyright-internal/src/analyzer/commentUtils.ts
@@ -98,7 +98,7 @@ function _overrideRules(
 
     // Enable the strict rules as appropriate.
     for (const ruleName of boolRuleNames) {
-        if (skipRuleNames.find((r) => r === ruleName)) {
+        if (skipRuleNames.includes(ruleName)) {
             continue;
         }
 
@@ -108,7 +108,7 @@ function _overrideRules(
     }
 
     for (const ruleName of diagRuleNames) {
-        if (skipRuleNames.find((r) => r === ruleName)) {
+        if (skipRuleNames.includes(ruleName)) {
             continue;
         }
 
@@ -171,12 +171,18 @@ function _parsePyrightComment(
 
         // If it contains a "strict" operand, replace the existing
         // diagnostic rules with their strict counterparts.
-        if (operandList.some((s) => s.trim() === strictSetting)) {
-            _applyStrictRules(ruleSet);
-        } else if (operandList.some((s) => s.trim() === standardSetting)) {
-            _applyStandardRules(ruleSet);
-        } else if (operandList.some((s) => s.trim() === basicSetting)) {
-            _applyBasicRules(ruleSet);
+        for (const s of operandList) {
+            const trimmed = s.trim();
+            if (trimmed === strictSetting) {
+                _applyStrictRules(ruleSet);
+                break;
+            } else if (trimmed === standardSetting) {
+                _applyStandardRules(ruleSet);
+                break;
+            } else if (trimmed === basicSetting) {
+                _applyBasicRules(ruleSet);
+                break;
+            }
         }
 
         let rangeOffset = 0;
@@ -208,7 +214,7 @@ function _parsePyrightOperand(
 
     // Handle basic directives "basic", "standard" and "strict".
     if (operandSplit.length === 1) {
-        if (trimmedRule && [strictSetting, standardSetting, basicSetting].some((setting) => trimmedRule === setting)) {
+        if (trimmedRule && [strictSetting, standardSetting, basicSetting].includes(trimmedRule)) {
             return ruleSet;
         }
     }
@@ -222,7 +228,7 @@ function _parsePyrightOperand(
         length: ruleValue.length,
     });
 
-    if (diagLevelRules.find((r) => r === trimmedRule)) {
+    if ((diagLevelRules as readonly string[]).includes(trimmedRule)) {
         const diagLevelValue = _parseDiagLevel(trimmedRuleValue);
         if (diagLevelValue !== undefined) {
             (ruleSet as any)[trimmedRule] = diagLevelValue;
@@ -233,7 +239,7 @@ function _parsePyrightOperand(
             };
             diagnostics.push(diag);
         }
-    } else if (boolRules.find((r) => r === trimmedRule)) {
+    } else if ((boolRules as readonly string[]).includes(trimmedRule)) {
         const boolValue = _parseBoolSetting(trimmedRuleValue);
         if (boolValue !== undefined) {
             (ruleSet as any)[trimmedRule] = boolValue;

--- a/packages/pyright-internal/src/analyzer/constraintSolution.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolution.ts
@@ -42,11 +42,11 @@ export class ConstraintSolutionSet {
     }
 
     doForEachTypeVar(callback: (type: Type, typeVarId: string) => void) {
-        this._typeVarMap.forEach((type, key) => {
+        for (const [key, type] of this._typeVarMap) {
             if (type) {
                 callback(type, key);
             }
-        });
+        }
     }
 }
 
@@ -59,13 +59,18 @@ export class ConstraintSolution {
     }
 
     isEmpty() {
-        return this._solutionSets.every((set) => set.isEmpty());
+        for (const set of this._solutionSets) {
+            if (!set.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     setType(typeVar: TypeVarType, type: Type) {
-        return this._solutionSets.forEach((set) => {
+        for (const set of this._solutionSets) {
             set.setType(typeVar, type);
-        });
+        }
     }
 
     getMainSolutionSet() {
@@ -77,9 +82,10 @@ export class ConstraintSolution {
     }
 
     doForEachSolutionSet(callback: (solutionSet: ConstraintSolutionSet, index: number) => void) {
-        this.getSolutionSets().forEach((set, index) => {
-            callback(set, index);
-        });
+        const sets = this.getSolutionSets();
+        for (let index = 0; index < sets.length; index++) {
+            callback(sets[index], index);
+        }
     }
 
     getSolutionSet(index: number) {

--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -558,7 +558,15 @@ function getTypeVarType(
                 if (!entry.upperBound || evaluator.assignType(entry.upperBound, lowerNoLiterals)) {
                     if (TypeVarType.hasConstraints(typeVar)) {
                         // Does it still match a value constraint?
-                        if (typeVar.shared.constraints.some((constraint) => isTypeSame(lowerNoLiterals, constraint))) {
+                        const constraints = typeVar.shared.constraints;
+                        let matchesConstraint = false;
+                        for (let i = 0; i < constraints.length; i++) {
+                            if (isTypeSame(lowerNoLiterals, constraints[i])) {
+                                matchesConstraint = true;
+                                break;
+                            }
+                        }
+                        if (matchesConstraint) {
                             lowerBound = lowerNoLiterals;
                         }
                     } else {
@@ -1107,19 +1115,25 @@ function assignConstrainedTypeVar(
         // If the type is a union, see if the entire union is assignable to one
         // of the constraints.
         if (!constrainedType && isUnion(concreteSrcType)) {
-            constrainedType = destType.shared.constraints.find((constraint) => {
+            const constraints = destType.shared.constraints;
+            for (let i = 0; i < constraints.length; i++) {
                 const adjustedConstraint = TypeBase.isInstantiable(destType)
-                    ? convertToInstantiable(constraint)
-                    : constraint;
-                return evaluator.assignType(
-                    adjustedConstraint,
-                    concreteSrcType,
-                    /* diag */ undefined,
-                    /* constraints */ undefined,
-                    AssignTypeFlags.Default,
-                    recursionCount
-                );
-            });
+                    ? convertToInstantiable(constraints[i])
+                    : constraints[i];
+                if (
+                    evaluator.assignType(
+                        adjustedConstraint,
+                        concreteSrcType,
+                        /* diag */ undefined,
+                        /* constraints */ undefined,
+                        AssignTypeFlags.Default,
+                        recursionCount
+                    )
+                ) {
+                    constrainedType = constraints[i];
+                    break;
+                }
+            }
         }
     }
 

--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -42,6 +42,7 @@ import {
     TupleTypeArg,
     Type,
     TypeBase,
+    TypeSameOptions,
     TypeVarKind,
     TypeVarScopeId,
     TypeVarType,
@@ -76,6 +77,8 @@ import {
 // many subtypes. For performance reasons, we need to cap this at some
 // point. This constant determines the cap.
 const maxSubtypeCountForTypeVarLowerBound = 64;
+
+const _ignoreTypeFlagsOptions: TypeSameOptions = { ignoreTypeFlags: true };
 
 // This debugging switch enables logging of the constraints before and
 // after it is updated by the constraint solver.
@@ -288,7 +291,7 @@ function solveTypeVarRecursive(
 
             for (const typeVar of typeVars) {
                 // Don't attempt to replace a TypeVar with itself.
-                if (isTypeSame(typeVar, entry.typeVar, { ignoreTypeFlags: true })) {
+                if (isTypeSame(typeVar, entry.typeVar, _ignoreTypeFlagsOptions)) {
                     continue;
                 }
 
@@ -702,7 +705,7 @@ function assignUnconstrainedTypeVar(
         // Update the upper bound.
         if (!curUpperBound || isTypeSame(destType, curUpperBound)) {
             newUpperBound = adjSrcType;
-        } else if (!isTypeSame(curUpperBound, adjSrcType, {}, recursionCount)) {
+        } else if (!isTypeSame(curUpperBound, adjSrcType, undefined, recursionCount)) {
             if (
                 evaluator.assignType(
                     curUpperBound,
@@ -764,7 +767,7 @@ function assignUnconstrainedTypeVar(
         if (!curLowerBound || isTypeSame(destType, curLowerBound)) {
             // There was previously no lower bound. We've now established one.
             newLowerBound = adjSrcType;
-        } else if (isTypeSame(curLowerBound, adjSrcType, {}, recursionCount)) {
+        } else if (isTypeSame(curLowerBound, adjSrcType, undefined, recursionCount)) {
             // If this is an invariant context and there is currently no upper bound
             // established, use the "no literals" version of the lower bound rather
             // than a version that has literals.
@@ -906,7 +909,7 @@ function assignUnconstrainedTypeVar(
 
         // Make sure we don't exceed the upper bound.
         if (curUpperBound && newLowerBound) {
-            if (!isTypeSame(curUpperBound, newLowerBound, {}, recursionCount)) {
+            if (!isTypeSame(curUpperBound, newLowerBound, undefined, recursionCount)) {
                 if (
                     !evaluator.assignType(
                         curUpperBound,
@@ -1209,7 +1212,7 @@ function assignParamSpec(
 
                 if (existingTypeWithoutArgsKwargs.shared.parameters.length === 0 && existingTypeParamSpec) {
                     // If there's an existing entry that matches, that's fine.
-                    if (isTypeSame(existingTypeParamSpec, adjSrcType, {}, recursionCount)) {
+                    if (isTypeSame(existingTypeParamSpec, adjSrcType, undefined, recursionCount)) {
                         return;
                     }
                 }

--- a/packages/pyright-internal/src/analyzer/constraintSolver.ts
+++ b/packages/pyright-internal/src/analyzer/constraintSolver.ts
@@ -240,14 +240,14 @@ export function applySourceSolutionToConstraints(constraints: ConstraintTracker,
     }
 
     constraints.doForEachConstraintSet((constraintSet) => {
-        constraintSet.getTypeVars().forEach((entry) => {
+        for (const entry of constraintSet.getTypeVars()) {
             constraintSet.setBounds(
                 entry.typeVar,
                 entry.lowerBound ? applySolvedTypeVars(entry.lowerBound, srcSolution) : undefined,
                 entry.upperBound ? applySolvedTypeVars(entry.upperBound, srcSolution) : undefined,
                 entry.retainLiterals
             );
-        });
+        }
     });
 }
 
@@ -344,9 +344,9 @@ export function addConstraintsForExpectedType(
     usageOffset: number | undefined = undefined
 ): boolean {
     if (isAny(expectedType)) {
-        type.shared.typeParams.forEach((typeParam) => {
+        for (const typeParam of type.shared.typeParams) {
             constraints.setBounds(typeParam, expectedType, expectedType);
-        });
+        }
         return true;
     }
 
@@ -377,7 +377,7 @@ export function addConstraintsForExpectedType(
     if (ClassType.isSameGenericClass(expectedType, type)) {
         const solution = buildSolutionFromSpecializedClass(expectedType);
         const typeParams = ClassType.getTypeParams(expectedType);
-        typeParams.forEach((typeParam) => {
+        for (const typeParam of typeParams) {
             let typeArgValue = solution.getMainSolutionSet().getType(typeParam);
 
             if (typeArgValue && liveTypeVarScopes) {
@@ -393,13 +393,16 @@ export function addConstraintsForExpectedType(
                     variance === Variance.Contravariant ? undefined : typeArgValue
                 );
             }
-        });
+        }
         return true;
     }
 
     // Create a generic version of the expected type.
     const expectedTypeScopeId = getTypeVarScopeId(expectedType);
-    const synthExpectedTypeArgs = ClassType.getTypeParams(expectedType).map((typeParam, index) => {
+    const expectedTypeParams = ClassType.getTypeParams(expectedType);
+    const synthExpectedTypeArgs: TypeVarType[] = [];
+    for (let index = 0; index < expectedTypeParams.length; index++) {
+        const typeParam = expectedTypeParams[index];
         const typeVar = TypeVarType.createInstance(
             `__dest${index}`,
             isParamSpec(typeParam) ? TypeVarKind.ParamSpec : TypeVarKind.TypeVar
@@ -409,12 +412,15 @@ export function addConstraintsForExpectedType(
         // Use invariance here so we set the lower and upper bound on the TypeVar.
         typeVar.shared.declaredVariance = Variance.Invariant;
         typeVar.priv.scopeId = expectedTypeScopeId;
-        return typeVar;
-    });
+        synthExpectedTypeArgs.push(typeVar);
+    }
     const genericExpectedType = ClassType.specialize(expectedType, synthExpectedTypeArgs);
 
     // For each type param in the target type, create a placeholder type variable.
-    const typeArgs = ClassType.getTypeParams(type).map((typeParam, index) => {
+    const srcTypeParams = ClassType.getTypeParams(type);
+    const typeArgs: TypeVarType[] = [];
+    for (let index = 0; index < srcTypeParams.length; index++) {
+        const typeParam = srcTypeParams[index];
         const typeVar = TypeVarType.createInstance(
             `__source${index}`,
             isParamSpec(typeParam) ? TypeVarKind.ParamSpec : TypeVarKind.TypeVar
@@ -422,8 +428,8 @@ export function addConstraintsForExpectedType(
         typeVar.shared.isSynthesized = true;
         typeVar.shared.synthesizedIndex = index;
         typeVar.shared.isExemptFromBoundCheck = true;
-        return TypeVarType.cloneAsUnificationVar(typeVar);
-    });
+        typeArgs.push(TypeVarType.cloneAsUnificationVar(typeVar));
+    }
 
     const specializedType = ClassType.specialize(type, typeArgs);
     const syntheticConstraints = new ConstraintTracker();
@@ -438,7 +444,8 @@ export function addConstraintsForExpectedType(
     ) {
         let isResultValid = true;
 
-        synthExpectedTypeArgs.forEach((typeVar, index) => {
+        for (let index = 0; index < synthExpectedTypeArgs.length; index++) {
+            const typeVar = synthExpectedTypeArgs[index];
             let synthTypeVar = getTypeVarType(evaluator, syntheticConstraints.getMainConstraintSet(), typeVar);
             const otherSubtypes: Type[] = [];
 
@@ -452,7 +459,7 @@ export function addConstraintsForExpectedType(
                 if (isUnion(synthTypeVar)) {
                     let foundSynthTypeVar: TypeVarType | undefined;
 
-                    sortTypes(synthTypeVar.priv.subtypes).forEach((subtype) => {
+                    for (const subtype of sortTypes(synthTypeVar.priv.subtypes)) {
                         if (
                             isTypeVar(subtype) &&
                             subtype.shared.isSynthesized &&
@@ -463,7 +470,7 @@ export function addConstraintsForExpectedType(
                         } else {
                             otherSubtypes.push(subtype);
                         }
-                    });
+                    }
 
                     if (foundSynthTypeVar) {
                         synthTypeVar = foundSynthTypeVar;
@@ -506,7 +513,7 @@ export function addConstraintsForExpectedType(
                     }
                 }
             }
-        });
+        }
 
         return isResultValid;
     }
@@ -1050,7 +1057,9 @@ function assignConstrainedTypeVar(
             }
 
             let constraintIndexUsed: number | undefined;
-            destType.shared.constraints.forEach((constraint, i) => {
+            const destConstraints = destType.shared.constraints;
+            for (let i = 0; i < destConstraints.length; i++) {
+                const constraint = destConstraints[i];
                 const adjustedConstraint = TypeBase.isInstantiable(destType)
                     ? convertToInstantiable(constraint)
                     : constraint;
@@ -1081,7 +1090,7 @@ function assignConstrainedTypeVar(
                         constraintIndexUsed = i;
                     }
                 }
-            });
+            }
 
             if (!constrainedSubtype) {
                 // We found a source subtype that is not compatible with the dest.
@@ -1347,19 +1356,20 @@ function stripLiteralValueForUnpackedTuple(evaluator: TypeEvaluator, type: Type)
     }
 
     let strippedLiteral = false;
-    const tupleTypeArgs: TupleTypeArg[] = type.priv.tupleTypeArgs.map((arg) => {
+    const tupleTypeArgs: TupleTypeArg[] = [];
+    for (const arg of type.priv.tupleTypeArgs) {
         const strippedType = stripTypeForm(evaluator.stripLiteralValue(arg.type));
 
         if (strippedType !== arg.type) {
             strippedLiteral = true;
         }
 
-        return {
+        tupleTypeArgs.push({
             isUnbounded: arg.isUnbounded,
             isOptional: arg.isOptional,
             type: strippedType,
-        };
-    });
+        });
+    }
 
     if (!strippedLiteral) {
         return type;
@@ -1387,7 +1397,7 @@ function logConstraints(evaluator: TypeEvaluator, constraints: ConstraintTracker
 function logTypeVarConstraintSet(evaluator: TypeEvaluator, context: ConstraintSet, indent: string) {
     let loggedConstraint = false;
 
-    context.getTypeVars().forEach((entry) => {
+    for (const entry of context.getTypeVars()) {
         const typeVarName = `${indent}${entry.typeVar.shared.name}`;
         const lowerBound = entry.lowerBound;
         const upperBound = entry.upperBound;
@@ -1406,7 +1416,7 @@ function logTypeVarConstraintSet(evaluator: TypeEvaluator, context: ConstraintSe
                 loggedConstraint = true;
             }
         }
-    });
+    }
 
     if (!loggedConstraint) {
         console.log(`${indent}no constraints`);

--- a/packages/pyright-internal/src/analyzer/constraintTracker.ts
+++ b/packages/pyright-internal/src/analyzer/constraintTracker.ts
@@ -59,12 +59,14 @@ export class ConstraintSet {
     clone() {
         const constraintSet = new ConstraintSet();
 
-        this._typeVarMap.forEach((value) => {
+        for (const value of this._typeVarMap.values()) {
             constraintSet.setBounds(value.typeVar, value.lowerBound, value.upperBound, value.retainLiterals);
-        });
+        }
 
         if (this._scopeIds) {
-            this._scopeIds.forEach((scopeId) => constraintSet.addScopeId(scopeId));
+            for (const scopeId of this._scopeIds) {
+                constraintSet.addScopeId(scopeId);
+            }
         }
 
         return constraintSet;
@@ -84,7 +86,7 @@ export class ConstraintSet {
         }
 
         let isSame = true;
-        this._typeVarMap.forEach((value, key) => {
+        for (const [key, value] of this._typeVarMap) {
             const otherValue = other._typeVarMap.get(key);
             if (
                 !otherValue ||
@@ -92,8 +94,9 @@ export class ConstraintSet {
                 !typesMatch(value.upperBound, otherValue.upperBound)
             ) {
                 isSame = false;
+                break;
             }
-        });
+        }
 
         return isSame;
     }
@@ -108,7 +111,7 @@ export class ConstraintSet {
         let score = 0;
 
         // Sum the scores for the defined type vars.
-        this._typeVarMap.forEach((entry) => {
+        for (const entry of this._typeVarMap.values()) {
             // Add 1 to the score for each type variable defined.
             score += 1;
 
@@ -119,7 +122,7 @@ export class ConstraintSet {
             if (typeVarType) {
                 score += 1.0 - getComplexityScoreForType(typeVarType);
             }
-        });
+        }
 
         return score;
     }
@@ -135,7 +138,9 @@ export class ConstraintSet {
     }
 
     doForEachTypeVar(cb: (entry: TypeVarConstraints) => void) {
-        this._typeVarMap.forEach(cb);
+        for (const entry of this._typeVarMap.values()) {
+            cb(entry);
+        }
     }
 
     getTypeVar(typeVar: TypeVarType): TypeVarConstraints | undefined {
@@ -146,9 +151,9 @@ export class ConstraintSet {
     getTypeVars(): TypeVarConstraints[] {
         const entries: TypeVarConstraints[] = [];
 
-        this._typeVarMap.forEach((entry) => {
+        for (const entry of this._typeVarMap.values()) {
             entries.push(entry);
-        });
+        }
 
         return entries;
     }
@@ -194,7 +199,11 @@ export class ConstraintTracker {
     clone() {
         const newTypeVarMap = new ConstraintTracker();
 
-        newTypeVarMap._constraintSets = this._constraintSets.map((set) => set.clone());
+        const clonedSets: ConstraintSet[] = [];
+        for (const set of this._constraintSets) {
+            clonedSets.push(set.clone());
+        }
+        newTypeVarMap._constraintSets = clonedSets;
 
         return newTypeVarMap;
     }
@@ -203,14 +212,19 @@ export class ConstraintTracker {
         const cloned = this.clone();
 
         if (scopeId) {
-            const filteredSets = this._constraintSets.filter((context) => context.hasScopeId(scopeId));
+            const filteredSets: ConstraintSet[] = [];
+            for (const context of this._constraintSets) {
+                if (context.hasScopeId(scopeId)) {
+                    filteredSets.push(context);
+                }
+            }
 
             if (filteredSets.length > 0) {
                 cloned._constraintSets = filteredSets;
             } else {
-                cloned._constraintSets.forEach((context) => {
+                for (const context of cloned._constraintSets) {
                     context.addScopeId(scopeId);
-                });
+                }
             }
         }
 
@@ -219,13 +233,17 @@ export class ConstraintTracker {
 
     // Copies a cloned type var context back into this object.
     copyFromClone(clone: ConstraintTracker) {
-        this._constraintSets = clone._constraintSets.map((context) => context.clone());
+        const clonedSets: ConstraintSet[] = [];
+        for (const context of clone._constraintSets) {
+            clonedSets.push(context.clone());
+        }
+        this._constraintSets = clonedSets;
     }
 
     copyBounds(entry: TypeVarConstraints) {
-        this._constraintSets.forEach((set) => {
+        for (const set of this._constraintSets) {
             set.setBounds(entry.typeVar, entry.lowerBound, entry.upperBound, entry.retainLiterals);
-        });
+        }
     }
 
     // Copy the specified constraint sets into this type var context.
@@ -244,25 +262,35 @@ export class ConstraintTracker {
             return false;
         }
 
-        return this._constraintSets.every((set, index) => set.isSame(other._constraintSets[index]));
+        for (let i = 0; i < this._constraintSets.length; i++) {
+            if (!this._constraintSets[i].isSame(other._constraintSets[i])) {
+                return false;
+            }
+        }
+        return true;
     }
 
     isEmpty() {
-        return this._constraintSets.every((set) => set.isEmpty());
+        for (const set of this._constraintSets) {
+            if (!set.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     setBounds(typeVar: TypeVarType, lowerBound: Type | undefined, upperBound?: Type, retainLiterals?: boolean) {
-        return this._constraintSets.forEach((set) => {
+        for (const set of this._constraintSets) {
             set.setBounds(typeVar, lowerBound, upperBound, retainLiterals);
-        });
+        }
     }
 
     getScore() {
         let total = 0;
 
-        this._constraintSets.forEach((set) => {
+        for (const set of this._constraintSets) {
             total += set.getScore();
-        });
+        }
 
         // Return the average score among all constraint sets.
         return total / this._constraintSets.length;
@@ -277,9 +305,10 @@ export class ConstraintTracker {
     }
 
     doForEachConstraintSet(callback: (constraintSet: ConstraintSet, index: number) => void) {
-        this.getConstraintSets().forEach((set, index) => {
-            callback(set, index);
-        });
+        const sets = this.getConstraintSets();
+        for (let i = 0; i < sets.length; i++) {
+            callback(sets[i], i);
+        }
     }
 
     getConstraintSet(index: number) {

--- a/packages/pyright-internal/src/analyzer/constraintTracker.ts
+++ b/packages/pyright-internal/src/analyzer/constraintTracker.ts
@@ -11,7 +11,9 @@
 
 import { assert } from '../common/debug';
 import { getComplexityScoreForType } from './typeComplexity';
-import { Type, TypeVarScopeId, TypeVarType, isTypeSame } from './types';
+import { Type, TypeSameOptions, TypeVarScopeId, TypeVarType, isTypeSame } from './types';
+
+const _typeArgExplicitFormOptions: TypeSameOptions = { honorIsTypeArgExplicit: true, honorTypeForm: true };
 
 // The maximum number of constraint sets that can be associated
 // with a constraint tracker. This equates to the number of overloads
@@ -78,7 +80,7 @@ export class ConstraintSet {
                 return type1 === type2;
             }
 
-            return isTypeSame(type1, type2, { honorIsTypeArgExplicit: true, honorTypeForm: true });
+            return isTypeSame(type1, type2, _typeArgExplicitFormOptions);
         }
 
         let isSame = true;

--- a/packages/pyright-internal/src/analyzer/constructorTransform.ts
+++ b/packages/pyright-internal/src/analyzer/constructorTransform.ts
@@ -17,7 +17,7 @@ import { LocMessage } from '../localization/localize';
 import { ArgCategory, ExpressionNode, ParamCategory } from '../parser/parseNodes';
 import { ConstraintTracker } from './constraintTracker';
 import { createFunctionFromConstructor } from './constructors';
-import { getParamListDetails, ParamKind } from './parameterUtils';
+import { getParamListDetails, ParamKind, VirtualParamDetails } from './parameterUtils';
 import { getTypedDictMembersForClass } from './typedDicts';
 import { Arg, FunctionResult, TypeEvaluator } from './typeEvaluatorTypes';
 import {
@@ -108,8 +108,10 @@ function applyPartialTransform(
     evaluator.inferReturnTypeIfNecessary(origFunctionType);
 
     // We don't currently handle unpacked arguments.
-    if (argList.some((arg) => arg.argCategory !== ArgCategory.Simple)) {
-        return undefined;
+    for (const arg of argList) {
+        if (arg.argCategory !== ArgCategory.Simple) {
+            return undefined;
+        }
     }
 
     // Make sure the first argument is a simple function.
@@ -141,7 +143,7 @@ function applyPartialTransform(
         let sawArgErrors = false;
 
         // Apply the partial transform to each of the functions in the overload.
-        overloads.forEach((overload) => {
+        for (const overload of overloads) {
             // Apply the transform to this overload, but don't report errors.
             const transformResult = applyPartialTransformToFunction(
                 evaluator,
@@ -158,7 +160,7 @@ function applyPartialTransform(
                     applicableOverloads.push(transformResult.returnType);
                 }
             }
-        });
+        }
 
         if (applicableOverloads.length === 0) {
             if (sawArgErrors && overloads.length > 0) {
@@ -178,11 +180,15 @@ function applyPartialTransform(
         if (applicableOverloads.length === 1) {
             synthesizedCallType = applicableOverloads[0];
         } else {
+            const mappedOverloads: FunctionType[] = [];
+            for (const overload of applicableOverloads) {
+                mappedOverloads.push(
+                    FunctionType.cloneWithNewFlags(overload, overload.shared.flags | FunctionTypeFlags.Overloaded)
+                );
+            }
             synthesizedCallType = OverloadedType.create(
                 // Set the "overloaded" flag for each of the __call__ overloads.
-                applicableOverloads.map((overload) =>
-                    FunctionType.cloneWithNewFlags(overload, overload.shared.flags | FunctionTypeFlags.Overloaded)
-                )
+                mappedOverloads
             );
         }
 
@@ -217,9 +223,10 @@ function applyPartialTransformToFunction(
     const constraints = new ConstraintTracker();
 
     const remainingArgsList = argList.slice(1);
-    remainingArgsList.forEach((arg, argIndex) => {
+    for (let argIndex = 0; argIndex < remainingArgsList.length; argIndex++) {
+        const arg = remainingArgsList[argIndex];
         if (!arg.valueExpression) {
-            return;
+            continue;
         }
 
         // Is it a positional argument or a keyword argument?
@@ -310,9 +317,13 @@ function applyPartialTransformToFunction(
                 paramMap.set(paramName, false);
             }
         } else {
-            const matchingParam = paramListDetails.params.find(
-                (paramInfo) => paramInfo.param.name === arg.name?.d.value && paramInfo.kind !== ParamKind.Positional
-            );
+            let matchingParam: VirtualParamDetails | undefined;
+            for (const paramInfo of paramListDetails.params) {
+                if (paramInfo.param.name === arg.name?.d.value && paramInfo.kind !== ParamKind.Positional) {
+                    matchingParam = paramInfo;
+                    break;
+                }
+            }
 
             if (!matchingParam) {
                 // Is there a kwargs parameter?
@@ -398,7 +409,7 @@ function applyPartialTransformToFunction(
                 }
             }
         }
-    });
+    }
 
     const specializedFunctionType = evaluator.solveAndApplyConstraints(origFunctionType, constraints);
     if (!isFunction(specializedFunctionType)) {
@@ -407,7 +418,9 @@ function applyPartialTransformToFunction(
 
     // Create a new parameter list that omits parameters that have been
     // populated already.
-    const updatedParamList: FunctionParam[] = specializedFunctionType.shared.parameters.map((param, index) => {
+    const updatedParamList: FunctionParam[] = [];
+    for (let index = 0; index < specializedFunctionType.shared.parameters.length; index++) {
+        const param = specializedFunctionType.shared.parameters[index];
         let newType = FunctionType.getParamType(specializedFunctionType, index);
 
         // If this is an **kwargs with an unpacked TypedDict, mark the provided
@@ -421,11 +434,11 @@ function applyPartialTransformToFunction(
             const typedDictEntries = getTypedDictMembersForClass(evaluator, newType);
             const narrowedEntriesMap = new Map<string, TypedDictEntry>(newType.priv.typedDictNarrowedEntries ?? []);
 
-            typedDictEntries.knownItems.forEach((entry, name) => {
+            for (const [name, entry] of typedDictEntries.knownItems) {
                 if (paramMap.has(name)) {
                     narrowedEntriesMap.set(name, { ...entry, isRequired: false });
                 }
-            });
+            }
 
             newType = ClassType.cloneAsInstance(
                 ClassType.cloneForNarrowedTypedDictEntries(newType, narrowedEntriesMap)
@@ -438,23 +451,20 @@ function applyPartialTransformToFunction(
         if (param.name && paramMap.get(param.name)) {
             newDefaultType = AnyType.create(/* isEllipsis */ true);
         }
-        return FunctionParam.create(param.category, newType, param.flags, param.name, newDefaultType);
-    });
-    const unassignedParamList = updatedParamList.filter((param) => {
+        updatedParamList.push(FunctionParam.create(param.category, newType, param.flags, param.name, newDefaultType));
+    }
+    const unassignedParamList: FunctionParam[] = [];
+    const assignedKeywordParamList: FunctionParam[] = [];
+    const kwargsParam: FunctionParam[] = [];
+    for (const param of updatedParamList) {
         if (param.category === ParamCategory.KwargsDict) {
-            return false;
+            kwargsParam.push(param);
+        } else if (param.name && paramMap.get(param.name)) {
+            assignedKeywordParamList.push(param);
+        } else if (param.category === ParamCategory.ArgsList || !param.name || !paramMap.has(param.name)) {
+            unassignedParamList.push(param);
         }
-        if (param.category === ParamCategory.ArgsList) {
-            return true;
-        }
-        return !param.name || !paramMap.has(param.name);
-    });
-    const assignedKeywordParamList = updatedParamList.filter((param) => {
-        return param.name && paramMap.get(param.name);
-    });
-    const kwargsParam = updatedParamList.filter((param) => {
-        return param.category === ParamCategory.KwargsDict;
-    });
+    }
 
     const newParamList: FunctionParam[] = [];
     appendArray(newParamList, unassignedParamList);
@@ -473,9 +483,9 @@ function applyPartialTransformToFunction(
     if (partialCallMemberType.shared.parameters.length > 0) {
         FunctionType.addParam(newCallMemberType, partialCallMemberType.shared.parameters[0]);
     }
-    newParamList.forEach((param) => {
+    for (const param of newParamList) {
         FunctionType.addParam(newCallMemberType, param);
-    });
+    }
 
     newCallMemberType.shared.declaredReturnType = specializedFunctionType.shared.declaredReturnType
         ? FunctionType.getEffectiveReturnType(specializedFunctionType)

--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -229,11 +229,11 @@ export function validateConstructorArgs(
     // If we weren't able to validate the args, analyze the expressions here
     // to mark symbols referenced and report expression evaluation errors.
     if (!validatedArgExpressions) {
-        argList.forEach((arg) => {
+        for (const arg of argList) {
             if (arg.valueExpression && !evaluator.isSpeculativeModeInUse(arg.valueExpression)) {
                 evaluator.getTypeOfExpression(arg.valueExpression);
             }
-        });
+        }
     }
 
     return returnResult;
@@ -506,7 +506,13 @@ function validateInitMethod(
         { type: initMethodType },
         constraints,
         skipUnknownArgCheck,
-        inferenceContext ? { ...inferenceContext, returnTypeOverride } : undefined
+        inferenceContext
+            ? {
+                  expectedType: inferenceContext.expectedType,
+                  isTypeIncomplete: inferenceContext.isTypeIncomplete,
+                  returnTypeOverride,
+              }
+            : undefined
     );
 
     let adjustedClassType = type;
@@ -840,15 +846,26 @@ function createFunctionFromNewMethod(
         // If there are no parameters that include class-scoped type parameters,
         // self-specialize the class because the type arguments for the class
         // can't be solved if there are no parameters to supply them.
-        const hasParamsWithTypeVars = newSubtype.shared.parameters.some((param, index) => {
-            if (index === 0 || !param.name) {
-                return false;
+        let hasParamsWithTypeVars = false;
+        for (let paramIdx = 1; paramIdx < newSubtype.shared.parameters.length; paramIdx++) {
+            const param = newSubtype.shared.parameters[paramIdx];
+            if (!param.name) {
+                continue;
             }
-
-            const paramType = FunctionType.getParamType(newSubtype, index);
+            const paramType = FunctionType.getParamType(newSubtype, paramIdx);
             const typeVars = getTypeVarArgsRecursive(paramType);
-            return typeVars.some((typeVar) => typeVar.priv.scopeId === getTypeVarScopeId(classType));
-        });
+            let found = false;
+            for (const typeVar of typeVars) {
+                if (typeVar.priv.scopeId === getTypeVarScopeId(classType)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (found) {
+                hasParamsWithTypeVars = true;
+                break;
+            }
+        }
 
         const boundNew = evaluator.bindFunctionToClassOrObject(
             hasParamsWithTypeVars ? selfSpecializeClass(classType) : classType,
@@ -886,12 +903,12 @@ function createFunctionFromNewMethod(
     }
 
     const newOverloads: FunctionType[] = [];
-    OverloadedType.getOverloads(newType).forEach((overload) => {
+    for (const overload of OverloadedType.getOverloads(newType)) {
         const converted = convertNewToConstructor(overload);
         if (converted) {
             newOverloads.push(converted);
         }
-    });
+    }
 
     if (newOverloads.length === 0) {
         return undefined;
@@ -973,14 +990,14 @@ function createFunctionFromInitMethod(
                 // on its default value (typically Unknown) in the resulting specialized type.
                 const typeVarsInParams: TypeVarType[] = [];
 
-                convertedInit.shared.parameters.forEach((param, index) => {
-                    const paramType = FunctionType.getParamType(convertedInit, index);
+                for (let paramIdx = 0; paramIdx < convertedInit.shared.parameters.length; paramIdx++) {
+                    const paramType = FunctionType.getParamType(convertedInit, paramIdx);
                     addTypeVarsToListIfUnique(typeVarsInParams, getTypeVarArgsRecursive(paramType));
-                });
+                }
 
-                typeVarsInParams.forEach((typeVar) => {
+                for (const typeVar of typeVarsInParams) {
                     constraints.setBounds(typeVar, typeVar);
-                });
+                }
 
                 returnType = evaluator.solveAndApplyConstraints(objectType, constraints, {
                     replaceUnsolved: {
@@ -1016,12 +1033,12 @@ function createFunctionFromInitMethod(
     }
 
     const initOverloads: FunctionType[] = [];
-    OverloadedType.getOverloads(initType).forEach((overload) => {
+    for (const overload of OverloadedType.getOverloads(initType)) {
         const converted = convertInitToConstructor(overload);
         if (converted) {
             initOverloads.push(converted);
         }
-    });
+    }
 
     if (initOverloads.length === 0) {
         return undefined;

--- a/packages/pyright-internal/src/analyzer/constructors.ts
+++ b/packages/pyright-internal/src/analyzer/constructors.ts
@@ -320,10 +320,7 @@ function validateNewAndInitMethods(
         // but didn't supply solved type arguments, we'll ignore its specialized return
         // type and rely on the __init__ method to supply the type arguments instead.
         let initMethodBindToType = newMethodReturnType;
-        if (
-            initMethodBindToType.priv.typeArgs &&
-            initMethodBindToType.priv.typeArgs.some((typeArg) => isUnknown(typeArg))
-        ) {
+        if (initMethodBindToType.priv.typeArgs && _hasUnknownTypeArg(initMethodBindToType)) {
             initMethodBindToType = ClassType.cloneAsInstance(type);
         }
 
@@ -1136,4 +1133,16 @@ function isDefaultNewMethod(newMethod?: Type): boolean {
     }
 
     return true;
+}
+
+function _hasUnknownTypeArg(type: ClassType): boolean {
+    if (!type.priv.typeArgs) {
+        return false;
+    }
+    for (const typeArg of type.priv.typeArgs) {
+        if (isUnknown(typeArg)) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/packages/pyright-internal/src/analyzer/dataClasses.ts
+++ b/packages/pyright-internal/src/analyzer/dataClasses.ts
@@ -30,7 +30,7 @@ import { getFileInfo } from './analyzerNodeInfo';
 import { ConstraintSolution } from './constraintSolution';
 import { ConstraintTracker } from './constraintTracker';
 import { createFunctionFromConstructor, getBoundInitMethod } from './constructors';
-import { DeclarationType } from './declaration';
+import { Declaration, DeclarationType } from './declaration';
 import { updateNamedTupleBaseClass } from './namedTuples';
 import {
     getClassFullName,
@@ -174,38 +174,43 @@ export function synthesizeDataClassMethods(
     const localEntryTypeEvaluator: { entry: DataClassEntry; evaluator: EntryTypeEvaluator }[] = [];
     let sawKeywordOnlySeparator = false;
 
-    ClassType.getSymbolTable(classType).forEach((symbol, name) => {
+    for (const [name, symbol] of ClassType.getSymbolTable(classType)) {
         if (symbol.isIgnoredForProtocolMatch()) {
-            return;
+            continue;
         }
 
         // Apparently, `__hash__` is special-cased in a dataclass. I can't find
         // this in the spec, but the runtime seems to treat is specially.
         if (name === '__hash__') {
-            return;
+            continue;
         }
 
         let isInferredFinal = false;
 
         // Only variables (not functions, classes, etc.) are considered.
-        let classVarDecl = symbol.getTypedDeclarations().find((decl) => {
+        let classVarDecl: Declaration | undefined;
+        for (const decl of symbol.getTypedDeclarations()) {
             if (decl.type !== DeclarationType.Variable) {
-                return false;
+                continue;
             }
 
             const container = getEnclosingClassOrFunction(decl.node);
             if (!container || container.nodeType !== ParseNodeType.Class) {
-                return false;
+                continue;
             }
 
-            return true;
-        });
+            classVarDecl = decl;
+            break;
+        }
 
         // See if this is an unannotated (inferred) Final value.
         if (!classVarDecl) {
-            classVarDecl = symbol.getDeclarations().find((decl) => {
-                return decl.type === DeclarationType.Variable && !decl.typeAnnotationNode && decl.isFinal;
-            });
+            for (const decl of symbol.getDeclarations()) {
+                if (decl.type === DeclarationType.Variable && !decl.typeAnnotationNode && decl.isFinal) {
+                    classVarDecl = decl;
+                    break;
+                }
+            }
 
             isInferredFinal = true;
         }
@@ -286,7 +291,13 @@ export function synthesizeDataClassMethods(
                             classType.shared.dataClassBehaviors?.fieldDescriptorNames || []
                         )
                     ) {
-                        const initArg = statement.d.rightExpr.d.args.find((arg) => arg.d.name?.d.value === 'init');
+                        let initArg: ArgumentNode | undefined;
+                        for (const arg of statement.d.rightExpr.d.args) {
+                            if (arg.d.name?.d.value === 'init') {
+                                initArg = arg;
+                                break;
+                            }
+                        }
                         if (initArg && initArg.d.valueExpr) {
                             const fileInfo = AnalyzerNodeInfo.getFileInfo(node);
                             includeInInit =
@@ -305,7 +316,13 @@ export function synthesizeDataClassMethods(
                                 ) ?? includeInInit;
                         }
 
-                        const kwOnlyArg = statement.d.rightExpr.d.args.find((arg) => arg.d.name?.d.value === 'kw_only');
+                        let kwOnlyArg: ArgumentNode | undefined;
+                        for (const arg of statement.d.rightExpr.d.args) {
+                            if (arg.d.name?.d.value === 'kw_only') {
+                                kwOnlyArg = arg;
+                                break;
+                            }
+                        }
                         if (kwOnlyArg && kwOnlyArg.d.valueExpr) {
                             const fileInfo = AnalyzerNodeInfo.getFileInfo(node);
                             isKeywordOnly =
@@ -324,17 +341,25 @@ export function synthesizeDataClassMethods(
                                 ) ?? isKeywordOnly;
                         }
 
-                        const defaultValueArg = statement.d.rightExpr.d.args.find(
-                            (arg) => arg.d.name?.d.value === 'default'
-                        );
+                        let defaultValueArg: ArgumentNode | undefined;
+                        for (const arg of statement.d.rightExpr.d.args) {
+                            if (arg.d.name?.d.value === 'default') {
+                                defaultValueArg = arg;
+                                break;
+                            }
+                        }
                         hasDefault = !!defaultValueArg;
                         if (defaultValueArg?.d.valueExpr) {
                             defaultExpr = defaultValueArg.d.valueExpr;
                         }
 
-                        const defaultFactoryArg = statement.d.rightExpr.d.args.find(
-                            (arg) => arg.d.name?.d.value === 'default_factory' || arg.d.name?.d.value === 'factory'
-                        );
+                        let defaultFactoryArg: ArgumentNode | undefined;
+                        for (const arg of statement.d.rightExpr.d.args) {
+                            if (arg.d.name?.d.value === 'default_factory' || arg.d.name?.d.value === 'factory') {
+                                defaultFactoryArg = arg;
+                                break;
+                            }
+                        }
                         if (defaultFactoryArg) {
                             hasDefault = true;
                             isDefaultFactory = true;
@@ -343,7 +368,13 @@ export function synthesizeDataClassMethods(
                             defaultExpr = defaultFactoryArg.d.valueExpr;
                         }
 
-                        const aliasArg = statement.d.rightExpr.d.args.find((arg) => arg.d.name?.d.value === 'alias');
+                        let aliasArg: ArgumentNode | undefined;
+                        for (const arg of statement.d.rightExpr.d.args) {
+                            if (arg.d.name?.d.value === 'alias') {
+                                aliasArg = arg;
+                                break;
+                            }
+                        }
                         if (aliasArg) {
                             const valueType = evaluator.getTypeOfExpression(aliasArg.d.valueExpr).type;
                             if (
@@ -355,9 +386,13 @@ export function synthesizeDataClassMethods(
                             }
                         }
 
-                        const converterArg = statement.d.rightExpr.d.args.find(
-                            (arg) => arg.d.name?.d.value === 'converter'
-                        );
+                        let converterArg: ArgumentNode | undefined;
+                        for (const arg of statement.d.rightExpr.d.args) {
+                            if (arg.d.name?.d.value === 'converter') {
+                                converterArg = arg;
+                                break;
+                            }
+                        }
                         if (converterArg && converterArg.d.valueExpr) {
                             converter = converterArg;
                         }
@@ -399,7 +434,7 @@ export function synthesizeDataClassMethods(
                         LocMessage.namedTupleFieldUnderscore(),
                         variableNameNode
                     );
-                    return;
+                    continue;
                 }
 
                 // Don't include class vars. PEP 557 indicates that they shouldn't
@@ -410,7 +445,13 @@ export function synthesizeDataClassMethods(
                 if (variableSymbol?.isClassVar()) {
                     // If an ancestor class declared an instance variable but this dataclass
                     // declares a ClassVar, delete the older one from the full data class entries.
-                    const index = fullDataClassEntries.findIndex((p) => p.name === variableName);
+                    let index = -1;
+                    for (let i = 0; i < fullDataClassEntries.length; i++) {
+                        if (fullDataClassEntries[i].name === variableName) {
+                            index = i;
+                            break;
+                        }
+                    }
                     if (index >= 0) {
                         fullDataClassEntries.splice(index, 1);
                     }
@@ -452,7 +493,13 @@ export function synthesizeDataClassMethods(
                     localEntryTypeEvaluator.push({ entry: dataClassEntry, evaluator: variableTypeEvaluator });
 
                     // Add the new entry to the local entry list.
-                    let insertIndex = localDataClassEntries.findIndex((e) => e.name === variableName);
+                    let insertIndex = -1;
+                    for (let i = 0; i < localDataClassEntries.length; i++) {
+                        if (localDataClassEntries[i].name === variableName) {
+                            insertIndex = i;
+                            break;
+                        }
+                    }
                     if (insertIndex >= 0) {
                         localDataClassEntries[insertIndex] = dataClassEntry;
                     } else {
@@ -460,7 +507,13 @@ export function synthesizeDataClassMethods(
                     }
 
                     // Add the new entry to the full entry list.
-                    insertIndex = fullDataClassEntries.findIndex((p) => p.name === variableName);
+                    insertIndex = -1;
+                    for (let i = 0; i < fullDataClassEntries.length; i++) {
+                        if (fullDataClassEntries[i].name === variableName) {
+                            insertIndex = i;
+                            break;
+                        }
+                    }
                     if (insertIndex >= 0) {
                         const oldEntry = fullDataClassEntries[insertIndex];
 
@@ -489,9 +542,14 @@ export function synthesizeDataClassMethods(
                     // If we've already seen a entry with a default value defined,
                     // all subsequent entries must also have default values.
                     if (!isKeywordOnly && includeInInit && !skipSynthesizeInit && !hasDefault) {
-                        const firstDefaultValueIndex = fullDataClassEntries.findIndex(
-                            (p) => p.hasDefault && p.includeInInit && !p.isKeywordOnly
-                        );
+                        let firstDefaultValueIndex = -1;
+                        for (let i = 0; i < fullDataClassEntries.length; i++) {
+                            const p = fullDataClassEntries[i];
+                            if (p.hasDefault && p.includeInInit && !p.isKeywordOnly) {
+                                firstDefaultValueIndex = i;
+                                break;
+                            }
+                        }
                         if (firstDefaultValueIndex >= 0 && firstDefaultValueIndex < insertIndex) {
                             evaluator.addDiagnostic(
                                 DiagnosticRule.reportGeneralTypeIssues,
@@ -508,16 +566,16 @@ export function synthesizeDataClassMethods(
             // runtime exception.
             const declarations = symbol.getDeclarations();
             if (declarations.length === 0) {
-                return;
+                continue;
             }
             const lastDecl = declarations[declarations.length - 1];
             if (lastDecl.type !== DeclarationType.Variable) {
-                return;
+                continue;
             }
 
             const statement = lastDecl.node.parent;
             if (!statement || statement.nodeType !== ParseNodeType.Assignment) {
-                return;
+                continue;
             }
 
             // If the RHS of the assignment is assigning a field instance where the
@@ -542,7 +600,7 @@ export function synthesizeDataClassMethods(
                 }
             }
         }
-    });
+    }
 
     if (isNamedTuple) {
         classType.shared.namedTupleEntries = namedTupleEntries;
@@ -555,16 +613,16 @@ export function synthesizeDataClassMethods(
     // evaluations. This could involve circular type dependencies, so it's
     // required that the list be complete (even if types are not yet accurate)
     // before we perform the type evaluations.
-    localEntryTypeEvaluator.forEach((entryEvaluator) => {
+    for (const entryEvaluator of localEntryTypeEvaluator) {
         entryEvaluator.entry.type = entryEvaluator.evaluator();
-    });
+    }
 
     const symbolTable = ClassType.getSymbolTable(classType);
     const keywordOnlyParams: FunctionParam[] = [];
 
     if (!skipSynthesizeInit && !hasExistingInitMethod) {
         if (allAncestorsKnown) {
-            fullDataClassEntries.forEach((entry) => {
+            for (const entry of fullDataClassEntries) {
                 if (entry.includeInInit) {
                     let defaultType: Type | undefined;
 
@@ -670,13 +728,13 @@ export function synthesizeDataClassMethods(
                         FunctionType.addParam(replaceType, paramWithDefault);
                     }
                 }
-            });
+            }
 
             if (keywordOnlyParams.length > 0) {
                 FunctionType.addKeywordOnlyParamSeparator(constructorType);
-                keywordOnlyParams.forEach((param) => {
+                for (const param of keywordOnlyParams) {
                     FunctionType.addParam(constructorType, param);
-                });
+                }
             }
         }
 
@@ -701,15 +759,16 @@ export function synthesizeDataClassMethods(
         (classType.shared.dataClassBehaviors?.matchArgs ?? true)
     ) {
         const matchArgsNames: string[] = [];
-        fullDataClassEntries.forEach((entry) => {
+        for (const entry of fullDataClassEntries) {
             if (entry.includeInInit && !entry.isKeywordOnly) {
                 // Use the field name, not its alias (if it has one).
                 matchArgsNames.push(entry.name);
             }
-        });
-        const literalTypes: TupleTypeArg[] = matchArgsNames.map((name) => {
-            return { type: ClassType.cloneAsInstance(ClassType.cloneWithLiteral(strType, name)), isUnbounded: false };
-        });
+        }
+        const literalTypes: TupleTypeArg[] = [];
+        for (const name of matchArgsNames) {
+            literalTypes.push({ type: ClassType.cloneAsInstance(ClassType.cloneWithLiteral(strType, name)), isUnbounded: false });
+        }
         const matchArgsType = ClassType.cloneAsInstance(specializeTupleClass(tupleClassType, literalTypes));
         symbolTable.set('__match_args__', Symbol.createWithType(SymbolFlags.ClassMember, matchArgsType));
     }
@@ -734,9 +793,9 @@ export function synthesizeDataClassMethods(
     }
 
     if (ClassType.isDataClassGenerateOrder(classType)) {
-        ['__lt__', '__le__', '__gt__', '__ge__'].forEach((operator) => {
+        for (const operator of ['__lt__', '__le__', '__gt__', '__ge__']) {
             synthesizeComparisonMethod(operator, selfType);
-        });
+        }
     }
 
     let synthesizeHashFunction = ClassType.isDataClassFrozen(classType);
@@ -786,7 +845,11 @@ export function synthesizeDataClassMethods(
     }
 
     if (ClassType.isDataClassGenerateSlots(classType) && classType.shared.localSlotsNames === undefined) {
-        classType.shared.localSlotsNames = localDataClassEntries.map((entry) => entry.name);
+        const slotNames: string[] = [];
+        for (const entry of localDataClassEntries) {
+            slotNames.push(entry.name);
+        }
+        classType.shared.localSlotsNames = slotNames;
     }
 
     // Should we synthesize a __slots__ symbol?
@@ -807,10 +870,14 @@ export function synthesizeDataClassMethods(
 
     // If this dataclass derived from a NamedTuple, update the NamedTuple with
     // the specialized entry types.
+    const entryTypes: Type[] = [];
+    for (const entry of fullDataClassEntries) {
+        entryTypes.push(entry.type);
+    }
     if (
         updateNamedTupleBaseClass(
             classType,
-            fullDataClassEntries.map((entry) => entry.type),
+            entryTypes,
             /* isTypeArgExplicit */ true
         )
     ) {
@@ -835,10 +902,14 @@ function getDefaultArgValueForFieldSpecifier(
     if (isFunction(callType)) {
         callTarget = callType;
     } else if (isOverloaded(callType)) {
+        const convertedArgs: Arg[] = [];
+        for (const arg of callNode.d.args) {
+            convertedArgs.push(evaluator.convertNodeToArg(arg));
+        }
         callTarget = evaluator.getBestOverloadForArgs(
             callNode,
             { type: callType, isIncomplete: callTypeResult.isIncomplete },
-            callNode.d.args.map((arg) => evaluator.convertNodeToArg(arg))
+            convertedArgs
         );
     } else if (isInstantiableClass(callType)) {
         const initMethodResult = getBoundInitMethod(evaluator, callNode, callType);
@@ -846,17 +917,27 @@ function getDefaultArgValueForFieldSpecifier(
             if (isFunction(initMethodResult.type)) {
                 callTarget = initMethodResult.type;
             } else if (isOverloaded(initMethodResult.type)) {
+                const convertedArgs: Arg[] = [];
+                for (const arg of callNode.d.args) {
+                    convertedArgs.push(evaluator.convertNodeToArg(arg));
+                }
                 callTarget = evaluator.getBestOverloadForArgs(
                     callNode,
                     { type: initMethodResult.type },
-                    callNode.d.args.map((arg) => evaluator.convertNodeToArg(arg))
+                    convertedArgs
                 );
             }
         }
     }
 
     if (callTarget) {
-        const initParamIndex = callTarget.shared.parameters.findIndex((p) => p.name === paramName);
+        let initParamIndex = -1;
+        for (let i = 0; i < callTarget.shared.parameters.length; i++) {
+            if (callTarget.shared.parameters[i].name === paramName) {
+                initParamIndex = i;
+                break;
+            }
+        }
         if (initParamIndex >= 0) {
             const initParam = callTarget.shared.parameters[initParamIndex];
 
@@ -1055,7 +1136,8 @@ function getDescriptorForConverterField(
     descriptorClass.shared.typeVarScopeId = scopeId;
 
     // Make the descriptor generic, copying the type parameters from the dataclass.
-    descriptorClass.shared.typeParams = dataclass.shared.typeParams.map((typeParm) => {
+    const typeParams: TypeVarType[] = [];
+    for (const typeParm of dataclass.shared.typeParams) {
         const typeParam = TypeVarType.cloneForScopeId(
             typeParm,
             scopeId,
@@ -1063,8 +1145,9 @@ function getDescriptorForConverterField(
             TypeVarScopeType.Class
         );
         typeParam.priv.computedVariance = Variance.Covariant;
-        return typeParam;
-    });
+        typeParams.push(typeParam);
+    }
+    descriptorClass.shared.typeParams = typeParams;
 
     const solution = buildSolution(dataclass.shared.typeParams, descriptorClass.shared.typeParams);
     getType = applySolvedTypeVars(getType, solution);
@@ -1145,15 +1228,21 @@ function transformDescriptorType(evaluator: TypeEvaluator, type: Type): Type {
 export function addInheritedDataClassEntries(classType: ClassType, entries: DataClassEntry[]) {
     let allAncestorsAreKnown = true;
 
-    ClassType.getReverseMro(classType).forEach((mroClass) => {
+    for (const mroClass of ClassType.getReverseMro(classType)) {
         if (isInstantiableClass(mroClass)) {
             const solution = buildSolutionFromSpecializedClass(mroClass);
             const dataClassEntries = ClassType.getDataClassEntries(mroClass);
 
             // Add the entries to the end of the list, replacing same-named
             // entries if found.
-            dataClassEntries.forEach((entry) => {
-                const existingIndex = entries.findIndex((e) => e.name === entry.name);
+            for (const entry of dataClassEntries) {
+                let existingIndex = -1;
+                for (let i = 0; i < entries.length; i++) {
+                    if (entries[i].name === entry.name) {
+                        existingIndex = i;
+                        break;
+                    }
+                }
 
                 // If the type from the parent class is generic, we need to convert
                 // to the type parameter namespace of child class.
@@ -1171,11 +1260,11 @@ export function addInheritedDataClassEntries(classType: ClassType, entries: Data
                 } else {
                     entries.push(updatedEntry);
                 }
-            });
+            }
         } else {
             allAncestorsAreKnown = false;
         }
-    });
+    }
 
     return allAncestorsAreKnown;
 }
@@ -1198,7 +1287,7 @@ function isDataclassFieldConstructor(type: Type, fieldDescriptorNames: string[])
         return false;
     }
 
-    return fieldDescriptorNames.some((name) => name === callName);
+    return fieldDescriptorNames.includes(callName);
 }
 
 export function validateDataClassTransformDecorator(
@@ -1220,14 +1309,14 @@ export function validateDataClassTransformDecorator(
     const fileInfo = AnalyzerNodeInfo.getFileInfo(node);
 
     // Parse the arguments to the call.
-    node.d.args.forEach((arg) => {
+    for (const arg of node.d.args) {
         if (!arg.d.name || arg.d.argCategory !== ArgCategory.Simple) {
             evaluator.addDiagnostic(
                 DiagnosticRule.reportCallIssue,
                 LocMessage.dataClassTransformPositionalParam(),
                 arg
             );
-            return;
+            continue;
         }
 
         switch (arg.d.name.d.value) {
@@ -1243,7 +1332,7 @@ export function validateDataClassTransformDecorator(
                         LocMessage.dataClassTransformExpectedBoolLiteral(),
                         arg.d.valueExpr
                     );
-                    return;
+                    continue;
                 }
 
                 behaviors.keywordOnly = value;
@@ -1262,7 +1351,7 @@ export function validateDataClassTransformDecorator(
                         LocMessage.dataClassTransformExpectedBoolLiteral(),
                         arg.d.valueExpr
                     );
-                    return;
+                    continue;
                 }
 
                 behaviors.skipGenerateEq = !value;
@@ -1281,7 +1370,7 @@ export function validateDataClassTransformDecorator(
                         LocMessage.dataClassTransformExpectedBoolLiteral(),
                         arg.d.valueExpr
                     );
-                    return;
+                    continue;
                 }
 
                 behaviors.generateOrder = value;
@@ -1300,7 +1389,7 @@ export function validateDataClassTransformDecorator(
                         LocMessage.dataClassTransformExpectedBoolLiteral(),
                         arg.d.valueExpr
                     );
-                    return;
+                    continue;
                 }
 
                 behaviors.frozen = value;
@@ -1319,14 +1408,36 @@ export function validateDataClassTransformDecorator(
             case 'field_descriptors':
             case 'field_specifiers': {
                 const valueType = evaluator.getTypeOfExpression(arg.d.valueExpr).type;
+                let hasInvalidEntry = false;
                 if (
                     !isClassInstance(valueType) ||
                     !ClassType.isBuiltIn(valueType, 'tuple') ||
-                    !valueType.priv.tupleTypeArgs ||
-                    valueType.priv.tupleTypeArgs.some(
-                        (entry) => !isInstantiableClass(entry.type) && !isFunctionOrOverloaded(entry.type)
-                    )
+                    !valueType.priv.tupleTypeArgs
                 ) {
+                    hasInvalidEntry = true;
+                } else {
+                    for (const entry of valueType.priv.tupleTypeArgs) {
+                        if (!isInstantiableClass(entry.type) && !isFunctionOrOverloaded(entry.type)) {
+                            hasInvalidEntry = true;
+                            break;
+                        }
+                    }
+
+                    if (!hasInvalidEntry) {
+                        for (const tupleArg of valueType.priv.tupleTypeArgs) {
+                            if (isInstantiableClass(tupleArg.type) || isFunction(tupleArg.type)) {
+                                behaviors.fieldDescriptorNames.push(tupleArg.type.shared.fullName);
+                            } else if (isOverloaded(tupleArg.type)) {
+                                const overloads = OverloadedType.getOverloads(tupleArg.type);
+                                if (overloads.length > 0) {
+                                    behaviors.fieldDescriptorNames.push(overloads[0].shared.fullName);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (hasInvalidEntry) {
                     evaluator.addDiagnostic(
                         DiagnosticRule.reportGeneralTypeIssues,
                         LocMessage.dataClassTransformFieldSpecifier().format({
@@ -1334,19 +1445,9 @@ export function validateDataClassTransformDecorator(
                         }),
                         arg.d.valueExpr
                     );
-                    return;
+                    continue;
                 }
 
-                valueType.priv.tupleTypeArgs.forEach((arg) => {
-                    if (isInstantiableClass(arg.type) || isFunction(arg.type)) {
-                        behaviors.fieldDescriptorNames.push(arg.type.shared.fullName);
-                    } else if (isOverloaded(arg.type)) {
-                        const overloads = OverloadedType.getOverloads(arg.type);
-                        if (overloads.length > 0) {
-                            behaviors.fieldDescriptorNames.push(overloads[0].shared.fullName);
-                        }
-                    }
-                });
                 break;
             }
 
@@ -1358,7 +1459,7 @@ export function validateDataClassTransformDecorator(
                 );
                 break;
         }
-    });
+    }
 
     return behaviors;
 }
@@ -1374,7 +1475,12 @@ export function getDataclassDecoratorBehaviors(type: Type): DataClassBehaviors |
         const overloads = OverloadedType.getOverloads(type);
         const impl = OverloadedType.getImplementation(type);
 
-        functionType = overloads.find((overload) => !!overload.shared.decoratorDataClassBehaviors);
+        for (const overload of overloads) {
+            if (overload.shared.decoratorDataClassBehaviors) {
+                functionType = overload;
+                break;
+            }
+        }
 
         if (!functionType && impl && isFunction(impl) && impl.shared.decoratorDataClassBehaviors) {
             functionType = impl;
@@ -1452,7 +1558,7 @@ function applyDataClassBehaviorOverrideValue(
                 behaviors.frozen = argValue;
             }
 
-            classType.shared.baseClasses.forEach((baseClass) => {
+                    for (const baseClass of classType.shared.baseClasses) {
                 if (isInstantiableClass(baseClass) && ClassType.isDataClass(baseClass)) {
                     if (ClassType.isDataClassFrozen(baseClass)) {
                         hasFrozenBaseClass = true;
@@ -1470,7 +1576,7 @@ function applyDataClassBehaviorOverrideValue(
                         hasUnfrozenBaseClass = true;
                     }
                 }
-            });
+            }
 
             if (argValue) {
                 // A frozen dataclass cannot derive from a non-frozen dataclass.
@@ -1548,7 +1654,7 @@ export function applyDataClassClassBehaviorOverrides(
 
     classType.shared.dataClassBehaviors = behaviors;
 
-    args.forEach((arg) => {
+    for (const arg of args) {
         if (arg.valueExpression && arg.name) {
             applyDataClassBehaviorOverride(
                 evaluator,
@@ -1563,7 +1669,7 @@ export function applyDataClassClassBehaviorOverrides(
                 sawFrozenArg = true;
             }
         }
-    });
+    }
 
     // If there was no frozen argument, it is implicitly set to the frozenDefault.
     // This check validates that we're not overriding a frozen class with a
@@ -1587,11 +1693,15 @@ export function applyDataClassDecorator(
     defaultBehaviors: DataClassBehaviors,
     callNode: CallNode | undefined
 ) {
+    const convertedArgs: Arg[] = [];
+    for (const arg of callNode?.d.args ?? []) {
+        convertedArgs.push(evaluator.convertNodeToArg(arg));
+    }
     applyDataClassClassBehaviorOverrides(
         evaluator,
         errorNode,
         classType,
-        (callNode?.d.args ?? []).map((arg) => evaluator.convertNodeToArg(arg)),
+        convertedArgs,
         defaultBehaviors
     );
 }

--- a/packages/pyright-internal/src/analyzer/declarationUtils.ts
+++ b/packages/pyright-internal/src/analyzer/declarationUtils.ts
@@ -199,15 +199,17 @@ export function isDefinedInFile(decl: Declaration, fileUri: Uri) {
 
 export function getDeclarationsWithUsesLocalNameRemoved(decls: Declaration[]) {
     // Make a shallow copy and clear the "usesLocalName" field.
-    return decls.map((localDecl) => {
+    const result: Declaration[] = [];
+    for (const localDecl of decls) {
         if (localDecl.type !== DeclarationType.Alias) {
-            return localDecl;
+            result.push(localDecl);
+        } else {
+            const nonLocalDecl: AliasDeclaration = { ...localDecl };
+            nonLocalDecl.usesLocalName = false;
+            result.push(nonLocalDecl);
         }
-
-        const nonLocalDecl: AliasDeclaration = { ...localDecl };
-        nonLocalDecl.usesLocalName = false;
-        return nonLocalDecl;
-    });
+    }
+    return result;
 }
 
 export function synthesizeAliasDeclaration(uri: Uri): AliasDeclaration {
@@ -352,11 +354,11 @@ export function resolveAliasDeclaration(
 
         // Try not to use declarations within an except suite even if it's a typed
         // declaration. These are typically used for fallback exception handling.
-        declarations = declarations.filter((decl) => !decl.isInExceptSuite);
+        declarations = _filterOutExceptSuite(declarations);
 
         if (declarations.length === 0) {
             declarations = symbol.getDeclarations();
-            declarations = declarations.filter((decl) => !decl.isInExceptSuite);
+            declarations = _filterOutExceptSuite(declarations);
         }
 
         if (declarations.length === 0) {
@@ -372,7 +374,7 @@ export function resolveAliasDeclaration(
 
         // Prefer the last unvisited declaration in the list. This ensures that
         // we use all of the overloads if it's an overloaded function.
-        const unvisitedDecls = declarations.filter((decl) => !alreadyVisited.includes(decl));
+        const unvisitedDecls = _filterOutVisited(declarations, alreadyVisited);
         if (unvisitedDecls.length > 0) {
             curDeclaration = unvisitedDecls[unvisitedDecls.length - 1];
         } else {
@@ -399,7 +401,7 @@ export function resolveAliasDeclaration(
         }
 
         // Make sure we don't follow a circular list indefinitely.
-        if (alreadyVisited.find((decl) => decl === curDeclaration)) {
+        if (alreadyVisited.includes(curDeclaration)) {
             // If the path path of the alias points back to the original path, use the submodule
             // fallback instead. This happens in the case where a module's __init__.py file
             // imports a submodule using itself as the import target. For example, if
@@ -417,4 +419,24 @@ export function resolveAliasDeclaration(
         }
         alreadyVisited.push(curDeclaration);
     }
+}
+
+function _filterOutExceptSuite(declarations: Declaration[]): Declaration[] {
+    const result: Declaration[] = [];
+    for (const decl of declarations) {
+        if (!decl.isInExceptSuite) {
+            result.push(decl);
+        }
+    }
+    return result;
+}
+
+function _filterOutVisited(declarations: Declaration[], alreadyVisited: Declaration[]): Declaration[] {
+    const result: Declaration[] = [];
+    for (const decl of declarations) {
+        if (!alreadyVisited.includes(decl)) {
+            result.push(decl);
+        }
+    }
+    return result;
 }

--- a/packages/pyright-internal/src/analyzer/decorators.ts
+++ b/packages/pyright-internal/src/analyzer/decorators.ts
@@ -70,7 +70,14 @@ export function getFunctionInfoFromDecorators(
         // Several magic methods are treated as class methods implicitly
         // by the runtime. Check for these here.
         const implicitClassMethods = ['__init_subclass__', '__class_getitem__'];
-        if (implicitClassMethods.some((name) => node.d.name.d.value === name)) {
+        let isImplicitClassMethod = false;
+        for (const name of implicitClassMethods) {
+            if (node.d.name.d.value === name) {
+                isImplicitClassMethod = true;
+                break;
+            }
+        }
+        if (isImplicitClassMethod) {
             flags |= FunctionTypeFlags.ClassMethod;
         }
     }
@@ -451,22 +458,28 @@ function getTypeOfDecorator(evaluator: TypeEvaluator, node: DecoratorNode, funct
     // and just *args and **kwargs parameters, assume that it
     // preserves the type of the input function.
     if (isFunction(returnType) && !returnType.shared.declaredReturnType) {
-        if (
-            !returnType.shared.parameters.some((param, index) => {
-                // Don't allow * or / separators or params with declared types.
-                if (!param.name || FunctionParam.isTypeDeclared(param)) {
-                    return true;
-                }
+        let hasDisqualifyingParam = false;
+        const params = returnType.shared.parameters;
+        for (let index = 0; index < params.length; index++) {
+            const param = params[index];
+            // Don't allow * or / separators or params with declared types.
+            if (!param.name || FunctionParam.isTypeDeclared(param)) {
+                hasDisqualifyingParam = true;
+                break;
+            }
 
-                // Allow *args or **kwargs parameters.
-                if (param.category !== ParamCategory.Simple) {
-                    return false;
-                }
+            // Allow *args or **kwargs parameters.
+            if (param.category !== ParamCategory.Simple) {
+                continue;
+            }
 
-                // Allow inferred "self" or "cls" parameters.
-                return index !== 0 || !FunctionParam.isTypeInferred(param);
-            })
-        ) {
+            // Allow inferred "self" or "cls" parameters.
+            if (index !== 0 || !FunctionParam.isTypeInferred(param)) {
+                hasDisqualifyingParam = true;
+                break;
+            }
+        }
+        if (!hasDisqualifyingParam) {
             return functionOrClassType;
         }
     }
@@ -476,8 +489,15 @@ function getTypeOfDecorator(evaluator: TypeEvaluator, node: DecoratorNode, funct
     // function.
     if (isPartlyUnknown(returnType)) {
         if (isFunction(decoratorTypeResult.type)) {
+            let hasTypeDeclaredParam = false;
+            for (const param of decoratorTypeResult.type.shared.parameters) {
+                if (FunctionParam.isTypeDeclared(param)) {
+                    hasTypeDeclaredParam = true;
+                    break;
+                }
+            }
             if (
-                !decoratorTypeResult.type.shared.parameters.find((param) => FunctionParam.isTypeDeclared(param)) &&
+                !hasTypeDeclaredParam &&
                 decoratorTypeResult.type.shared.declaredReturnType === undefined
             ) {
                 return functionOrClassType;
@@ -505,7 +525,10 @@ export function addOverloadsToFunctionType(evaluator: TypeEvaluator, node: Funct
         const decls = symbolWithScope.symbol.getDeclarations();
 
         // Find this function's declaration.
-        const declIndex = decls.findIndex((decl) => decl === functionDecl);
+        let declIndex = -1;
+        if (functionDecl) {
+            declIndex = decls.indexOf(functionDecl);
+        }
         if (declIndex > 0) {
             // Evaluate all of the previous function declarations. They will
             // be cached. We do it in this order to avoid a stack overflow due
@@ -561,12 +584,15 @@ export function addOverloadsToFunctionType(evaluator: TypeEvaluator, node: Funct
             // have their own docstrings.
             if (implementation && isFunction(implementation) && implementation.shared.docString) {
                 const docString = implementation.shared.docString;
-                overloadedTypes = overloadedTypes.map((overload) => {
+                const newOverloadedTypes: FunctionType[] = [];
+                for (const overload of overloadedTypes) {
                     if (FunctionType.isOverloaded(overload) && !overload.shared.docString) {
-                        return FunctionType.cloneWithDocString(overload, docString);
+                        newOverloadedTypes.push(FunctionType.cloneWithDocString(overload, docString));
+                    } else {
+                        newOverloadedTypes.push(overload);
                     }
-                    return overload;
-                });
+                }
+                overloadedTypes = newOverloadedTypes;
             }
 
             // PEP 702 indicates that if the implementation of an overloaded
@@ -574,12 +600,15 @@ export function addOverloadsToFunctionType(evaluator: TypeEvaluator, node: Funct
             // treated as deprecated as well.
             if (implementation && isFunction(implementation) && implementation.shared.deprecatedMessage !== undefined) {
                 const deprecationMessage = implementation.shared.deprecatedMessage;
-                overloadedTypes = overloadedTypes.map((overload) => {
+                const newOverloadedTypes: FunctionType[] = [];
+                for (const overload of overloadedTypes) {
                     if (FunctionType.isOverloaded(overload) && overload.shared.deprecatedMessage === undefined) {
-                        return FunctionType.cloneWithDeprecatedMessage(overload, deprecationMessage);
+                        newOverloadedTypes.push(FunctionType.cloneWithDeprecatedMessage(overload, deprecationMessage));
+                    } else {
+                        newOverloadedTypes.push(overload);
                     }
-                    return overload;
-                });
+                }
+                overloadedTypes = newOverloadedTypes;
             }
 
             return OverloadedType.create(overloadedTypes, implementation);
@@ -598,7 +627,10 @@ export function getDeprecatedMessageFromCall(node: CallNode): string {
         node.d.args[0].d.valueExpr.nodeType === ParseNodeType.StringList
     ) {
         const stringListNode = node.d.args[0].d.valueExpr;
-        const message = stringListNode.d.strings.map((s) => s.d.value).join('');
+        let message = '';
+        for (const s of stringListNode.d.strings) {
+            message += s.d.value;
+        }
         return convertDocStringToPlainText(message);
     }
 

--- a/packages/pyright-internal/src/analyzer/docStringConversion.ts
+++ b/packages/pyright-internal/src/analyzer/docStringConversion.ts
@@ -136,7 +136,9 @@ class DocStringConverter {
         const isEpyDoc = epyDocFieldTokensRegExp.test(this._input);
         if (isEpyDoc) {
             // fixup cv2 leading '.'
-            this._lines = this._lines.map((v) => v.replace(epyDocCv2FixRegExp, ''));
+            for (let i = 0; i < this._lines.length; i++) {
+                this._lines[i] = this._lines[i].replace(epyDocCv2FixRegExp, '');
+            }
         }
 
         while (this._currentLineOrUndefined() !== undefined) {
@@ -191,9 +193,14 @@ class DocStringConverter {
     }
 
     private _nextBlockIndent(): number {
-        return _countLeadingSpaces(
-            this._lines.slice(this._lineNum + 1).find((v) => !_isUndefinedOrWhitespace(v)) || ''
-        );
+        let nextNonWhitespace = '';
+        for (let i = this._lineNum + 1; i < this._lines.length; i++) {
+            if (!_isUndefinedOrWhitespace(this._lines[i])) {
+                nextNonWhitespace = this._lines[i];
+                break;
+            }
+        }
+        return _countLeadingSpaces(nextNonWhitespace);
     }
 
     private _currentLineIsOutsideBlock(): boolean {
@@ -300,9 +307,9 @@ class DocStringConverter {
     }
 
     private _escapeHtml(line: string): string {
-        HtmlEscapes.forEach((escape) => {
+        for (const escape of HtmlEscapes) {
             line = line.replace(escape.exp, escape.replacement);
-        });
+        }
 
         return line;
     }
@@ -380,14 +387,14 @@ class DocStringConverter {
 
             // Escape _, *, and ~, but ignore things like ":param \*\*kwargs:".
             const subparts = part.split(linkRegExp);
-            subparts.forEach((item) => {
+            for (const item of subparts) {
                 // Don't escape links
                 if (linkRegExp.test(item)) {
                     this._append(item);
                 } else {
                     this._append(item.replace(UnescapedMarkdownCharsRegExp, '\\$1'));
                 }
-            });
+            }
         }
 
         // Go straight to the builder so that _appendLine doesn't think
@@ -403,7 +410,9 @@ class DocStringConverter {
             return '';
         }
 
-        LiteralBlockReplacements.forEach((item) => (line = line.replace(item.exp, item.replacement)));
+        for (const item of LiteralBlockReplacements) {
+            line = line.replace(item.exp, item.replacement);
+        }
 
         line = line.replace(DoubleTickRegExp, '`');
         return line;
@@ -692,9 +701,9 @@ class DocStringConverter {
                 this._tableState.inHeader = false;
 
                 // Append header
-                headerStrings.forEach((h) => {
+                for (const h of headerStrings) {
                     formattedLine += `${h}|`;
-                });
+                }
                 this._appendLine(formattedLine);
 
                 // Convert header end
@@ -704,13 +713,13 @@ class DocStringConverter {
             } else {
                 // Normal row parsing
                 let colStart = 0;
-                columnParts.forEach((column) => {
+                for (const column of columnParts) {
                     const len = column.length + 1;
                     const columnStr = line.slice(colStart, colStart + len);
                     formattedLine += `${columnStr}|`;
 
                     colStart += len;
-                });
+                }
 
                 this._appendLine(formattedLine);
                 this._eatLine();

--- a/packages/pyright-internal/src/analyzer/docStringUtils.ts
+++ b/packages/pyright-internal/src/analyzer/docStringUtils.ts
@@ -21,7 +21,8 @@ export function cleanAndSplitDocString(rawString: string): string[] {
 
     // Determine the max indent amount.
     let leftSpacesToRemove = Number.MAX_VALUE;
-    lines.forEach((line, index) => {
+    for (let index = 0; index < lines.length; index++) {
+        const line = lines[index];
         // First line is special.
         if (lines.length <= 1 || index > 0) {
             const trimmed = line.trimLeft();
@@ -29,7 +30,7 @@ export function cleanAndSplitDocString(rawString: string): string[] {
                 leftSpacesToRemove = Math.min(leftSpacesToRemove, line.length - trimmed.length);
             }
         }
-    });
+    }
 
     // Handle the case where there were only empty lines.
     if (leftSpacesToRemove >= Number.MAX_VALUE) {
@@ -38,13 +39,14 @@ export function cleanAndSplitDocString(rawString: string): string[] {
 
     // Trim the lines.
     const trimmedLines: string[] = [];
-    lines.forEach((line, index) => {
+    for (let index = 0; index < lines.length; index++) {
+        const line = lines[index];
         if (index === 0) {
             trimmedLines.push(line.trim());
         } else {
             trimmedLines.push(line.substr(leftSpacesToRemove).trimRight());
         }
-    });
+    }
 
     // Strip off leading and trailing blank lines.
     while (trimmedLines.length > 0 && trimmedLines[0].length === 0) {

--- a/packages/pyright-internal/src/analyzer/enums.ts
+++ b/packages/pyright-internal/src/analyzer/enums.ts
@@ -48,9 +48,12 @@ const enumEvalStack: EnumEvalStackEntry[] = [];
 
 // Determines whether the class is an Enum metaclass or a subclass thereof.
 export function isEnumMetaclass(classType: ClassType) {
-    return classType.shared.mro.some(
-        (mroClass) => isClass(mroClass) && ClassType.isBuiltIn(mroClass, ['EnumMeta', 'EnumType'])
-    );
+    for (const mroClass of classType.shared.mro) {
+        if (isClass(mroClass) && ClassType.isBuiltIn(mroClass, ['EnumMeta', 'EnumType'])) {
+            return true;
+        }
+    }
+    return false;
 }
 
 // Determines whether this is an enum class that has at least one enum
@@ -101,7 +104,11 @@ export function createEnumType(
         return undefined;
     }
 
-    const className = nameArg.valueExpression.d.strings.map((s) => s.d.value).join('');
+    let classNameParts = '';
+    for (const s of nameArg.valueExpression.d.strings) {
+        classNameParts += s.d.value;
+    }
+    const className = classNameParts;
     const classType = ClassType.createInstantiable(
         className,
         getClassFullName(errorNode, fileInfo.moduleName, className),
@@ -146,14 +153,22 @@ export function createEnumType(
     //   Enum('name', {'a': 1, 'b': 2, 'c': 3})
     if (initArg.valueExpression.nodeType === ParseNodeType.StringList) {
         // Don't allow format strings in the init arg.
-        if (!initArg.valueExpression.d.strings.every((str) => str.nodeType === ParseNodeType.String)) {
+        let hasNonString = false;
+        for (const str of initArg.valueExpression.d.strings) {
+            if (str.nodeType !== ParseNodeType.String) {
+                hasNonString = true;
+                break;
+            }
+        }
+        if (hasNonString) {
             return undefined;
         }
 
-        const initStr = initArg.valueExpression.d.strings
-            .map((s) => s.d.value)
-            .join('')
-            .trim();
+        let initStr = '';
+        for (const s of initArg.valueExpression.d.strings) {
+            initStr += s.d.value;
+        }
+        initStr = initStr.trim();
 
         // Split by comma or whitespace.
         const entryNames = initStr.split(/[\s,]+/);
@@ -325,11 +340,14 @@ export function transformTypeForEnumMember(
     recursionCount++;
 
     // Avoid infinite recursion.
-    if (
-        enumEvalStack.find(
-            (entry) => ClassType.isSameGenericClass(entry.classType, classType) && entry.memberName === memberName
-        )
-    ) {
+    let foundOnStack = false;
+    for (const entry of enumEvalStack) {
+        if (ClassType.isSameGenericClass(entry.classType, classType) && entry.memberName === memberName) {
+            foundOnStack = true;
+            break;
+        }
+    }
+    if (foundOnStack) {
         return undefined;
     }
 
@@ -625,14 +643,14 @@ export function getTypeOfEnumMember(
         // a union of all possible enum literals.
         const literalValues = enumerateLiteralsForType(evaluator, classType);
         if (literalValues && literalValues.length > 0) {
+            const nameTypes: Type[] = [];
+            for (const literalClass of literalValues) {
+                const literalValue = literalClass.priv.literalValue;
+                assert(literalValue instanceof EnumLiteral);
+                nameTypes.push(makeNameType(literalValue));
+            }
             return {
-                type: combineTypes(
-                    literalValues.map((literalClass) => {
-                        const literalValue = literalClass.priv.literalValue;
-                        assert(literalValue instanceof EnumLiteral);
-                        return makeNameType(literalValue);
-                    })
-                ),
+                type: combineTypes(nameTypes),
                 isIncomplete,
             };
         }
@@ -696,14 +714,14 @@ export function getTypeOfEnumMember(
         // a union of all possible enum literals.
         const literalValues = enumerateLiteralsForType(evaluator, classType);
         if (literalValues && literalValues.length > 0) {
+            const valueTypes: Type[] = [];
+            for (const literalClass of literalValues) {
+                const literalValue = literalClass.priv.literalValue;
+                assert(literalValue instanceof EnumLiteral);
+                valueTypes.push(literalValue.itemType);
+            }
             return {
-                type: combineTypes(
-                    literalValues.map((literalClass) => {
-                        const literalValue = literalClass.priv.literalValue;
-                        assert(literalValue instanceof EnumLiteral);
-                        return literalValue.itemType;
-                    })
-                ),
+                type: combineTypes(valueTypes),
                 isIncomplete,
             };
         }
@@ -746,5 +764,10 @@ export function getEnumAutoValueType(evaluator: TypeEvaluator, node: ExpressionN
 }
 
 function isReprEnumClass(enumClass: ClassType) {
-    return enumClass.shared.mro.some((mroClass) => isClass(mroClass) && ClassType.isBuiltIn(mroClass, 'ReprEnum'));
+    for (const mroClass of enumClass.shared.mro) {
+        if (isClass(mroClass) && ClassType.isBuiltIn(mroClass, 'ReprEnum')) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/packages/pyright-internal/src/analyzer/functionTransform.ts
+++ b/packages/pyright-internal/src/analyzer/functionTransform.ts
@@ -64,13 +64,16 @@ function applyTotalOrderingTransform(
 
     // Verify that the class has at least one of the required functions.
     let firstMemberFound: ClassMember | undefined;
-    const missingMethods = orderingMethods.filter((methodName) => {
+    const missingMethods: string[] = [];
+    for (const methodName of orderingMethods) {
         const memberInfo = lookUpObjectMember(instanceType, methodName, MemberAccessFlags.SkipInstanceMembers);
         if (memberInfo && !firstMemberFound) {
             firstMemberFound = memberInfo;
         }
-        return !memberInfo;
-    });
+        if (!memberInfo) {
+            missingMethods.push(methodName);
+        }
+    }
 
     if (!firstMemberFound) {
         evaluator.addDiagnostic(
@@ -123,7 +126,7 @@ function applyTotalOrderingTransform(
     );
 
     // Add the missing members to the class's symbol table.
-    missingMethods.forEach((methodName) => {
+    for (const methodName of missingMethods) {
         const methodToAdd = FunctionType.createSynthesizedInstance(methodName);
         FunctionType.addParam(methodToAdd, selfParam);
         FunctionType.addParam(methodToAdd, objParam);
@@ -133,7 +136,7 @@ function applyTotalOrderingTransform(
             methodName,
             Symbol.createWithType(SymbolFlags.ClassMember, methodToAdd)
         );
-    });
+    }
 
     return result;
 }

--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -218,8 +218,8 @@ export class ImportResolver {
         // When ImportResolver resolves an import to a stub file, a second resolve is done
         // ignoring stub files, which gives us an approximation of where the implementation
         // for that stub is located.
-        this._cachedImportResults.forEach((map) => {
-            map.forEach((result) => {
+        for (const map of this._cachedImportResults.values()) {
+            for (const result of map.values()) {
                 if (result.isStubFile && result.isImportFound && result.nonStubImportResult) {
                     if (result.resolvedUris[result.resolvedUris.length - 1].equals(stubFileUri)) {
                         if (result.nonStubImportResult.isImportFound) {
@@ -236,8 +236,8 @@ export class ImportResolver {
                         }
                     }
                 }
-            });
-        });
+            }
+        }
 
         // We haven't seen an import of that stub, attempt to find the source
         // in some other ways.
@@ -417,10 +417,14 @@ export class ImportResolver {
         // Add paths to search stub packages.
         addPaths(this._configOptions.stubPath);
         addPaths(execEnv.root ?? this._configOptions.projectRoot);
-        execEnv.extraPaths.forEach((p) => addPaths(p));
+        for (const p of execEnv.extraPaths) {
+            addPaths(p);
+        }
         addPaths(typeshedPathEx);
 
-        this.getPythonSearchPaths().forEach((p) => addPaths(p));
+        for (const p of this.getPythonSearchPaths()) {
+            addPaths(p);
+        }
 
         this.partialStubs.processPartialStubPackages(paths, this.getImportRoots(execEnv), typeshedPathEx);
         this._invalidateFileSystemCache();
@@ -471,7 +475,7 @@ export class ImportResolver {
             this._cachedTypeshedStdLibModuleVersionInfo = this._readTypeshedStdLibVersions(customTypeshedPath);
         }
 
-        this._cachedTypeshedStdLibModuleVersionInfo.forEach((versionInfo, moduleName) => {
+        for (const [moduleName, versionInfo] of this._cachedTypeshedStdLibModuleVersionInfo) {
             let shouldExcludeModule = false;
 
             if (versionInfo.max !== undefined && PythonVersion.isGreaterThan(pythonVersion, versionInfo.max)) {
@@ -506,7 +510,7 @@ export class ImportResolver {
                 const moduleFilePath = moduleDirPath.replaceExtension('.pyi');
                 excludes.push(moduleFilePath);
             }
-        });
+        }
 
         return excludes;
     }
@@ -548,7 +552,7 @@ export class ImportResolver {
                         resolvableName.substring(0, resolvableName.length - stubsSuffix.length)
                     );
                 }
-            });
+        }
         } catch {
             // Swallow error
         }
@@ -634,7 +638,9 @@ export class ImportResolver {
 
         if (importLogger) {
             const console = this.serviceProvider.console();
-            importLogger.getLogs().forEach((diag) => console.log(diag));
+            for (const diag of importLogger.getLogs()) {
+                console.log(diag);
+            }
         }
 
         return importResult;
@@ -828,11 +834,11 @@ export class ImportResolver {
         }
 
         const filteredImplicitImports = new Map<string, ImplicitImport>();
-        importResult.implicitImports.forEach((implicitImport) => {
+        for (const [, implicitImport] of importResult.implicitImports) {
             if (importedSymbols.has(implicitImport.name)) {
                 filteredImplicitImports.set(implicitImport.name, implicitImport);
             }
-        });
+        }
 
         if (filteredImplicitImports.size === importResult.implicitImports.size) {
             return importResult;
@@ -1952,7 +1958,7 @@ export class ImportResolver {
 
         if (stdlibRoot) {
             const readDir = (root: Uri, prefix: string | undefined) => {
-                this.readdirEntriesCached(root).entries.forEach((entry) => {
+                for (const entry of this.readdirEntriesCached(root).entries) {
                     if (entry.isDirectory()) {
                         const dirRoot = root.combinePaths(entry.name);
                         readDir(dirRoot, prefix ? `${prefix}.${entry.name}` : entry.name);
@@ -1972,7 +1978,7 @@ export class ImportResolver {
                             }
                         }
                     }
-                });
+                }
             };
             readDir(stdlibRoot, undefined);
         }
@@ -2072,7 +2078,7 @@ export class ImportResolver {
                     suggestions
                 );
             }
-        });
+        }
     }
 
     // Returns the directory for a module within the stdlib typeshed directory.
@@ -2540,18 +2546,18 @@ export class ImportResolver {
             currentPath
         );
 
-        entries.files.forEach((file) => {
+        for (const file of entries.files) {
             // Strip multi-dot extensions to handle file names like "foo.cpython-32m.so". We want
             // to detect the ".so" but strip off the entire ".cpython-32m.so" extension.
             const fileWithoutExtension = file.stripAllExtensions().fileName;
 
             if (ImportResolver.isSupportedImportFile(file)) {
                 if (fileWithoutExtension === '__init__') {
-                    return;
+                    continue;
                 }
 
                 if (filter && !StringUtils.isPatternInSymbol(filter, fileWithoutExtension)) {
-                    return;
+                    continue;
                 }
 
                 if (
@@ -2565,17 +2571,17 @@ export class ImportResolver {
                         strictOnly
                     )
                 ) {
-                    return;
+                    continue;
                 }
 
                 suggestions.set(fileWithoutExtension, file);
             }
-        });
+        }
 
-        entries.directories.forEach((dir) => {
+        for (const dir of entries.directories) {
             const dirSuggestion = dir.fileName;
             if (filter && !dirSuggestion.startsWith(filter)) {
-                return;
+                continue;
             }
 
             if (
@@ -2589,24 +2595,24 @@ export class ImportResolver {
                     strictOnly
                 )
             ) {
-                return;
+                continue;
             }
 
             const initPyiPath = dir.initPyiUri;
             if (this.fileExistsCached(initPyiPath)) {
                 suggestions.set(dirSuggestion, initPyiPath);
-                return;
+                continue;
             }
 
             const initPyPath = dir.initPyUri;
             if (this.fileExistsCached(initPyPath)) {
                 suggestions.set(dirSuggestion, initPyPath);
-                return;
+                continue;
             }
 
             // It is a namespace package. there is no corresponding module path.
             suggestions.set(dirSuggestion, Uri.empty());
-        });
+        }
     }
 
     // Fix for editable installed submodules where the suggested directory was a namespace directory that wouldn't resolve.

--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -533,7 +533,7 @@ export class ImportResolver {
         };
         try {
             const entries = this.fileSystem.readdirEntriesSync(uri);
-            entries.forEach((entry) => {
+            for (const entry of entries) {
                 newCachedDir.entries.set(entry.name, entry);
                 let isFile = entry.isFile();
                 let isDirectory = entry.isDirectory();
@@ -552,7 +552,7 @@ export class ImportResolver {
                         resolvableName.substring(0, resolvableName.length - stubsSuffix.length)
                     );
                 }
-        }
+            }
         } catch {
             // Swallow error
         }
@@ -1958,7 +1958,7 @@ export class ImportResolver {
 
         if (stdlibRoot) {
             const readDir = (root: Uri, prefix: string | undefined) => {
-                for (const entry of this.readdirEntriesCached(root).entries) {
+                for (const entry of this.readdirEntriesCached(root).entries.values()) {
                     if (entry.isDirectory()) {
                         const dirRoot = root.combinePaths(entry.name);
                         readDir(dirRoot, prefix ? `${prefix}.${entry.name}` : entry.name);
@@ -2068,7 +2068,7 @@ export class ImportResolver {
             return;
         }
 
-        typeshedPaths.forEach((typeshedPath) => {
+        for (const typeshedPath of typeshedPaths) {
             if (this.dirExistsCached(typeshedPath)) {
                 this._getCompletionSuggestionsAbsolute(
                     sourceFileUri,

--- a/packages/pyright-internal/src/analyzer/importStatementUtils.ts
+++ b/packages/pyright-internal/src/analyzer/importStatementUtils.ts
@@ -128,9 +128,9 @@ export function getTopLevelImports(parseTree: ModuleNode, includeImplicitImports
     let followsNonImportStatement = false;
     let foundFirstImportStatement = false;
 
-    parseTree.d.statements.forEach((statement) => {
+    for (const statement of parseTree.d.statements) {
         if (statement.nodeType === ParseNodeType.StatementList) {
-            statement.d.statements.forEach((subStatement) => {
+            for (const subStatement of statement.d.statements) {
                 if (subStatement.nodeType === ParseNodeType.Import) {
                     foundFirstImportStatement = true;
                     _processImportNode(subStatement, localImports, followsNonImportStatement);
@@ -147,11 +147,11 @@ export function getTopLevelImports(parseTree: ModuleNode, includeImplicitImports
                 } else {
                     followsNonImportStatement = foundFirstImportStatement;
                 }
-            });
+            }
         } else {
             followsNonImportStatement = foundFirstImportStatement;
         }
-    });
+    }
 
     return localImports;
 }
@@ -632,7 +632,7 @@ function _getInsertionEditForAutoImportInsertion(
 }
 
 function _processImportNode(node: ImportNode, localImports: ImportStatements, followsNonImportStatement: boolean) {
-    node.d.list.forEach((importAsNode) => {
+    for (const importAsNode of node.d.list) {
         const importResult = AnalyzerNodeInfo.getImportInfo(importAsNode.d.module);
         let resolvedPath: Uri | undefined;
 
@@ -660,7 +660,7 @@ function _processImportNode(node: ImportNode, localImports: ImportStatements, fo
                 localImports.mapByFilePath.set(resolvedPath.key, localImport);
             }
         }
-    });
+    }
 }
 
 function _processImportFromNode(
@@ -681,7 +681,13 @@ function _processImportFromNode(
 
         if (importResult.implicitImports) {
             for (const implicitImport of importResult.implicitImports.values()) {
-                const importFromAs = node.d.imports.find((i) => i.d.name.d.value === implicitImport.name);
+                let importFromAs: ImportFromAsNode | undefined;
+                for (const i of node.d.imports) {
+                    if (i.d.name.d.value === implicitImport.name) {
+                        importFromAs = i;
+                        break;
+                    }
+                }
                 if (importFromAs) {
                     localImports.implicitImports.set(implicitImport.uri.key, importFromAs);
                 }
@@ -721,7 +727,14 @@ export function formatModuleName(node: ModuleNameNode): string {
         moduleName = moduleName + '.';
     }
 
-    moduleName += node.d.nameParts.map((part) => part.d.value).join('.');
+    let namePartsStr = '';
+    for (let i = 0; i < node.d.nameParts.length; i++) {
+        if (i > 0) {
+            namePartsStr += '.';
+        }
+        namePartsStr += node.d.nameParts[i].d.value;
+    }
+    moduleName += namePartsStr;
 
     return moduleName;
 }
@@ -994,11 +1007,11 @@ export function getWildcardImportNames(lookupInfo: ImportLookupResult): string[]
         appendArray(namesToImport, lookupInfo.dunderAllNames);
     }
 
-    lookupInfo.symbolTable.forEach((symbol, name) => {
+    for (const [name, symbol] of lookupInfo.symbolTable) {
         if (!symbol.isExternallyHidden() && !name.startsWith('_')) {
             namesToImport!.push(name);
         }
-    });
+    }
 
     return namesToImport;
 }

--- a/packages/pyright-internal/src/analyzer/importStatementUtils.ts
+++ b/packages/pyright-internal/src/analyzer/importStatementUtils.ts
@@ -185,13 +185,24 @@ export function getTextEditsForAutoImportSymbolAddition(
     // Make sure we're not attempting to auto-import a symbol that
     // already exists in the import list.
     const importFrom = importStatement.node;
-    importNameInfo = (Array.isArray(importNameInfo) ? importNameInfo : [importNameInfo]).filter(
-        (info) =>
-            !!info.name &&
-            !importFrom.d.imports.some(
-                (importAs) => importAs.d.name.d.value === info.name && importAs.d.alias?.d.value === info.alias
-            )
-    );
+    const importNameArray = Array.isArray(importNameInfo) ? importNameInfo : [importNameInfo];
+    const filteredNames: ImportNameInfo[] = [];
+    for (const info of importNameArray) {
+        if (!info.name) {
+            continue;
+        }
+        let alreadyImported = false;
+        for (const importAs of importFrom.d.imports) {
+            if (importAs.d.name.d.value === info.name && importAs.d.alias?.d.value === info.alias) {
+                alreadyImported = true;
+                break;
+            }
+        }
+        if (!alreadyImported) {
+            filteredNames.push(info);
+        }
+    }
+    importNameInfo = filteredNames;
 
     if (importNameInfo.length === 0) {
         return additionEdits;
@@ -215,12 +226,14 @@ export function getTextEditsForAutoImportSymbolAddition(
         if (editGroup.length === 1) {
             textEditList.push(editGroup[0]);
         } else {
+            editGroup.sort((a, b) => _compareImportNames(a.importName, b.importName));
+            let merged = '';
+            for (const e of editGroup) {
+                merged += e.replacementText;
+            }
             textEditList.push({
                 range: editGroup[0].range,
-                replacementText: editGroup
-                    .sort((a, b) => _compareImportNames(a.importName, b.importName))
-                    .map((e) => e.replacementText)
-                    .join(''),
+                replacementText: merged,
             });
         }
     }
@@ -388,27 +401,37 @@ export function getTextEditsForAutoImportInsertion(
 
 function _convertInsertionEditsToTextEdits(parseFileResults: ParseFileResults, insertionEdits: InsertionEdit[]) {
     if (insertionEdits.length < 2) {
-        return insertionEdits.map((e) => getTextEdit(e));
+        const result: TextEditAction[] = [];
+        for (const e of insertionEdits) {
+            result.push(getTextEdit(e));
+        }
+        return result;
     }
 
     // Merge edits with the same insertion point.
-    const editsMap = [...createMapFromItems(insertionEdits, (e) => `${e.importGroup} ${Range.print(e.range)}`)]
-        .sort((a, b) => compareStringsCaseSensitive(a[0], b[0]))
-        .map((v) => v[1]);
+    const editsMapEntries = [
+        ...createMapFromItems(insertionEdits, (e) => `${e.importGroup} ${Range.print(e.range)}`),
+    ].sort((a, b) => compareStringsCaseSensitive(a[0], b[0]));
+    const editsMap: InsertionEdit[][] = [];
+    for (const entry of editsMapEntries) {
+        editsMap.push(entry[1]);
+    }
 
     const textEditList: TextEditAction[] = [];
     for (const editGroup of editsMap) {
         if (editGroup.length === 1) {
             textEditList.push(getTextEdit(editGroup[0]));
         } else {
+            const importStatements: string[] = [];
+            for (const e of editGroup) {
+                importStatements.push(e.importStatement);
+            }
+            importStatements.sort(compareImports);
             textEditList.push({
                 range: editGroup[0].range,
                 replacementText:
                     editGroup[0].preChange +
-                    editGroup
-                        .map((e) => e.importStatement)
-                        .sort((a, b) => compareImports(a, b))
-                        .join(parseFileResults.tokenizerOutput.predominantEndOfLineSequence) +
+                    importStatements.join(parseFileResults.tokenizerOutput.predominantEndOfLineSequence) +
                     editGroup[0].postChange,
             });
         }
@@ -477,10 +500,15 @@ function _getInsertionEditsForAutoImportInsertion(
     }
 
     function appendToEdits(importNameInfo: ImportNameInfo[], importStatementGetter: (n: string[]) => string) {
-        const importNames = importNameInfo
-            .map((i) => getImportAsText(i, moduleNameInfo.name))
-            .sort((a, b) => _compareImportNames(a.sortText, b.sortText))
-            .reduce((set, v) => addIfUnique(set, v.text), [] as string[]);
+        const importAsTexts: { sortText: string; text: string }[] = [];
+        for (const i of importNameInfo) {
+            importAsTexts.push(getImportAsText(i, moduleNameInfo.name));
+        }
+        importAsTexts.sort((a, b) => _compareImportNames(a.sortText, b.sortText));
+        const importNames: string[] = [];
+        for (const v of importAsTexts) {
+            addIfUnique(importNames, v.text);
+        }
 
         insertionEdits.push(
             _getInsertionEditForAutoImportInsertion(

--- a/packages/pyright-internal/src/analyzer/namedTuples.ts
+++ b/packages/pyright-internal/src/analyzer/namedTuples.ts
@@ -62,9 +62,13 @@ export function createNamedTupleType(
     // The "rename" parameter is supported only in the untyped version.
     let allowRename = false;
     if (!includesTypes) {
-        const renameArg = argList.find(
-            (arg) => arg.argCategory === ArgCategory.Simple && arg.name?.d.value === 'rename'
-        );
+        let renameArg: Arg | undefined;
+        for (const arg of argList) {
+            if (arg.argCategory === ArgCategory.Simple && arg.name?.d.value === 'rename') {
+                renameArg = arg;
+                break;
+            }
+        }
 
         if (renameArg?.valueExpression) {
             const renameValue = evaluateStaticBoolExpression(
@@ -89,13 +93,23 @@ export function createNamedTupleType(
                 argList[0].valueExpression || errorNode
             );
         } else if (nameArg.valueExpression && nameArg.valueExpression.nodeType === ParseNodeType.StringList) {
-            className = nameArg.valueExpression.d.strings.map((s) => s.d.value).join('');
+            let classNameParts = '';
+            for (const s of nameArg.valueExpression.d.strings) {
+                classNameParts += s.d.value;
+            }
+            className = classNameParts;
         }
     }
 
     // Is there is a default arg? If so, is it defined in a way that we
     // can determine its length statically?
-    const defaultsArg = argList.find((arg) => arg.name?.d.value === 'defaults');
+    let defaultsArg: Arg | undefined;
+    for (const arg of argList) {
+        if (arg.name?.d.value === 'defaults') {
+            defaultsArg = arg;
+            break;
+        }
+    }
     let defaultArgCount: number | undefined = 0;
     if (defaultsArg && defaultsArg.valueExpression) {
         const defaultsArgType = evaluator.getTypeOfExpression(defaultsArg.valueExpression).type;
@@ -171,13 +185,16 @@ export function createNamedTupleType(
                 entriesArg.valueExpression.nodeType === ParseNodeType.StringList
             ) {
                 const entryNameNode = entriesArg.valueExpression;
-                const entries = entriesArg.valueExpression.d.strings
-                    .map((s) => s.d.value)
-                    .join('')
+                let entryStr = '';
+                for (const s of entriesArg.valueExpression.d.strings) {
+                    entryStr += s.d.value;
+                }
+                const entries = entryStr
                     .split(/[,\s]+/);
                 const firstParamWithDefaultIndex =
                     defaultArgCount === undefined ? 0 : Math.max(0, entries.length - defaultArgCount);
-                entries.forEach((entryName, index) => {
+                for (let index = 0; index < entries.length; index++) {
+                    let entryName = entries[index];
                     entryName = entryName.trim();
                     if (entryName) {
                         entryName = renameUnderscore(evaluator, entryName, allowRename, entryNameNode, index);
@@ -217,7 +234,7 @@ export function createNamedTupleType(
                         classFields.set(entryName, newSymbol);
                         entryTypes.push(entryType);
                     }
-                });
+                }
             } else if (
                 entriesArg.valueExpression?.nodeType === ParseNodeType.List ||
                 entriesArg.valueExpression?.nodeType === ParseNodeType.Tuple
@@ -232,7 +249,8 @@ export function createNamedTupleType(
                 const firstParamWithDefaultIndex =
                     defaultArgCount === undefined ? 0 : Math.max(0, entryExpressions.length - defaultArgCount);
 
-                entryExpressions.forEach((entry, index) => {
+                for (let index = 0; index < entryExpressions.length; index++) {
+                    const entry = entryExpressions[index];
                     let entryTypeNode: ExpressionNode | undefined;
                     let entryType: Type | undefined;
                     let entryNameNode: ExpressionNode | undefined;
@@ -337,7 +355,7 @@ export function createNamedTupleType(
                     }
                     classFields.set(entryName, newSymbol);
                     namedTupleEntries.add(entryName);
-                });
+                }
 
                 // Set the type in the type cache for the dict node so it
                 // doesn't get evaluated again.
@@ -408,9 +426,10 @@ export function createNamedTupleType(
         tupleClassType &&
         isInstantiableClass(tupleClassType)
     ) {
-        const literalTypes: TupleTypeArg[] = matchArgsNames.map((name) => {
-            return { type: ClassType.cloneAsInstance(ClassType.cloneWithLiteral(strType, name)), isUnbounded: false };
-        });
+        const literalTypes: TupleTypeArg[] = [];
+        for (const name of matchArgsNames) {
+            literalTypes.push({ type: ClassType.cloneAsInstance(ClassType.cloneWithLiteral(strType, name)), isUnbounded: false });
+        }
         const matchArgsType = ClassType.cloneAsInstance(specializeTupleClass(tupleClassType, literalTypes));
         classFields.set('__match_args__', Symbol.createWithType(SymbolFlags.ClassMember, matchArgsType));
     }
@@ -425,9 +444,11 @@ export function createNamedTupleType(
 export function updateNamedTupleBaseClass(classType: ClassType, typeArgs: Type[], isTypeArgExplicit: boolean): boolean {
     let isUpdateNeeded = false;
 
-    classType.shared.baseClasses = classType.shared.baseClasses.map((baseClass) => {
+    const updatedBaseClasses: Type[] = [];
+    for (const baseClass of classType.shared.baseClasses) {
         if (!isInstantiableClass(baseClass) || !ClassType.isBuiltIn(baseClass, 'NamedTuple')) {
-            return baseClass;
+            updatedBaseClasses.push(baseClass);
+            continue;
         }
 
         const tupleTypeArgs: TupleTypeArg[] = [];
@@ -438,30 +459,32 @@ export function updateNamedTupleBaseClass(classType: ClassType, typeArgs: Type[]
                 isUnbounded: true,
             });
         } else {
-            typeArgs.forEach((t) => {
+            for (const t of typeArgs) {
                 tupleTypeArgs.push({ type: t, isUnbounded: false });
-            });
+            }
         }
 
         // Create a copy of the NamedTuple class that replaces the tuple base class.
         const clonedNamedTupleClass = ClassType.specialize(baseClass, /* typeArgs */ undefined, isTypeArgExplicit);
         clonedNamedTupleClass.shared = { ...clonedNamedTupleClass.shared };
 
-        clonedNamedTupleClass.shared.baseClasses = clonedNamedTupleClass.shared.baseClasses.map(
-            (namedTupleBaseClass) => {
-                if (!isInstantiableClass(namedTupleBaseClass) || !ClassType.isBuiltIn(namedTupleBaseClass, 'tuple')) {
-                    return namedTupleBaseClass;
-                }
-
-                return specializeTupleClass(namedTupleBaseClass, tupleTypeArgs, isTypeArgExplicit);
+        const updatedInnerBaseClasses: Type[] = [];
+        for (const namedTupleBaseClass of clonedNamedTupleClass.shared.baseClasses) {
+            if (!isInstantiableClass(namedTupleBaseClass) || !ClassType.isBuiltIn(namedTupleBaseClass, 'tuple')) {
+                updatedInnerBaseClasses.push(namedTupleBaseClass);
+                continue;
             }
-        );
+
+            updatedInnerBaseClasses.push(specializeTupleClass(namedTupleBaseClass, tupleTypeArgs, isTypeArgExplicit));
+        }
+        clonedNamedTupleClass.shared.baseClasses = updatedInnerBaseClasses;
 
         computeMroLinearization(clonedNamedTupleClass);
 
         isUpdateNeeded = true;
-        return clonedNamedTupleClass;
-    });
+        updatedBaseClasses.push(clonedNamedTupleClass);
+    }
+    classType.shared.baseClasses = updatedBaseClasses;
 
     return isUpdateNeeded;
 }

--- a/packages/pyright-internal/src/analyzer/packageTypeVerifier.ts
+++ b/packages/pyright-internal/src/analyzer/packageTypeVerifier.ts
@@ -185,13 +185,13 @@ export class PackageTypeVerifier {
                     // use this map to determine which diagnostics to report. We don't want
                     // to report diagnostics many times for types that include public types.
                     const publicSymbols = new Set<string>();
-                    publicModules.forEach((moduleName) => {
+                    for (const moduleName of publicModules) {
                         this._getPublicSymbolsForModule(moduleName, publicSymbols, report.alternateSymbolNames);
-                    });
+                    }
 
-                    publicModules.forEach((moduleName) => {
+                    for (const moduleName of publicModules) {
                         this._verifyTypesOfModule(moduleName, publicSymbols, report);
-                    });
+                    }
                 }
             }
         } catch (e: any) {
@@ -310,7 +310,7 @@ export class PackageTypeVerifier {
         symbolTable: SymbolTable,
         scopeType: ScopeType
     ) {
-        symbolTable.forEach((symbol, name) => {
+        for (const [name, symbol] of symbolTable) {
             if (
                 !isPrivateOrProtectedName(name) &&
                 !symbol.isIgnoredForProtocolMatch() &&
@@ -352,7 +352,7 @@ export class PackageTypeVerifier {
                     }
                 }
             }
-        });
+        }
     }
 
     private _addAlternateSymbolName(map: AlternateSymbolNameMap, name: string, altName: string) {
@@ -429,12 +429,12 @@ export class PackageTypeVerifier {
         const uniqueModules: string[] = [];
         const moduleMap = new Map<string, string>();
 
-        publicModules.forEach((module) => {
+        for (const module of publicModules) {
             if (!moduleMap.has(module)) {
                 uniqueModules.push(module);
                 moduleMap.set(module, module);
             }
-        });
+        }
 
         return uniqueModules;
     }
@@ -447,7 +447,7 @@ export class PackageTypeVerifier {
     ) {
         const dirEntries = this._serviceProvider.fs().readdirEntriesSync(dirPath);
 
-        dirEntries.forEach((entry) => {
+        for (const entry of dirEntries) {
             let isFile = entry.isFile();
             let isDirectory = entry.isDirectory();
             if (entry.isSymbolicLink()) {
@@ -493,7 +493,7 @@ export class PackageTypeVerifier {
                     );
                 }
             }
-        });
+        }
     }
 
     private _isLegalModulePartName(name: string): boolean {
@@ -522,7 +522,7 @@ export class PackageTypeVerifier {
 
         let knownStatus = TypeKnownStatus.Known;
 
-        symbolTable.forEach((symbol, name) => {
+        for (const [name, symbol] of symbolTable) {
             if (
                 !isPrivateOrProtectedName(name) &&
                 !symbol.isExternallyHidden() &&
@@ -538,7 +538,7 @@ export class PackageTypeVerifier {
                 const cachedSymbolInfo = report.symbols.get(fullName);
                 if (cachedSymbolInfo) {
                     cachedSymbolInfo.referenceCount++;
-                    return;
+                    continue;
                 }
 
                 let symbolType = this._program.getTypeOfSymbol(symbol);
@@ -591,7 +591,7 @@ export class PackageTypeVerifier {
                         primaryDecl?.type === DeclarationType.Variable &&
                         primaryDecl.isDefinedBySlots
                     ) {
-                        return;
+                        continue;
                     }
 
                     symbolInfo = {
@@ -678,7 +678,7 @@ export class PackageTypeVerifier {
 
                 knownStatus = this._updateKnownStatusIfWorse(knownStatus, symbolInfo.typeKnownStatus);
             }
-        });
+        }
 
         return knownStatus;
     }
@@ -764,7 +764,8 @@ export class PackageTypeVerifier {
 
         const aliasInfo = type.props?.typeAliasInfo;
         if (aliasInfo?.typeArgs) {
-            aliasInfo.typeArgs.forEach((typeArg, index) => {
+            for (let index = 0; index < aliasInfo.typeArgs.length; index++) {
+                const typeArg = aliasInfo.typeArgs[index];
                 if (isUnknown(typeArg)) {
                     this._addSymbolError(
                         symbolInfo,
@@ -784,7 +785,7 @@ export class PackageTypeVerifier {
                     );
                     knownStatus = TypeKnownStatus.PartiallyUnknown;
                 }
-            });
+            }
         }
 
         if (TypeBase.isAmbiguous(type) && !isUnknown(type)) {
@@ -884,12 +885,12 @@ export class PackageTypeVerifier {
 
                     const propertyClass = type;
 
-                    propMethodInfo.forEach((info) => {
+                    for (const info of propMethodInfo) {
                         const methodAccessor = info[1];
                         let accessType = methodAccessor(propertyClass);
 
                         if (!accessType) {
-                            return;
+                            continue;
                         }
 
                         if (isFunction(accessType)) {
@@ -914,7 +915,7 @@ export class PackageTypeVerifier {
                                 publicSymbols
                             )
                         );
-                    });
+                    }
 
                     break;
                 }
@@ -929,7 +930,8 @@ export class PackageTypeVerifier {
 
                 // Analyze type arguments if present to make sure they are known.
                 if (type.priv.typeArgs) {
-                    type.priv.typeArgs!.forEach((typeArg, index) => {
+                    for (let index = 0; index < type.priv.typeArgs!.length; index++) {
+                        const typeArg = type.priv.typeArgs![index];
                         if (isUnknown(typeArg)) {
                             this._addSymbolError(
                                 symbolInfo,
@@ -951,7 +953,7 @@ export class PackageTypeVerifier {
                             );
                             knownStatus = this._updateKnownStatusIfWorse(knownStatus, TypeKnownStatus.PartiallyUnknown);
                         }
-                    });
+                    }
                 }
 
                 break;
@@ -997,7 +999,8 @@ export class PackageTypeVerifier {
             declFileUri = type.shared.declaration.uri;
         }
 
-        type.shared.parameters.forEach((param, index) => {
+        for (let index = 0; index < type.shared.parameters.length; index++) {
+            const param = type.shared.parameters[index];
             const paramType = FunctionType.getParamType(type, index);
 
             // Skip nameless parameters like "*" and "/".
@@ -1068,7 +1071,7 @@ export class PackageTypeVerifier {
                     }
                 }
             }
-        });
+        }
 
         if (type.shared.declaredReturnType) {
             if (isUnknown(type.shared.declaredReturnType)) {
@@ -1232,7 +1235,7 @@ export class PackageTypeVerifier {
         }
 
         // Add information for base classes.
-        type.shared.baseClasses.forEach((baseClass) => {
+        for (const baseClass of type.shared.baseClasses) {
             if (!isInstantiableClass(baseClass)) {
                 this._addSymbolError(symbolInfo, `Type of base class unknown`, getEmptyRange(), Uri.empty());
                 symbolInfo.typeKnownStatus = this._updateKnownStatusIfWorse(
@@ -1243,7 +1246,7 @@ export class PackageTypeVerifier {
                 // Handle "tuple" specially. Even though it's a generic class, it
                 // doesn't require a type argument.
                 if (ClassType.isBuiltIn(baseClass, 'tuple')) {
-                    return;
+                    continue;
                 }
 
                 const diag = new DiagnosticAddendum();
@@ -1263,7 +1266,7 @@ export class PackageTypeVerifier {
                     );
                 }
             }
-        });
+        }
 
         return symbolInfo;
     }
@@ -1323,7 +1326,8 @@ export class PackageTypeVerifier {
 
         const aliasInfo = type.props?.typeAliasInfo;
         if (aliasInfo?.typeArgs) {
-            aliasInfo.typeArgs.forEach((typeArg, index) => {
+            for (let index = 0; index < aliasInfo.typeArgs.length; index++) {
+                const typeArg = aliasInfo.typeArgs[index];
                 if (isUnknown(typeArg)) {
                     diag.addMessage(
                         `Type argument ${index + 1} for type alias "${aliasInfo!.shared.name}" has unknown type`
@@ -1337,7 +1341,7 @@ export class PackageTypeVerifier {
                     );
                     knownStatus = this._updateKnownStatusIfWorse(knownStatus, TypeKnownStatus.PartiallyUnknown);
                 }
-            });
+            }
         }
 
         if (TypeBase.isAmbiguous(type)) {
@@ -1408,7 +1412,8 @@ export class PackageTypeVerifier {
 
                 // Analyze type arguments if present to make sure they are known.
                 if (type.priv.typeArgs) {
-                    type.priv.typeArgs!.forEach((typeArg, index) => {
+                    for (let index = 0; index < type.priv.typeArgs!.length; index++) {
+                        const typeArg = type.priv.typeArgs![index];
                         if (isUnknown(typeArg)) {
                             diag.addMessage(
                                 `Type argument ${index + 1} for class "${type.shared.name}" has unknown type`
@@ -1420,7 +1425,7 @@ export class PackageTypeVerifier {
                             );
                             knownStatus = this._updateKnownStatusIfWorse(knownStatus, TypeKnownStatus.PartiallyUnknown);
                         }
-                    });
+                    }
                 }
 
                 break;

--- a/packages/pyright-internal/src/analyzer/parameterUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parameterUtils.ts
@@ -6,7 +6,7 @@
  * Utility functions for parameters.
  */
 
-import { assert, fail } from '../common/debug';
+import { fail } from '../common/debug';
 import { ParamCategory } from '../parser/parseNodes';
 import { isDunderName } from './symbolNameUtils';
 import {

--- a/packages/pyright-internal/src/analyzer/parameterUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parameterUtils.ts
@@ -6,7 +6,7 @@
  * Utility functions for parameters.
  */
 
-import { assert } from '../common/debug';
+import { assert, fail } from '../common/debug';
 import { ParamCategory } from '../parser/parseNodes';
 import { isDunderName } from './symbolNameUtils';
 import {
@@ -100,7 +100,13 @@ export function getParamListDetails(type: FunctionType, options?: ParamListDetai
         hasUnpackedTypedDict: false,
     };
 
-    let positionOnlyIndex = type.shared.parameters.findIndex((p) => isPositionOnlySeparator(p));
+    let positionOnlyIndex = -1;
+    for (let i = 0; i < type.shared.parameters.length; i++) {
+        if (isPositionOnlySeparator(type.shared.parameters[i])) {
+            positionOnlyIndex = i;
+            break;
+        }
+    }
 
     // Handle the old (pre Python 3.8) way of specifying positional-only
     // parameters by naming them with "__".
@@ -170,14 +176,18 @@ export function getParamListDetails(type: FunctionType, options?: ParamListDetai
         }
     };
 
-    type.shared.parameters.forEach((param, index) => {
+    const parameters = type.shared.parameters;
+    for (let index = 0; index < parameters.length; index++) {
+        const param = parameters[index];
         if (param.category === ParamCategory.ArgsList) {
             // If this is an unpacked tuple, expand the entries.
             const paramType = FunctionType.getParamType(type, index);
             if (param.name && isUnpackedClass(paramType) && paramType.priv.tupleTypeArgs) {
                 const addToPositionalOnly = index < result.positionOnlyParamCount;
 
-                paramType.priv.tupleTypeArgs.forEach((tupleArg, tupleIndex) => {
+                const tupleTypeArgs = paramType.priv.tupleTypeArgs;
+                for (let tupleIndex = 0; tupleIndex < tupleTypeArgs.length; tupleIndex++) {
+                    const tupleArg = tupleTypeArgs[tupleIndex];
                     const category =
                         isTypeVarTuple(tupleArg.type) || tupleArg.isUnbounded
                             ? ParamCategory.ArgsList
@@ -211,7 +221,7 @@ export function getParamListDetails(type: FunctionType, options?: ParamListDetai
                     if (tupleIndex > 0 && addToPositionalOnly) {
                         result.positionOnlyParamCount++;
                     }
-                });
+                }
 
                 // Normally, a VarArgList parameter (either named or as an unnamed separator)
                 // would signify the start of keyword-only parameters. However, we can construct
@@ -256,8 +266,8 @@ export function getParamListDetails(type: FunctionType, options?: ParamListDetai
                 }
 
                 const typedDictType = paramType;
-                paramType.shared.typedDictEntries.knownItems.forEach((entry, name) => {
-                    entry = paramType.priv.typedDictNarrowedEntries?.get(name) ?? entry;
+                for (const [name, origEntry] of paramType.shared.typedDictEntries.knownItems) {
+                    const entry = paramType.priv.typedDictNarrowedEntries?.get(name) ?? origEntry;
 
                     const specializedParamType = partiallySpecializeType(
                         entry.valueType,
@@ -278,7 +288,7 @@ export function getParamListDetails(type: FunctionType, options?: ParamListDetai
                         specializedParamType,
                         defaultParamType
                     );
-                });
+                }
 
                 const extraItemsType = paramType.shared.typedDictEntries.extraItems?.valueType;
 
@@ -334,18 +344,22 @@ export function getParamListDetails(type: FunctionType, options?: ParamListDetai
                     : undefined
             );
         }
-    });
+    }
 
     // If the signature ends in `*args: P.args, **kwargs: P.kwargs`,
     // extract the ParamSpec P.
     result.paramSpec = FunctionType.getParamSpecFromArgsKwargs(type);
 
-    result.firstPositionOrKeywordIndex = result.params.findIndex(
-        (p) => p.kind !== ParamKind.Positional && p.kind !== ParamKind.ExpandedArgs
-    );
-    if (result.firstPositionOrKeywordIndex < 0) {
-        result.firstPositionOrKeywordIndex = result.params.length;
+    let firstPositionOrKeywordIndex = -1;
+    for (let i = 0; i < result.params.length; i++) {
+        const kind = result.params[i].kind;
+        if (kind !== ParamKind.Positional && kind !== ParamKind.ExpandedArgs) {
+            firstPositionOrKeywordIndex = i;
+            break;
+        }
     }
+    result.firstPositionOrKeywordIndex =
+        firstPositionOrKeywordIndex < 0 ? result.params.length : firstPositionOrKeywordIndex;
 
     return result;
 }
@@ -433,10 +447,11 @@ export class ParamAssignmentTracker {
     params: ParamAssignmentInfo[];
 
     constructor(paramInfos: VirtualParamDetails[]) {
-        this.params = paramInfos.map((p) => {
+        this.params = [];
+        for (const p of paramInfos) {
             const argsNeeded = !!p.defaultType || p.param.category !== ParamCategory.Simple ? 0 : 1;
-            return { paramDetails: p, argsNeeded, argsReceived: 0 };
-        });
+            this.params.push({ paramDetails: p, argsNeeded, argsReceived: 0 });
+        }
     }
 
     // Add a virtual keyword parameter for a keyword argument that
@@ -452,22 +467,28 @@ export class ParamAssignmentTracker {
     }
 
     lookupName(name: string): ParamAssignmentInfo | undefined {
-        return this.params.find((p) => {
+        for (const p of this.params) {
             // Don't return positional parameters because their names are irrelevant.
             const kind = p.paramDetails.kind;
             if (kind === ParamKind.Positional || kind === ParamKind.ExpandedArgs) {
-                return false;
+                continue;
             }
 
             const effectiveName = p.keywordName ?? p.paramDetails.param.name;
-            return effectiveName === name;
-        });
+            if (effectiveName === name) {
+                return p;
+            }
+        }
+        return undefined;
     }
 
     lookupDetails(paramInfo: VirtualParamDetails): ParamAssignmentInfo {
-        const info = this.params.find((p) => p.paramDetails === paramInfo);
-        assert(info !== undefined);
-        return info;
+        for (const p of this.params) {
+            if (p.paramDetails === paramInfo) {
+                return p;
+            }
+        }
+        fail('paramInfo not found');
     }
 
     markArgReceived(paramInfo: VirtualParamDetails) {
@@ -479,17 +500,17 @@ export class ParamAssignmentTracker {
     // required number of arguments.
     getUnassignedParams(): string[] {
         const unassignedParams: string[] = [];
-        this.params.forEach((p) => {
+        for (const p of this.params) {
             if (!p.paramDetails.param.name) {
-                return;
+                continue;
             }
 
             if (p.argsReceived >= p.argsNeeded) {
-                return;
+                continue;
             }
 
             unassignedParams.push(p.paramDetails.param.name);
-        });
+        }
 
         return unassignedParams;
     }

--- a/packages/pyright-internal/src/analyzer/parameterUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parameterUtils.ts
@@ -24,9 +24,12 @@ import {
     isTypeVarTuple,
     isUnpackedClass,
     Type,
+    TypeSameOptions,
     TypeVarType,
 } from './types';
 import { doForEachSubtype, partiallySpecializeType } from './typeUtils';
+
+const _ignoreTypeFlagsOptions: TypeSameOptions = { ignoreTypeFlags: true };
 
 export function isTypedKwargs(param: FunctionParam, effectiveParamType: Type): boolean {
     return (
@@ -356,7 +359,7 @@ export function isParamSpecArgs(paramSpec: TypeVarType, argType: Type) {
         if (
             isParamSpec(argSubtype) &&
             argSubtype.priv.paramSpecAccess === 'args' &&
-            isTypeSame(argSubtype, paramSpec, { ignoreTypeFlags: true })
+            isTypeSame(argSubtype, paramSpec, _ignoreTypeFlagsOptions)
         ) {
             return;
         }
@@ -390,7 +393,7 @@ export function isParamSpecKwargs(paramSpec: TypeVarType, argType: Type) {
         if (
             isParamSpec(argSubtype) &&
             argSubtype.priv.paramSpecAccess === 'kwargs' &&
-            isTypeSame(argSubtype, paramSpec, { ignoreTypeFlags: true })
+            isTypeSame(argSubtype, paramSpec, _ignoreTypeFlagsOptions)
         ) {
             return;
         }

--- a/packages/pyright-internal/src/analyzer/parentDirectoryCache.ts
+++ b/packages/pyright-internal/src/analyzer/parentDirectoryCache.ts
@@ -52,17 +52,14 @@ export class ParentDirectoryCache {
             return false;
         }
 
-        this._libPathCache =
-            this._libPathCache ??
-            this._importRootGetter()
-                .map((r) => fs.realCasePath(r))
-                .filter((r) => !r.equals(root))
-                .filter((r) => r.startsWith(root));
+        this._libPathCache = this._libPathCache ?? _computeLibPaths(this._importRootGetter(), fs, root);
 
-        if (this._libPathCache.some((p) => sourceFileUri.startsWith(p))) {
-            // Make sure it is not lib folders under user code root.
-            // ex) .venv folder
-            return false;
+        for (const p of this._libPathCache) {
+            if (sourceFileUri.startsWith(p)) {
+                // Make sure it is not lib folders under user code root.
+                // ex) .venv folder
+                return false;
+            }
         }
 
         return true;
@@ -84,4 +81,15 @@ export class ParentDirectoryCache {
         this._cachedResults.clear();
         this._libPathCache = undefined;
     }
+}
+
+function _computeLibPaths(importRoots: Uri[], fs: FileSystem, root: Uri): Uri[] {
+    const result: Uri[] = [];
+    for (const r of importRoots) {
+        const real = fs.realCasePath(r);
+        if (!real.equals(root) && real.startsWith(root)) {
+            result.push(real);
+        }
+    }
+    return result;
 }

--- a/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeUtils.ts
@@ -1680,10 +1680,10 @@ export class NameNodeWalker extends ParseTreeWalker {
         const prevBaseExpression = this._baseExpression;
         this._baseExpression = node.d.leftExpr;
 
-        node.d.items.forEach((item, index) => {
+        for (let index = 0; index < node.d.items.length; index++) {
             this._subscriptIndex = index;
-            this.walk(item);
-        });
+            this.walk(node.d.items[index]);
+        }
 
         this._subscriptIndex = prevSubscriptIndex;
         this._baseExpression = prevBaseExpression;
@@ -1758,9 +1758,10 @@ export function getCallNodeAndActiveParamIndex(
     let addedActive = false;
     let activeIndex = -1;
     let activeOrFake = false;
-    callNode.d.args.forEach((arg, index) => {
+    for (let index = 0; index < callNode.d.args.length; index++) {
+        const arg = callNode.d.args[index];
         if (addedActive) {
-            return;
+            continue;
         }
 
         // Calculate the argument's bounds including whitespace and colons.
@@ -1796,7 +1797,7 @@ export function getCallNodeAndActiveParamIndex(
             activeOrFake = insertionOffset >= start;
             addedActive = true;
         }
-    });
+    }
 
     if (!addedActive) {
         activeIndex = callNode.d.args.length + 1;
@@ -2075,11 +2076,11 @@ export function getFileInfoFromNode(node: ParseNode) {
 export function isFunctionSuiteEmpty(node: FunctionNode) {
     let isEmpty = true;
 
-    node.d.suite.d.statements.forEach((statement) => {
+    for (const statement of node.d.suite.d.statements) {
         if (statement.nodeType === ParseNodeType.Error) {
-            return;
+            continue;
         } else if (statement.nodeType === ParseNodeType.StatementList) {
-            statement.d.statements.forEach((subStatement) => {
+            for (const subStatement of statement.d.statements) {
                 // Allow docstrings, ellipsis, and pass statements.
                 if (
                     subStatement.nodeType !== ParseNodeType.Ellipsis &&
@@ -2088,11 +2089,11 @@ export function isFunctionSuiteEmpty(node: FunctionNode) {
                 ) {
                     isEmpty = false;
                 }
-            });
+            }
         } else {
             isEmpty = false;
         }
-    });
+    }
 
     return isEmpty;
 }

--- a/packages/pyright-internal/src/analyzer/parseTreeWalker.ts
+++ b/packages/pyright-internal/src/analyzer/parseTreeWalker.ts
@@ -919,11 +919,11 @@ export class ParseTreeWalker extends ParseTreeVisitor<boolean> {
     }
 
     walkMultiple(nodes: ParseNodeArray) {
-        nodes.forEach((node) => {
+        for (const node of nodes) {
             if (node) {
                 this.walk(node);
             }
-        });
+        }
     }
 
     // If this.visit(node) returns true, all child nodes for the node are returned.

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -89,7 +89,7 @@ import {
 
 // PEP 634 indicates that several built-in classes are handled differently
 // when used with class pattern matching.
-const classPatternSpecialCases = [
+const classPatternSpecialCases = new Set([
     'builtins.bool',
     'builtins.bytearray',
     'builtins.bytes',
@@ -101,7 +101,7 @@ const classPatternSpecialCases = [
     'builtins.set',
     'builtins.str',
     'builtins.tuple',
-];
+]);
 
 // There are cases where sequence pattern matching of tuples with
 // large unions can blow up and cause hangs. This constant limits
@@ -183,7 +183,7 @@ export function checkForUnusedPattern(evaluator: TypeEvaluator, pattern: Pattern
         reportUnnecessaryPattern(evaluator, pattern, subjectType);
     } else if (pattern.nodeType === ParseNodeType.PatternAs && pattern.d.orPatterns.length > 1) {
         // Check each of the or patterns separately.
-        pattern.d.orPatterns.forEach((orPattern) => {
+        for (const orPattern of pattern.d.orPatterns) {
             const subjectTypeMatch = narrowTypeBasedOnPattern(
                 evaluator,
                 subjectType,
@@ -196,7 +196,7 @@ export function checkForUnusedPattern(evaluator: TypeEvaluator, pattern: Pattern
             }
 
             subjectType = narrowTypeBasedOnPattern(evaluator, subjectType, orPattern, /* isPositiveTest */ false);
-        });
+        }
     } else {
         const subjectTypeMatch = narrowTypeBasedOnPattern(evaluator, subjectType, pattern, /* isPositiveTest */ true);
 
@@ -264,7 +264,8 @@ function narrowTypeBasedOnSequencePattern(
         }
 
         const negativeNarrowedDims: number[] = [];
-        pattern.d.entries.forEach((sequenceEntry, index) => {
+        for (let index = 0; index < pattern.d.entries.length; index++) {
+            const sequenceEntry = pattern.d.entries[index];
             const entryType = getTypeOfPatternSequenceEntry(
                 evaluator,
                 pattern,
@@ -288,7 +289,7 @@ function narrowTypeBasedOnSequencePattern(
                     ) {
                         appendArray(
                             narrowedEntryTypes,
-                            narrowedEntryType.priv.tupleTypeArgs.map((t) => t.type)
+                            narrowedEntryType.priv.tupleTypeArgs.map((t) => t.type) // small, bounded by tuple arity
                         );
                     } else {
                         narrowedEntryTypes.push(narrowedEntryType);
@@ -323,7 +324,7 @@ function narrowTypeBasedOnSequencePattern(
                     canNarrowTuple = false;
                 }
             }
-        });
+        }
 
         if (pattern.d.entries.length === 0) {
             // If the pattern is an empty sequence, use the entry types.
@@ -357,18 +358,18 @@ function narrowTypeBasedOnSequencePattern(
                         expandedEntryTypes.push(newEntryTypes);
                     }
 
-                    entry.subtype = combineTypes(
-                        expandedEntryTypes.map((entryTypes) => {
-                            return ClassType.cloneAsInstance(
-                                specializeTupleClass(
-                                    tupleClassType,
-                                    entryTypes.map((t) => {
-                                        return { type: t, isUnbounded: false };
-                                    })
-                                )
-                            );
-                        })
-                    );
+                    const expandedTupleTypes = new Array<Type>(expandedEntryTypes.length);
+                    for (let ei = 0; ei < expandedEntryTypes.length; ei++) {
+                        const entryTypes = expandedEntryTypes[ei];
+                        const tupleTypeArgs = new Array<{ type: Type; isUnbounded: boolean }>(entryTypes.length);
+                        for (let ti = 0; ti < entryTypes.length; ti++) {
+                            tupleTypeArgs[ti] = { type: entryTypes[ti], isUnbounded: false };
+                        }
+                        expandedTupleTypes[ei] = ClassType.cloneAsInstance(
+                            specializeTupleClass(tupleClassType, tupleTypeArgs)
+                        );
+                    }
+                    entry.subtype = combineTypes(expandedTupleTypes);
 
                     // Note that we're using tuple expansion in case we
                     // need to limit the number of subtypes generated.
@@ -386,13 +387,12 @@ function narrowTypeBasedOnSequencePattern(
             if (canNarrowTuple) {
                 const tupleClassType = evaluator.getBuiltInType(pattern, 'tuple');
                 if (tupleClassType && isInstantiableClass(tupleClassType)) {
+                    const tupleTypeArgs = new Array<{ type: Type; isUnbounded: boolean }>(narrowedEntryTypes.length);
+                    for (let ti = 0; ti < narrowedEntryTypes.length; ti++) {
+                        tupleTypeArgs[ti] = { type: narrowedEntryTypes[ti], isUnbounded: false };
+                    }
                     entry.subtype = ClassType.cloneAsInstance(
-                        specializeTupleClass(
-                            tupleClassType,
-                            narrowedEntryTypes.map((t) => {
-                                return { type: t, isUnbounded: false };
-                            })
-                        )
+                        specializeTupleClass(tupleClassType, tupleTypeArgs)
                     );
                 }
             }
@@ -415,8 +415,12 @@ function narrowTypeBasedOnSequencePattern(
         return isPlausibleMatch;
     });
 
+    const sequenceSubtypes = new Array<Type>(sequenceInfo.length);
+    for (let i = 0; i < sequenceInfo.length; i++) {
+        sequenceSubtypes[i] = sequenceInfo[i].subtype;
+    }
     return combineTypes(
-        sequenceInfo.map((entry) => entry.subtype),
+        sequenceSubtypes,
         { maxSubtypeCount: usingTupleExpansion ? maxSequencePatternTupleExpansionSubtypes : undefined }
     );
 }
@@ -430,22 +434,23 @@ function narrowTypeBasedOnAsPattern(
     let remainingType = type;
 
     if (!isPositiveTest) {
-        pattern.d.orPatterns.forEach((subpattern) => {
+        for (const subpattern of pattern.d.orPatterns) {
             remainingType = narrowTypeBasedOnPattern(evaluator, remainingType, subpattern, /* isPositiveTest */ false);
-        });
+        }
         return remainingType;
     }
 
-    const narrowedTypes = pattern.d.orPatterns.map((subpattern) => {
-        const narrowedSubtype = narrowTypeBasedOnPattern(
+    const narrowedTypes = new Array<Type>(pattern.d.orPatterns.length);
+    for (let i = 0; i < pattern.d.orPatterns.length; i++) {
+        const subpattern = pattern.d.orPatterns[i];
+        narrowedTypes[i] = narrowTypeBasedOnPattern(
             evaluator,
             remainingType,
             subpattern,
             /* isPositiveTest */ true
         );
         remainingType = narrowTypeBasedOnPattern(evaluator, remainingType, subpattern, /* isPositiveTest */ false);
-        return narrowedSubtype;
-    });
+    }
     return combineTypes(narrowedTypes);
 }
 
@@ -464,7 +469,13 @@ function narrowTypeBasedOnMappingPattern(
             pattern.d.entries[0].nodeType === ParseNodeType.PatternMappingExpandEntry
         ) {
             const mappingInfo = getMappingPatternInfo(evaluator, type, pattern);
-            return combineTypes(mappingInfo.filter((m) => !m.isDefinitelyMapping).map((m) => m.subtype));
+            const nonMappingSubtypes: Type[] = [];
+            for (let i = 0; i < mappingInfo.length; i++) {
+                if (!mappingInfo[i].isDefinitelyMapping) {
+                    nonMappingSubtypes.push(mappingInfo[i].subtype);
+                }
+            }
+            return combineTypes(nonMappingSubtypes);
         }
 
         if (pattern.d.entries.length !== 1 || pattern.d.entries[0].nodeType !== ParseNodeType.PatternMappingKeyEntry) {
@@ -475,15 +486,24 @@ function narrowTypeBasedOnMappingPattern(
         // a field discriminated by a literal.
         const keyPattern = pattern.d.entries[0].d.keyPattern;
         const valuePattern = pattern.d.entries[0].d.valuePattern;
-        if (
-            keyPattern.nodeType !== ParseNodeType.PatternLiteral ||
-            valuePattern.nodeType !== ParseNodeType.PatternAs ||
-            !valuePattern.d.orPatterns.every((orPattern) => orPattern.nodeType === ParseNodeType.PatternLiteral)
-        ) {
+
+        let allOrPatternsAreLiteral = true;
+        if (keyPattern.nodeType === ParseNodeType.PatternLiteral && valuePattern.nodeType === ParseNodeType.PatternAs) {
+            for (const orPattern of valuePattern.d.orPatterns) {
+                if (orPattern.nodeType !== ParseNodeType.PatternLiteral) {
+                    allOrPatternsAreLiteral = false;
+                    break;
+                }
+            }
+        } else {
+            allOrPatternsAreLiteral = false;
+        }
+
+        if (!allOrPatternsAreLiteral) {
             return type;
         }
 
-        const keyType = evaluator.getTypeOfExpression(keyPattern.d.expr).type;
+        const keyType = evaluator.getTypeOfExpression((keyPattern as PatternLiteralNode).d.expr).type;
 
         // The key type must be a str literal.
         if (
@@ -495,9 +515,13 @@ function narrowTypeBasedOnMappingPattern(
         }
         const keyValue = keyType.priv.literalValue as string;
 
-        const valueTypes = valuePattern.d.orPatterns.map(
-            (orPattern) => evaluator.getTypeOfExpression((orPattern as PatternLiteralNode).d.expr).type
-        );
+        const orPatterns = (valuePattern as PatternAsNode).d.orPatterns;
+        const valueTypes = new Array<Type>(orPatterns.length);
+        for (let i = 0; i < orPatterns.length; i++) {
+            valueTypes[i] = evaluator.getTypeOfExpression(
+                (orPatterns[i] as PatternLiteralNode).d.expr
+            ).type;
+        }
 
         return mapSubtypes(type, (subtype) => {
             if (isClassInstance(subtype) && ClassType.isTypedDictClass(subtype)) {
@@ -509,14 +533,19 @@ function narrowTypeBasedOnMappingPattern(
 
                     // If there's at least one literal value pattern that matches
                     // the literal type of the member, we can eliminate this type.
-                    if (
-                        valueTypes.some(
-                            (valueType) =>
-                                isClassInstance(valueType) &&
-                                ClassType.isSameGenericClass(valueType, memberValueType) &&
-                                valueType.priv.literalValue === memberValueType.priv.literalValue
-                        )
-                    ) {
+                    let hasMatchingLiteral = false;
+                    for (let vi = 0; vi < valueTypes.length; vi++) {
+                        const valueType = valueTypes[vi];
+                        if (
+                            isClassInstance(valueType) &&
+                            ClassType.isSameGenericClass(valueType, memberValueType) &&
+                            valueType.priv.literalValue === memberValueType.priv.literalValue
+                        ) {
+                            hasMatchingLiteral = true;
+                            break;
+                        }
+                    }
+                    if (hasMatchingLiteral) {
                         return undefined;
                     }
                 }
@@ -536,7 +565,7 @@ function narrowTypeBasedOnMappingPattern(
 
         let isPlausibleMatch = true;
 
-        pattern.d.entries.forEach((mappingEntry) => {
+        for (const mappingEntry of pattern.d.entries) {
             if (mappingSubtypeInfo.typedDict) {
                 if (mappingEntry.nodeType === ParseNodeType.PatternMappingKeyEntry) {
                     const narrowedKeyType = narrowTypeBasedOnPattern(
@@ -628,12 +657,16 @@ function narrowTypeBasedOnMappingPattern(
                     }
                 }
             }
-        });
+        }
 
         return isPlausibleMatch;
     });
 
-    return combineTypes(mappingInfo.map((entry) => entry.subtype));
+    const mappingSubtypes = new Array<Type>(mappingInfo.length);
+    for (let i = 0; i < mappingInfo.length; i++) {
+        mappingSubtypes[i] = mappingInfo[i].subtype;
+    }
+    return combineTypes(mappingSubtypes);
 }
 
 // Looks up the "__match_args__" class member to determine the names of
@@ -651,13 +684,20 @@ function getPositionalMatchArgNames(evaluator: TypeEvaluator, type: ClassType): 
             const tupleArgs = matchArgsType.priv.tupleTypeArgs;
 
             // Are all the args string literals?
-            if (
-                tupleArgs.every(
-                    (arg) =>
-                        isClassInstance(arg.type) && ClassType.isBuiltIn(arg.type, 'str') && isLiteralType(arg.type)
-                )
-            ) {
-                return tupleArgs.map((arg) => (arg.type as ClassType).priv.literalValue as string);
+            let allStringLiterals = true;
+            for (let i = 0; i < tupleArgs.length; i++) {
+                const argType = tupleArgs[i].type;
+                if (!isClassInstance(argType) || !ClassType.isBuiltIn(argType, 'str') || !isLiteralType(argType)) {
+                    allStringLiterals = false;
+                    break;
+                }
+            }
+            if (allStringLiterals) {
+                const result = new Array<string>(tupleArgs.length);
+                for (let i = 0; i < tupleArgs.length; i++) {
+                    result[i] = (tupleArgs[i].type as ClassType).priv.literalValue as string;
+                }
+                return result;
             }
         }
     }
@@ -761,7 +801,14 @@ function narrowTypeBasedOnClassPattern(
     // Are there any positional arguments? If so, try to get the mappings for
     // these arguments by fetching the __match_args__ symbol from the class.
     let positionalArgNames: string[] = [];
-    if (pattern.d.args.some((arg) => !arg.d.name) && isInstantiableClass(exprType)) {
+    let hasPositionalArgs = false;
+    for (let i = 0; i < pattern.d.args.length; i++) {
+        if (!pattern.d.args[i].d.name) {
+            hasPositionalArgs = true;
+            break;
+        }
+    }
+    if (hasPositionalArgs && isInstantiableClass(exprType)) {
         positionalArgNames = getPositionalMatchArgNames(evaluator, exprType);
     }
 
@@ -1029,12 +1076,20 @@ function narrowTypeBasedOnClassPattern(
                         // Are there any positional arguments? If so, try to get the mappings for
                         // these arguments by fetching the __match_args__ symbol from the class.
                         let positionalArgNames: string[] = [];
-                        if (pattern.d.args.some((arg) => !arg.d.name)) {
+                        let hasPositionalArg = false;
+                        for (let ai = 0; ai < pattern.d.args.length; ai++) {
+                            if (!pattern.d.args[ai].d.name) {
+                                hasPositionalArg = true;
+                                break;
+                            }
+                        }
+                        if (hasPositionalArg) {
                             positionalArgNames = getPositionalMatchArgNames(evaluator, expandedSubtype);
                         }
 
                         let isMatchValid = true;
-                        pattern.d.args.forEach((arg, index) => {
+                        for (let index = 0; index < pattern.d.args.length; index++) {
+                            const arg = pattern.d.args[index];
                             // Narrow the arg pattern. It's possible that the actual type of the object
                             // being matched is a subtype of the resultType, so it might contain additional
                             // attributes that we don't know about.
@@ -1050,7 +1105,7 @@ function narrowTypeBasedOnClassPattern(
                             if (isNever(narrowedArgType)) {
                                 isMatchValid = false;
                             }
-                        });
+                        }
 
                         if (isMatchValid) {
                             return resultType;
@@ -1069,7 +1124,7 @@ function narrowTypeBasedOnClassPattern(
 // Some built-in classes are treated as special cases for the class pattern
 // if a positional argument is used.
 function isClassSpecialCaseForClassPattern(classType: ClassType) {
-    if (classPatternSpecialCases.some((className) => classType.shared.fullName === className)) {
+    if (classPatternSpecialCases.has(classType.shared.fullName)) {
         return true;
     }
 
@@ -1081,7 +1136,7 @@ function isClassSpecialCaseForClassPattern(classType: ClassType) {
 
     // If the class derives from a built-in class, it is considered a special case.
     for (const mroClass of classType.shared.mro) {
-        if (isClass(mroClass) && classPatternSpecialCases.some((className) => mroClass.shared.fullName === className)) {
+        if (isClass(mroClass) && classPatternSpecialCases.has(mroClass.shared.fullName)) {
             return true;
         }
     }
@@ -1125,12 +1180,13 @@ function narrowTypeOfClassPatternArg(
         if (isClassSpecialCaseForClassPattern(matchType)) {
             useSelfForPattern = true;
         } else if (positionalArgNames.length === 0) {
-            matchType.shared.mro.forEach((mroClass) => {
+            for (const mroClass of matchType.shared.mro) {
                 if (isClass(mroClass) && isClassSpecialCaseForClassPattern(mroClass)) {
                     selfForPatternType = mroClass;
                     useSelfForPattern = true;
+                    break;
                 }
-            });
+            }
         }
     }
 
@@ -1414,9 +1470,17 @@ function getSequencePatternInfo(
                         { type: UnknownType.create(), isUnbounded: true },
                     ];
 
-                    let tupleIndeterminateIndex = typeArgs.findIndex(
-                        (t) => t.isUnbounded || isUnpackedTypeVarTuple(t.type) || isUnpackedTypeVar(t.type)
-                    );
+                    let tupleIndeterminateIndex = -1;
+                    for (let ti = 0; ti < typeArgs.length; ti++) {
+                        if (
+                            typeArgs[ti].isUnbounded ||
+                            isUnpackedTypeVarTuple(typeArgs[ti].type) ||
+                            isUnpackedTypeVar(typeArgs[ti].type)
+                        ) {
+                            tupleIndeterminateIndex = ti;
+                            break;
+                        }
+                    }
 
                     let tupleDeterminateEntryCount = typeArgs.length;
 
@@ -1448,11 +1512,21 @@ function getSequencePatternInfo(
                     ) {
                         const entriesToCombine = typeArgs.length - patternEntryCount + 1;
                         const removedEntries = typeArgs.splice(patternStarEntryIndex, entriesToCombine);
+                        const removedTypes = new Array<Type>(removedEntries.length);
+                        let allUnbounded = true;
+                        for (let ri = 0; ri < removedEntries.length; ri++) {
+                            removedTypes[ri] = removedEntries[ri].type;
+                            if (
+                                !removedEntries[ri].isUnbounded &&
+                                !isUnpackedTypeVarTuple(removedEntries[ri].type) &&
+                                !isUnpackedTypeVar(removedEntries[ri].type)
+                            ) {
+                                allUnbounded = false;
+                            }
+                        }
                         typeArgs.splice(patternStarEntryIndex, 0, {
-                            type: combineTypes(removedEntries.map((t) => t.type)),
-                            isUnbounded: removedEntries.every(
-                                (t) => t.isUnbounded || isUnpackedTypeVarTuple(t.type) || isUnpackedTypeVar(t.type)
-                            ),
+                            type: combineTypes(removedTypes),
+                            isUnbounded: allUnbounded,
                         });
 
                         tupleDeterminateEntryCount -= entriesToCombine;
@@ -1502,9 +1576,19 @@ function getSequencePatternInfo(
                             }
                         }
 
+                        let entryTypes: Type[];
+                        if (isDefiniteNoMatch) {
+                            entryTypes = [];
+                        } else {
+                            entryTypes = new Array<Type>(typeArgs.length);
+                            for (let ti = 0; ti < typeArgs.length; ti++) {
+                                entryTypes[ti] = typeArgs[ti].type;
+                            }
+                        }
+
                         sequenceInfo.push({
                             subtype,
-                            entryTypes: isDefiniteNoMatch ? [] : typeArgs.map((t) => t.type),
+                            entryTypes,
                             isIndeterminateLength: false,
                             isTuple: true,
                             isUnboundedTuple: tupleIndeterminateIndex >= 0,
@@ -1555,9 +1639,19 @@ function getSequencePatternInfo(
                                 }
                             }
 
+                            let starEntryTypes: Type[];
+                            if (isDefiniteNoMatch) {
+                                starEntryTypes = [];
+                            } else {
+                                starEntryTypes = new Array<Type>(typeArgs.length);
+                                for (let ti = 0; ti < typeArgs.length; ti++) {
+                                    starEntryTypes[ti] = typeArgs[ti].type;
+                                }
+                            }
+
                             sequenceInfo.push({
                                 subtype,
-                                entryTypes: isDefiniteNoMatch ? [] : typeArgs.map((t) => t.type),
+                                entryTypes: starEntryTypes,
                                 isIndeterminateLength: false,
                                 isTuple: true,
                                 isUnboundedTuple: tupleIndeterminateIndex >= 0,
@@ -1693,19 +1787,21 @@ function getTypeOfPatternSequenceEntry(
     if (entryIndex === starEntryIndex) {
         // Create a list out of the entries that map to the star entry.
         // Note that we strip literal types here.
-        const starEntryTypes = sequenceInfo.entryTypes
-            .slice(starEntryIndex, starEntryIndex + sequenceInfo.entryTypes.length - entryCount + 1)
-            .map((type) => {
-                // If this is a TypeVarTuple, there's not much we can say about
-                // its type other than it's "Unknown". We could evaluate it as an
-                // "object", but that will cause problems given that this type will
-                // be wrapped in a "list" below, and lists are invariant.
-                if (isTypeVarTuple(type) && !type.priv.isInUnion) {
-                    return UnknownType.create();
-                }
-
-                return evaluator.stripLiteralValue(type);
-            });
+        const starStart = starEntryIndex;
+        const starEnd = starEntryIndex + sequenceInfo.entryTypes.length - entryCount + 1;
+        const starEntryTypes = new Array<Type>(starEnd - starStart);
+        for (let si = starStart; si < starEnd; si++) {
+            const type = sequenceInfo.entryTypes[si];
+            // If this is a TypeVarTuple, there's not much we can say about
+            // its type other than it's "Unknown". We could evaluate it as an
+            // "object", but that will cause problems given that this type will
+            // be wrapped in a "list" below, and lists are invariant.
+            if (isTypeVarTuple(type) && !type.priv.isInUnion) {
+                starEntryTypes[si - starStart] = UnknownType.create();
+            } else {
+                starEntryTypes[si - starStart] = evaluator.stripLiteralValue(type);
+            }
+        }
 
         let entryType = combineTypes(starEntryTypes);
 
@@ -1741,23 +1837,24 @@ export function assignTypeToPatternTargets(
                 (seqInfo) => !seqInfo.isDefiniteNoMatch
             );
 
-            pattern.d.entries.forEach((entry, index) => {
-                const entryType = combineTypes(
-                    sequenceInfo.map((info) =>
-                        getTypeOfPatternSequenceEntry(
-                            evaluator,
-                            pattern,
-                            info,
-                            index,
-                            pattern.d.entries.length,
-                            pattern.d.starEntryIndex,
-                            /* unpackStarEntry */ false
-                        )
-                    )
-                );
+            for (let index = 0; index < pattern.d.entries.length; index++) {
+                const entry = pattern.d.entries[index];
+                const seqTypes = new Array<Type>(sequenceInfo.length);
+                for (let si = 0; si < sequenceInfo.length; si++) {
+                    seqTypes[si] = getTypeOfPatternSequenceEntry(
+                        evaluator,
+                        pattern,
+                        sequenceInfo[si],
+                        index,
+                        pattern.d.entries.length,
+                        pattern.d.starEntryIndex,
+                        /* unpackStarEntry */ false
+                    );
+                }
+                const entryType = combineTypes(seqTypes);
 
                 assignTypeToPatternTargets(evaluator, entryType, isTypeIncomplete, entry);
-            });
+            }
             break;
         }
 
@@ -1771,7 +1868,7 @@ export function assignTypeToPatternTargets(
             }
 
             let runningNarrowedType = narrowedType;
-            pattern.d.orPatterns.forEach((orPattern) => {
+            for (const orPattern of pattern.d.orPatterns) {
                 assignTypeToPatternTargets(evaluator, runningNarrowedType, isTypeIncomplete, orPattern);
 
                 // OR patterns are evaluated left to right, so we can narrow
@@ -1782,7 +1879,7 @@ export function assignTypeToPatternTargets(
                     orPattern,
                     /* positiveTest */ false
                 );
-            });
+            }
             break;
         }
 
@@ -1823,11 +1920,11 @@ export function assignTypeToPatternTargets(
         case ParseNodeType.PatternMapping: {
             const mappingInfo = getMappingPatternInfo(evaluator, narrowedType, pattern);
 
-            pattern.d.entries.forEach((mappingEntry) => {
+            for (const mappingEntry of pattern.d.entries) {
                 const keyTypes: Type[] = [];
                 const valueTypes: Type[] = [];
 
-                mappingInfo.forEach((mappingSubtypeInfo) => {
+                for (const mappingSubtypeInfo of mappingInfo) {
                     if (mappingSubtypeInfo.typedDict) {
                         if (mappingEntry.nodeType === ParseNodeType.PatternMappingKeyEntry) {
                             const keyType = narrowTypeBasedOnPattern(
@@ -1880,7 +1977,7 @@ export function assignTypeToPatternTargets(
                             valueTypes.push(mappingSubtypeInfo.dictTypeArgs.value);
                         }
                     }
-                });
+                }
 
                 const keyType = combineTypes(keyTypes);
                 const valueType = combineTypes(valueTypes);
@@ -1901,12 +1998,15 @@ export function assignTypeToPatternTargets(
                         mappingEntry.d.target
                     );
                 }
-            });
+            }
             break;
         }
 
         case ParseNodeType.PatternClass: {
-            const argTypes: Type[][] = pattern.d.args.map((arg) => []);
+            const argTypes: Type[][] = new Array(pattern.d.args.length);
+            for (let ai = 0; ai < pattern.d.args.length; ai++) {
+                argTypes[ai] = [];
+            }
 
             evaluator.mapSubtypesExpandTypeVars(narrowedType, /* options */ undefined, (expandedSubtype) => {
                 if (isClassInstance(expandedSubtype)) {
@@ -1914,21 +2014,29 @@ export function assignTypeToPatternTargets(
                         const concreteSubtype = evaluator.makeTopLevelTypeVarsConcrete(subjectSubtype);
 
                         if (isAnyOrUnknown(concreteSubtype)) {
-                            pattern.d.args.forEach((arg, index) => {
+                            for (let index = 0; index < pattern.d.args.length; index++) {
                                 argTypes[index].push(concreteSubtype);
-                            });
+                            }
                         } else if (isClassInstance(concreteSubtype)) {
                             // Are there any positional arguments? If so, try to get the mappings for
                             // these arguments by fetching the __match_args__ symbol from the class.
                             let positionalArgNames: string[] = [];
-                            if (pattern.d.args.some((arg) => !arg.d.name)) {
+                            let hasPositionalArg = false;
+                            for (let pi = 0; pi < pattern.d.args.length; pi++) {
+                                if (!pattern.d.args[pi].d.name) {
+                                    hasPositionalArg = true;
+                                    break;
+                                }
+                            }
+                            if (hasPositionalArg) {
                                 positionalArgNames = getPositionalMatchArgNames(
                                     evaluator,
                                     ClassType.cloneAsInstantiable(expandedSubtype)
                                 );
                             }
 
-                            pattern.d.args.forEach((arg, index) => {
+                            for (let index = 0; index < pattern.d.args.length; index++) {
+                                const arg = pattern.d.args[index];
                                 const narrowedArgType = narrowTypeOfClassPatternArg(
                                     evaluator,
                                     arg,
@@ -1938,21 +2046,26 @@ export function assignTypeToPatternTargets(
                                     /* isPositiveTest */ true
                                 );
                                 argTypes[index].push(narrowedArgType);
-                            });
+                            }
                         }
                     });
                 } else {
-                    pattern.d.args.forEach((arg, index) => {
+                    for (let index = 0; index < pattern.d.args.length; index++) {
                         argTypes[index].push(UnknownType.create());
-                    });
+                    }
                 }
 
                 return undefined;
             });
 
-            pattern.d.args.forEach((arg, index) => {
-                assignTypeToPatternTargets(evaluator, combineTypes(argTypes[index]), isTypeIncomplete, arg.d.pattern);
-            });
+            for (let index = 0; index < pattern.d.args.length; index++) {
+                assignTypeToPatternTargets(
+                    evaluator,
+                    combineTypes(argTypes[index]),
+                    isTypeIncomplete,
+                    pattern.d.args[index].d.pattern
+                );
+            }
             break;
         }
 
@@ -2039,7 +2152,13 @@ export function validateClassPattern(evaluator: TypeEvaluator, pattern: PatternC
 
         // Emits an error if the supplied number of positional patterns is less than
         // expected for the given subject type.
-        let positionalPatternCount = pattern.d.args.findIndex((arg) => arg.d.name !== undefined);
+        let positionalPatternCount = -1;
+        for (let i = 0; i < pattern.d.args.length; i++) {
+            if (pattern.d.args[i].d.name !== undefined) {
+                positionalPatternCount = i;
+                break;
+            }
+        }
         if (positionalPatternCount < 0) {
             positionalPatternCount = pattern.d.args.length;
         }
@@ -2047,7 +2166,14 @@ export function validateClassPattern(evaluator: TypeEvaluator, pattern: PatternC
         let expectedPatternCount = 1;
         if (!isBuiltIn) {
             let positionalArgNames: string[] = [];
-            if (pattern.d.args.some((arg) => !arg.d.name)) {
+            let hasPositionalArg = false;
+            for (let i = 0; i < pattern.d.args.length; i++) {
+                if (!pattern.d.args[i].d.name) {
+                    hasPositionalArg = true;
+                    break;
+                }
+            }
+            if (hasPositionalArg) {
                 positionalArgNames = getPositionalMatchArgNames(evaluator, exprType);
             }
 
@@ -2148,7 +2274,13 @@ export function getPatternSubtypeNarrowingCallback(
     // Look for a subject expression that contains the reference
     // expression as an entry in a tuple.
     if (subjectExpression.nodeType === ParseNodeType.Tuple) {
-        const matchingEntryIndex = subjectExpression.d.items.findIndex((expr) => isMatchingExpression(reference, expr));
+        let matchingEntryIndex = -1;
+        for (let i = 0; i < subjectExpression.d.items.length; i++) {
+            if (isMatchingExpression(reference, subjectExpression.d.items[i])) {
+                matchingEntryIndex = i;
+                break;
+            }
+        }
         if (matchingEntryIndex >= 0) {
             const typeResult = evaluator.getTypeOfExpression(subjectExpression.d.items[matchingEntryIndex]);
 
@@ -2161,10 +2293,20 @@ export function getPatternSubtypeNarrowingCallback(
                         isClassInstance(subtype) &&
                         ClassType.isBuiltIn(subtype, 'tuple') &&
                         subtype.priv.tupleTypeArgs &&
-                        matchingEntryIndex < subtype.priv.tupleTypeArgs.length &&
-                        subtype.priv.tupleTypeArgs.every((e) => !e.isUnbounded)
+                        matchingEntryIndex < subtype.priv.tupleTypeArgs.length
                     ) {
-                        narrowedSubtypes.push(subtype.priv.tupleTypeArgs[matchingEntryIndex].type);
+                        let allBounded = true;
+                        for (let ti = 0; ti < subtype.priv.tupleTypeArgs.length; ti++) {
+                            if (subtype.priv.tupleTypeArgs[ti].isUnbounded) {
+                                allBounded = false;
+                                break;
+                            }
+                        }
+                        if (allBounded) {
+                            narrowedSubtypes.push(subtype.priv.tupleTypeArgs[matchingEntryIndex].type);
+                        } else {
+                            canNarrow = false;
+                        }
                     } else if (isNever(narrowedSubjectType)) {
                         narrowedSubtypes.push(narrowedSubjectType);
                     } else {

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -232,7 +232,7 @@ export class Program {
 
         // Tell all source files we're no longer in edit mode. Gather
         // up all of their edits and find files that no longer needed.
-        mutatedFiles.forEach((fileInfo) => {
+        for (const fileInfo of mutatedFiles) {
             if (fileInfo.isCreatedInEditMode) {
                 filesToDelete.add(fileInfo);
             }
@@ -252,7 +252,7 @@ export class Program {
                     replacementText: newContents,
                 });
             }
-        });
+        }
 
         // Delete files added while in edit mode
         if (filesToDelete.size > 0) {
@@ -298,18 +298,18 @@ export class Program {
         if (this._sourceFileList.length > 0) {
             // We need to determine which files to remove from the existing file list.
             const newFileMap = new Map<string, Uri>();
-            fileUris.forEach((path) => {
+            for (const path of fileUris) {
                 newFileMap.set(path.key, path);
-            });
+            }
 
             // Files that are not in the tracked file list are
             // marked as no longer tracked.
-            this._sourceFileList.forEach((oldFile) => {
+            for (const oldFile of this._sourceFileList) {
                 const fileUri = oldFile.uri;
                 if (!newFileMap.has(fileUri.key)) {
                     oldFile.isTracked = false;
                 }
-            });
+            }
         }
 
         // Add the new files. Only the new items will be added.
@@ -334,9 +334,9 @@ export class Program {
     }
 
     addTrackedFiles(fileUris: Uri[], isThirdPartyImport = false, isInPyTypedPackage = false) {
-        fileUris.forEach((fileUri) => {
+        for (const fileUri of fileUris) {
             this.addTrackedFile(fileUri, isThirdPartyImport, isInPyTypedPackage);
-        });
+        }
     }
 
     addInterimFile(fileUri: Uri): SourceFileInfo {
@@ -468,7 +468,7 @@ export class Program {
     markAllFilesDirty(evenIfContentsAreSame: boolean) {
         const markDirtySet = new Set<string>();
 
-        this._sourceFileList.forEach((sourceFileInfo) => {
+        for (const sourceFileInfo of this._sourceFileList) {
             if (evenIfContentsAreSame) {
                 sourceFileInfo.sourceFile.markDirty();
             } else if (sourceFileInfo.sourceFile.didContentsChangeOnDisk()) {
@@ -478,7 +478,7 @@ export class Program {
                 // also. This will retrigger analysis of these other files.
                 this._markFileDirtyRecursive(sourceFileInfo, markDirtySet);
             }
-        });
+        }
 
         if (markDirtySet.size > 0) {
             this._createNewEvaluator();
@@ -487,7 +487,7 @@ export class Program {
 
     markFilesDirty(fileUris: Uri[], evenIfContentsAreSame: boolean) {
         const markDirtySet = new Set<string>();
-        fileUris.forEach((fileUri) => {
+        for (const fileUri of fileUris) {
             const sourceFileInfo = this.getSourceFileInfo(fileUri);
             if (sourceFileInfo) {
                 const fileName = fileUri.fileName;
@@ -496,7 +496,7 @@ export class Program {
                 // included by all source files.
                 if (fileName === 'builtins.pyi' || fileName === '__builtins__.pyi') {
                     this.markAllFilesDirty(evenIfContentsAreSame);
-                    return;
+                    continue;
                 }
 
                 // If !evenIfContentsAreSame, see if the on-disk contents have
@@ -513,7 +513,7 @@ export class Program {
                     this._markFileDirtyRecursive(sourceFileInfo, markDirtySet);
                 }
             }
-        });
+        }
 
         if (markDirtySet.size > 0) {
             this._createNewEvaluator();
@@ -560,7 +560,7 @@ export class Program {
             return { files: 0, cells: 0 };
         }
 
-        this._sourceFileList.forEach((fileInfo) => {
+        for (const fileInfo of this._sourceFileList) {
             const sourceFile = fileInfo.sourceFile;
             if (sourceFile.isCheckingRequired()) {
                 if (this._shouldCheckFile(fileInfo)) {
@@ -569,7 +569,7 @@ export class Program {
                         : filesToAnalyzeCount++;
                 }
             }
-        });
+        }
 
         return {
             files: filesToAnalyzeCount,
@@ -796,10 +796,10 @@ export class Program {
         this._console.info('');
         this._console.info('Analysis time by file');
 
-        sortedFiles.forEach((sfInfo) => {
+        for (const sfInfo of sortedFiles) {
             const checkTimeInMs = sfInfo.sourceFile.getCheckTime()!;
             this._console.info(`${checkTimeInMs}ms: ${sfInfo.uri}`);
-        });
+        }
     }
 
     // Prints import dependency information for each of the files in
@@ -814,7 +814,7 @@ export class Program {
 
         const zeroImportFiles: SourceFile[] = [];
 
-        sortedFiles.forEach((sfInfo) => {
+        for (const sfInfo of sortedFiles) {
             this._console.info('');
             const fileUri = fs.getOriginalUri(sfInfo.uri);
             let fileString = fileUri.toString();
@@ -829,33 +829,33 @@ export class Program {
                 ` Imports     ${sfInfo.imports.length} ` + `file${sfInfo.imports.length === 1 ? '' : 's'}`
             );
             if (verbose) {
-                sfInfo.imports.forEach((importInfo) => {
+                for (const importInfo of sfInfo.imports) {
                     this._console.info(`    ${fs.getOriginalUri(importInfo.uri)}`);
-                });
+                }
             }
 
             this._console.info(
                 ` Imported by ${sfInfo.importedBy.length} ` + `file${sfInfo.importedBy.length === 1 ? '' : 's'}`
             );
             if (verbose) {
-                sfInfo.importedBy.forEach((importInfo) => {
+                for (const importInfo of sfInfo.importedBy) {
                     this._console.info(`    ${fs.getOriginalUri(importInfo.uri)}`);
-                });
+                }
             }
 
             if (sfInfo.importedBy.length === 0) {
                 zeroImportFiles.push(sfInfo.sourceFile);
             }
-        });
+        }
 
         if (zeroImportFiles.length > 0) {
             this._console.info('');
             this._console.info(
                 `${zeroImportFiles.length} file${zeroImportFiles.length === 1 ? '' : 's'}` + ` not explicitly imported`
             );
-            zeroImportFiles.forEach((importFile) => {
+            for (const importFile of zeroImportFiles) {
                 this._console.info(`    ${fs.getOriginalUri(importFile.getUri())}`);
-            });
+            }
         }
     }
 
@@ -946,7 +946,7 @@ export class Program {
     getDiagnostics(options: ConfigOptions, reportDeltasOnly = true): FileDiagnostics[] {
         const fileDiagnostics: FileDiagnostics[] = this._removeUnneededFiles();
 
-        this._sourceFileList.forEach((sourceFileInfo) => {
+        for (const sourceFileInfo of this._sourceFileList) {
             if (this._shouldCheckFile(sourceFileInfo)) {
                 let diagnostics = sourceFileInfo.sourceFile.getDiagnostics(
                     options,
@@ -983,7 +983,7 @@ export class Program {
                 });
                 sourceFileInfo.diagnosticsVersion = undefined;
             }
-        });
+        }
 
         return fileDiagnostics;
     }
@@ -1062,7 +1062,12 @@ export class Program {
         this._discardCachedParseResults();
         this._parsedFileCount = 0;
 
-        this.serviceProvider.tryGet(ServiceKeys.stateMutationListeners)?.forEach((l) => l.onClearCache?.());
+        const listeners = this.serviceProvider.tryGet(ServiceKeys.stateMutationListeners);
+        if (listeners) {
+            for (const l of listeners) {
+                l.onClearCache?.();
+            }
+        }
     }
 
     bindShadowFile(stubFileUri: Uri, shadowFile: Uri): SourceFile | undefined {
@@ -1188,10 +1193,10 @@ export class Program {
 
                 // Unlink any imports and remove them from the list if
                 // they are no longer referenced.
-                fileInfo.imports.forEach((importedFile) => {
+                for (const importedFile of fileInfo.imports) {
                     const indexToRemove = importedFile.importedBy.findIndex((fi) => fi === fileInfo);
                     if (indexToRemove < 0) {
-                        return;
+                        continue;
                     }
 
                     importedFile.mutate((s) => s.importedBy.splice(indexToRemove, 1));
@@ -1216,12 +1221,12 @@ export class Program {
                             i--;
                         }
                     }
-                });
+                }
 
                 // Remove any shadowed files corresponding to this file.
-                fileInfo.shadowedBy.forEach((shadowedFile) => {
+                for (const shadowedFile of fileInfo.shadowedBy) {
                     shadowedFile.mutate((s) => (s.shadows = s.shadows.filter((f) => f !== fileInfo)));
-                });
+                }
                 fileInfo.mutate((s) => (s.shadowedBy = []));
             } else {
                 // If we're showing the user errors only for open files, clear
@@ -1454,7 +1459,7 @@ export class Program {
             }
         }
 
-        imports.forEach((importResult) => {
+        for (const importResult of imports) {
             if (importResult.isImportFound) {
                 if (this._isImportAllowed(sourceFileInfo, importResult, importResult.isStubFile)) {
                     if (importResult.resolvedUris.length > 0) {
@@ -1472,20 +1477,22 @@ export class Program {
                     }
                 }
 
-                importResult.filteredImplicitImports?.forEach((implicitImport) => {
-                    if (this._isImportAllowed(sourceFileInfo, importResult, implicitImport.isStubFile)) {
-                        if (!implicitImport.isNativeLib) {
-                            const thirdPartyTypeInfo = getThirdPartyImportInfo(importResult);
-                            newImportPathMap.set(implicitImport.uri.key, {
-                                path: implicitImport.uri,
-                                isTypeshedFile:
-                                    !!importResult.isStdlibTypeshedFile || !!importResult.isThirdPartyTypeshedFile,
-                                isThirdPartyImport: thirdPartyTypeInfo.isThirdPartyImport,
-                                isPyTypedPresent: thirdPartyTypeInfo.isPyTypedPresent,
-                            });
+                if (importResult.filteredImplicitImports) {
+                    for (const implicitImport of importResult.filteredImplicitImports.values()) {
+                        if (this._isImportAllowed(sourceFileInfo, importResult, implicitImport.isStubFile)) {
+                            if (!implicitImport.isNativeLib) {
+                                const thirdPartyTypeInfo = getThirdPartyImportInfo(importResult);
+                                newImportPathMap.set(implicitImport.uri.key, {
+                                    path: implicitImport.uri,
+                                    isTypeshedFile:
+                                        !!importResult.isStdlibTypeshedFile || !!importResult.isThirdPartyTypeshedFile,
+                                    isThirdPartyImport: thirdPartyTypeInfo.isThirdPartyImport,
+                                    isPyTypedPresent: thirdPartyTypeInfo.isPyTypedPresent,
+                                });
+                            }
                         }
                     }
-                });
+                }
 
                 // If the stub was found but the non-stub (source) file was not, dump
                 // the failure to the log for diagnostic purposes.
@@ -1501,9 +1508,9 @@ export class Program {
                             );
 
                             if (importResult.nonStubImportResult.importFailureInfo) {
-                                importResult.nonStubImportResult.importFailureInfo.forEach((diag) => {
+                                for (const diag of importResult.nonStubImportResult.importFailureInfo) {
                                     this._console.info(`  ${diag}`);
-                                });
+                                }
                             }
                         }
                     }
@@ -1514,15 +1521,15 @@ export class Program {
                         `in file '${sourceFileInfo.uri.toUserVisibleString()}'`
                 );
                 if (importResult.importFailureInfo) {
-                    importResult.importFailureInfo.forEach((diag) => {
+                    for (const diag of importResult.importFailureInfo) {
                         this._console.info(`  ${diag}`);
-                    });
+                    }
                 }
             }
-        });
+        }
 
         const updatedImportMap = new Map<string, SourceFileInfo>();
-        sourceFileInfo.imports.forEach((importInfo) => {
+        for (const importInfo of sourceFileInfo.imports) {
             const oldFilePath = importInfo.uri;
 
             // A previous import was removed.
@@ -1533,10 +1540,10 @@ export class Program {
             } else {
                 updatedImportMap.set(oldFilePath.key, importInfo);
             }
-        });
+        }
 
         // See if there are any new imports to be added.
-        newImportPathMap.forEach((importInfo, normalizedImportPath) => {
+        for (const [normalizedImportPath, importInfo] of newImportPathMap) {
             if (!updatedImportMap.has(normalizedImportPath)) {
                 // We found a new import to add. See if it's already part
                 // of the program.
@@ -1567,17 +1574,17 @@ export class Program {
                 importedFileInfo.mutate((s) => s.importedBy.push(sourceFileInfo));
                 updatedImportMap.set(normalizedImportPath, importedFileInfo);
             }
-        });
+        }
 
         // Update the imports list. It should now map the set of imports
         // specified by the source file.
         const newImports: SourceFileInfo[] = [];
-        newImportPathMap.forEach((_, key) => {
+        for (const [key] of newImportPathMap) {
             const newImport = this._getSourceFileInfoFromKey(key);
             if (newImport) {
                 newImports.push(newImport);
             }
-        });
+        }
 
         // Mutate only when necessary to avoid extra binding operations.
         if (
@@ -1866,9 +1873,11 @@ export class Program {
     private _getEffectiveFutureImports(futureImports: Set<string>, chainedSourceFile: SourceFileInfo): Set<string> {
         const effectiveFutureImports = new Set<string>(futureImports);
 
-        chainedSourceFile.effectiveFutureImports?.forEach((value) => {
-            effectiveFutureImports.add(value);
-        });
+        if (chainedSourceFile.effectiveFutureImports) {
+            for (const value of chainedSourceFile.effectiveFutureImports) {
+                effectiveFutureImports.add(value);
+            }
+        }
 
         return effectiveFutureImports;
     }
@@ -2047,7 +2056,7 @@ export class Program {
                     const closureMap = new Map<string, SourceFileInfo>();
                     this._getImportsRecursive(fileToCheck, closureMap, 0);
 
-                    closureMap.forEach((file) => {
+                    for (const file of closureMap.values()) {
                         timingStats.cycleDetectionTime.timeOperation(() => {
                             const filesVisitedMap = new Map<string, SourceFileInfo>();
 
@@ -2055,12 +2064,12 @@ export class Program {
                                 // If no cycles were found in any of the files we visited,
                                 // set a flag to indicates that we don't need to visit them again
                                 // on subsequent cycle checks.
-                                filesVisitedMap.forEach((sourceFileInfo) => {
+                                for (const sourceFileInfo of filesVisitedMap.values()) {
                                     sourceFileInfo.sourceFile.setNoCircularDependencyConfirmed();
-                                });
+                                }
                             }
                         });
-                    });
+                    }
                 }
             }
 
@@ -2233,9 +2242,9 @@ export class Program {
 
     private _logImportCycle(dependencyChain: SourceFileInfo[]) {
         const circDep = new CircularDependency();
-        dependencyChain.forEach((sourceFileInfo) => {
+        for (const sourceFileInfo of dependencyChain) {
             circDep.appendPath(sourceFileInfo.uri);
-        });
+        }
 
         circDep.normalizeOrder();
         const firstFilePath = circDep.getPaths()[0];
@@ -2255,12 +2264,12 @@ export class Program {
         sourceFileInfo.sourceFile.markReanalysisRequired(forceRebinding);
         markSet.add(fileUri.key);
 
-        sourceFileInfo.importedBy.forEach((dep) => {
+        for (const dep of sourceFileInfo.importedBy) {
             // Changes on chained source file can change symbols in the symbol table and
             // dependencies on the dependent file. Force rebinding.
             const forceRebinding = dep.chainedSourceFile === sourceFileInfo;
             this._markFileDirtyRecursive(dep, markSet, forceRebinding);
-        });
+        }
 
         // Change in the current file could impact checker result of chainedSourceFile such as unused symbols.
         let reevaluationRequired = false;

--- a/packages/pyright-internal/src/analyzer/properties.ts
+++ b/packages/pyright-internal/src/analyzer/properties.ts
@@ -77,15 +77,13 @@ export function createProperty(
 
     // Clone the symbol table of the old class type.
     const fields = ClassType.getSymbolTable(propertyClass);
-    ClassType.getSymbolTable(decoratorType).forEach((symbol, name) => {
-        const ignoredMethods = ['__get__', '__set__', '__delete__'];
-
+    for (const [name, symbol] of ClassType.getSymbolTable(decoratorType)) {
         if (!symbol.isIgnoredForProtocolMatch()) {
-            if (!ignoredMethods.some((m) => m === name)) {
+            if (name !== '__get__' && name !== '__set__' && name !== '__delete__') {
                 fields.set(name, symbol);
             }
         }
-    });
+    }
 
     const propertyObject = ClassType.cloneAsInstance(propertyClass);
     propertyClass.priv.isAsymmetricDescriptor = false;
@@ -183,11 +181,11 @@ export function clonePropertyWithSetter(
 
     // Clone the symbol table of the old class type.
     const fields = ClassType.getSymbolTable(propertyClass);
-    ClassType.getSymbolTable(classType).forEach((symbol, name) => {
+    for (const [name, symbol] of ClassType.getSymbolTable(classType)) {
         if (!symbol.isIgnoredForProtocolMatch()) {
             fields.set(name, symbol);
         }
-    });
+    }
 
     // Update the __get__ and __delete__ methods if present.
     updateGetSetDelMethodForClonedProperty(evaluator, propertyObject);
@@ -242,11 +240,11 @@ export function clonePropertyWithDeleter(
 
     // Clone the symbol table of the old class type.
     const fields = ClassType.getSymbolTable(propertyClass);
-    ClassType.getSymbolTable(classType).forEach((symbol, name) => {
+    for (const [name, symbol] of ClassType.getSymbolTable(classType)) {
         if (!symbol.isIgnoredForProtocolMatch()) {
             fields.set(name, symbol);
         }
-    });
+    }
 
     // Update the __get__ and __set__ methods if present.
     updateGetSetDelMethodForClonedProperty(evaluator, propertyObject);
@@ -448,7 +446,7 @@ function addDecoratorMethodsToPropertySymbolTable(propertyObject: ClassType) {
     const fields = ClassType.getSymbolTable(propertyObject);
 
     // Fill in the getter, setter and deleter methods.
-    ['getter', 'setter', 'deleter'].forEach((accessorName) => {
+    for (const accessorName of ['getter', 'setter', 'deleter']) {
         const accessorFunction = FunctionType.createSynthesizedInstance(accessorName);
         FunctionType.addParam(
             accessorFunction,
@@ -461,7 +459,7 @@ function addDecoratorMethodsToPropertySymbolTable(propertyObject: ClassType) {
         accessorFunction.shared.declaredReturnType = propertyObject;
         const accessorSymbol = Symbol.createWithType(SymbolFlags.ClassMember, accessorFunction);
         fields.set(accessorName, accessorSymbol);
-    });
+    }
 }
 
 export function assignProperty(
@@ -500,7 +498,7 @@ export function assignProperty(
         },
     ];
 
-    accessors.forEach((accessorInfo) => {
+    for (const accessorInfo of accessors) {
         let destAccessType = accessorInfo.getFunction(destPropertyType);
 
         if (destAccessType && isFunction(destAccessType)) {
@@ -509,7 +507,7 @@ export function assignProperty(
             if (!srcAccessType || !isFunction(srcAccessType)) {
                 diag?.addMessage(accessorInfo.missingDiagMsg());
                 isAssignable = false;
-                return;
+                continue;
             }
 
             evaluator.inferReturnTypeIfNecessary(srcAccessType);
@@ -556,7 +554,7 @@ export function assignProperty(
                 isAssignable = false;
             }
         }
-    });
+    }
 
     return isAssignable;
 }

--- a/packages/pyright-internal/src/analyzer/protocols.ts
+++ b/packages/pyright-internal/src/analyzer/protocols.ts
@@ -32,6 +32,7 @@ import {
     OverloadedType,
     Type,
     TypeBase,
+    TypeSameOptions,
     TypeVarType,
     UnknownType,
     Variance,
@@ -50,6 +51,8 @@ import {
     selfSpecializeClass,
     synthesizeTypeVarForSelfCls,
 } from './typeUtils';
+
+const _typeArgExplicitFormOptions: TypeSameOptions = { honorIsTypeArgExplicit: true, honorTypeForm: true };
 
 interface ProtocolAssignmentStackEntry {
     srcType: ClassType;
@@ -268,8 +271,8 @@ function getProtocolCompatibility(
         }
 
         if (
-            isTypeSame(entry.destType, destType, { honorIsTypeArgExplicit: true, honorTypeForm: true }) &&
-            isTypeSame(entry.srcType, srcType, { honorIsTypeArgExplicit: true, honorTypeForm: true }) &&
+            isTypeSame(entry.destType, destType, _typeArgExplicitFormOptions) &&
+            isTypeSame(entry.srcType, srcType, _typeArgExplicitFormOptions) &&
             isConstraintTrackerSame(constraints, entry.preConstraints)
         ) {
             return entry;

--- a/packages/pyright-internal/src/analyzer/protocols.ts
+++ b/packages/pyright-internal/src/analyzer/protocols.ts
@@ -32,6 +32,7 @@ import {
     OverloadedType,
     Type,
     TypeBase,
+    TypeCondition,
     TypeSameOptions,
     TypeVarType,
     UnknownType,
@@ -101,11 +102,14 @@ export function assignClassToProtocol(
 
     // Use a stack of pending protocol class evaluations to detect recursion.
     // This can happen when a protocol class refers to itself.
-    if (
-        protocolAssignmentStack.some((entry) => {
-            return isTypeSame(entry.srcType, srcType) && isTypeSame(entry.destType, destType);
-        })
-    ) {
+    let isRecursive = false;
+    for (const entry of protocolAssignmentStack) {
+        if (isTypeSame(entry.srcType, srcType) && isTypeSame(entry.destType, destType)) {
+            isRecursive = true;
+            break;
+        }
+    }
+    if (isRecursive) {
         return !enforceInvariance;
     }
 
@@ -192,8 +196,10 @@ export function isMethodOnlyProtocol(classType: ClassType): boolean {
             continue;
         }
 
-        if (symbol.getDeclarations().some((decl) => decl.type !== DeclarationType.Function)) {
-            return false;
+        for (const decl of symbol.getDeclarations()) {
+            if (decl.type !== DeclarationType.Function) {
+                return false;
+            }
         }
     }
 
@@ -211,14 +217,14 @@ export function isProtocolUnsafeOverlap(evaluator: TypeEvaluator, protocol: Clas
 
     let isUnsafeOverlap = true;
 
-    protocol.shared.mro.forEach((mroClass) => {
+    for (const mroClass of protocol.shared.mro) {
         if (!isUnsafeOverlap || !isInstantiableClass(mroClass) || !ClassType.isProtocolClass(mroClass)) {
-            return;
+            continue;
         }
 
-        ClassType.getSymbolTable(mroClass).forEach((destSymbol, name) => {
+        for (const [name, destSymbol] of ClassType.getSymbolTable(mroClass)) {
             if (!isUnsafeOverlap || !destSymbol.isClassMember() || destSymbol.isIgnoredForProtocolMatch()) {
-                return;
+                continue;
             }
 
             // Does the classType have a member with the same name?
@@ -226,8 +232,8 @@ export function isProtocolUnsafeOverlap(evaluator: TypeEvaluator, protocol: Clas
             if (!srcMemberInfo) {
                 isUnsafeOverlap = false;
             }
-        });
-    });
+        }
+    }
 
     return isUnsafeOverlap;
 }
@@ -309,10 +315,15 @@ function setProtocolCompatibility(
     // and the destType are specialized.
     let isAlwaysIncompatible = false;
 
-    if (
-        !isCompatible &&
-        !entries.some((entry) => entry.flags === flags && ClassType.isSameGenericClass(entry.destType, destType))
-    ) {
+    let hasMatchingEntry = false;
+    for (const entry of entries) {
+        if (entry.flags === flags && ClassType.isSameGenericClass(entry.destType, destType)) {
+            hasMatchingEntry = true;
+            break;
+        }
+    }
+
+    if (!isCompatible && !hasMatchingEntry) {
         const genericDestType = requiresTypeArgs(destType)
             ? selfSpecializeClass(destType, { overrideTypeArgs: true })
             : destType;
@@ -383,7 +394,15 @@ function assignToProtocolInternal(
     if (isClass(srcType)) {
         // If the srcType is conditioned on "self", use "Self" as the selfType.
         // Otherwise use the class type for selfType.
-        const synthCond = srcType.props?.condition?.find((c) => TypeVarType.isSelf(c.typeVar));
+        let synthCond: TypeCondition | undefined;
+        if (srcType.props?.condition) {
+            for (const c of srcType.props.condition) {
+                if (TypeVarType.isSelf(c.typeVar)) {
+                    synthCond = c;
+                    break;
+                }
+            }
+        }
         if (synthCond) {
             selfType = synthesizeTypeVarForSelfCls(
                 TypeBase.cloneForCondition(srcType, undefined),
@@ -418,26 +437,26 @@ function assignToProtocolInternal(
         ? AssignTypeFlags.RetainLiteralsForTypeVar
         : AssignTypeFlags.Default;
 
-    destType.shared.mro.forEach((mroClass) => {
+    for (const mroClass of destType.shared.mro) {
         if (!isInstantiableClass(mroClass) || !ClassType.isProtocolClass(mroClass)) {
-            return;
+            continue;
         }
 
         // If we've already determined that the types are not consistent and the caller
         // hasn't requested detailed diagnostic output, we can shortcut the remainder.
         if (!typesAreConsistent && !diag) {
-            return;
+            continue;
         }
 
-        ClassType.getSymbolTable(mroClass).forEach((destSymbol, name) => {
+        for (const [name, destSymbol] of ClassType.getSymbolTable(mroClass)) {
             // If we've already determined that the types are not consistent and the caller
             // hasn't requested detailed diagnostic output, we can shortcut the remainder.
             if (!typesAreConsistent && !diag) {
-                return;
+                continue;
             }
 
             if (!destSymbol.isClassMember() || destSymbol.isIgnoredForProtocolMatch() || checkedSymbolSet.has(name)) {
-                return;
+                continue;
             }
 
             let isMemberFromMetaclass = false;
@@ -447,13 +466,13 @@ function assignToProtocolInternal(
             // Special-case the `__class_getitem__` for normal protocol comparison.
             // This is a convention agreed upon by typeshed maintainers.
             if (!sourceIsClassObject && name === '__class_getitem__') {
-                return;
+                continue;
             }
 
             // Special-case the `__slots__` entry for all protocol comparisons.
             // This is a convention agreed upon by typeshed maintainers.
             if (name === '__slots__') {
-                return;
+                continue;
             }
 
             // Note that we've already checked this symbol. It doesn't need to
@@ -462,7 +481,7 @@ function assignToProtocolInternal(
 
             let destMemberType = evaluator.getDeclaredTypeOfSymbol(destSymbol)?.type;
             if (!destMemberType) {
-                return;
+                continue;
             }
 
             let srcMemberType: Type;
@@ -489,7 +508,7 @@ function assignToProtocolInternal(
                 if (!srcMemberInfo) {
                     diag?.addMessage(LocAddendum.protocolMemberMissing().format({ name }));
                     typesAreConsistent = false;
-                    return;
+                    continue;
                 }
 
                 srcSymbol = srcMemberInfo.symbol;
@@ -532,8 +551,11 @@ function assignToProtocolInternal(
                         // Special-case dataclasses whose entries act like instance members.
                         if (ClassType.isDataClass(srcType)) {
                             const dataClassFields = ClassType.getDataClassEntries(srcType);
-                            if (dataClassFields.some((entry) => entry.name === name)) {
-                                isInstanceMember = true;
+                            for (const entry of dataClassFields) {
+                                if (entry.name === name) {
+                                    isInstanceMember = true;
+                                    break;
+                                }
                             }
                         }
 
@@ -559,7 +581,7 @@ function assignToProtocolInternal(
                                 srcMemberType = boundSrcFunction;
                             } else {
                                 typesAreConsistent = false;
-                                return;
+                                continue;
                             }
                         }
                     }
@@ -574,7 +596,7 @@ function assignToProtocolInternal(
                 if (!srcSymbol) {
                     diag?.addMessage(LocAddendum.protocolMemberMissing().format({ name }));
                     typesAreConsistent = false;
-                    return;
+                    continue;
                 }
 
                 srcMemberType = evaluator.getEffectiveTypeOfSymbol(srcSymbol);
@@ -621,18 +643,26 @@ function assignToProtocolInternal(
                     destMemberType = boundDeclaredType;
                 } else {
                     typesAreConsistent = false;
-                    return;
+                    continue;
                 }
             }
 
             const subDiag = diag?.createAddendum();
 
-            const isDestFinal = destSymbol
-                .getTypedDeclarations()
-                .some((decl) => decl.type === DeclarationType.Variable && !!decl.isFinal);
-            const isSrcFinal = srcSymbol
-                .getTypedDeclarations()
-                .some((decl) => decl.type === DeclarationType.Variable && !!decl.isFinal);
+            let isDestFinal = false;
+            for (const decl of destSymbol.getTypedDeclarations()) {
+                if (decl.type === DeclarationType.Variable && !!decl.isFinal) {
+                    isDestFinal = true;
+                    break;
+                }
+            }
+            let isSrcFinal = false;
+            for (const decl of srcSymbol.getTypedDeclarations()) {
+                if (decl.type === DeclarationType.Variable && !!decl.isFinal) {
+                    isSrcFinal = true;
+                    break;
+                }
+            }
 
             if (isSrcFinal) {
                 isSrcReadOnly = true;
@@ -752,7 +782,13 @@ function assignToProtocolInternal(
                 srcSymbol,
                 /* isDataclass */ isClass(srcType) && ClassType.isDataClass(srcType)
             );
-            const isSrcVariable = srcSymbol.getDeclarations().some((decl) => decl.type === DeclarationType.Variable);
+            let isSrcVariable = false;
+            for (const decl of srcSymbol.getDeclarations()) {
+                if (decl.type === DeclarationType.Variable) {
+                    isSrcVariable = true;
+                    break;
+                }
+            }
 
             if (sourceIsClassObject) {
                 // If the source is not marked as a ClassVar or the dest (the protocol) is,
@@ -801,8 +837,8 @@ function assignToProtocolInternal(
                     typesAreConsistent = false;
                 }
             }
-        });
-    });
+        }
+    }
 
     // If the dest protocol has type parameters, make sure the source type arguments match.
     if (typesAreConsistent && destType.shared.typeParams.length > 0) {
@@ -844,7 +880,9 @@ function createProtocolConstraints(
 ): ConstraintTracker {
     const protocolConstraints = new ConstraintTracker();
 
-    destType.shared.typeParams.forEach((typeParam, index) => {
+    const typeParams = destType.shared.typeParams;
+    for (let index = 0; index < typeParams.length; index++) {
+        const typeParam = typeParams[index];
         const entry = constraints?.getMainConstraintSet().getTypeVar(typeParam);
 
         if (entry) {
@@ -877,7 +915,7 @@ function createProtocolConstraints(
                 assignTypeVar(evaluator, typeParam, typeArg, /* diag */ undefined, protocolConstraints, flags);
             }
         }
-    });
+    }
 
     return protocolConstraints;
 }

--- a/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
@@ -67,7 +67,7 @@ export function findPythonSearchPaths(
         const foundPaths: Uri[] = [];
         const sitePackagesPaths: Uri[] = [];
 
-        [pathConsts.lib, pathConsts.lib64, pathConsts.libAlternate].forEach((libPath) => {
+        for (const libPath of [pathConsts.lib, pathConsts.lib64, pathConsts.libAlternate]) {
             const sitePackagesPath = findSitePackagesPath(
                 fs,
                 venvPath.combinePaths(libPath),
@@ -78,21 +78,21 @@ export function findPythonSearchPaths(
                 addPathIfUnique(foundPaths, sitePackagesPath);
                 sitePackagesPaths.push(fs.realCasePath(sitePackagesPath));
             }
-        });
+        }
 
         // Now add paths from ".pth" files located in each of the site packages folders.
-        sitePackagesPaths.forEach((sitePackagesPath) => {
+        for (const sitePackagesPath of sitePackagesPaths) {
             const pthPaths = getPathsFromPthFiles(fs, sitePackagesPath);
-            pthPaths.forEach((path) => {
+            for (const path of pthPaths) {
                 addPathIfUnique(foundPaths, path);
-            });
-        });
+            }
+        }
 
         if (foundPaths.length > 0) {
             importLogger?.log(`Found the following '${pathConsts.sitePackages}' dirs`);
-            foundPaths.forEach((path) => {
+            for (const path of foundPaths) {
                 importLogger?.log(`  ${path}`);
-            });
+            }
             return foundPaths;
         }
 
@@ -182,7 +182,7 @@ export function readPthSearchPaths(pthFile: Uri, fs: FileSystem): Uri[] {
     if (fs.existsSync(pthFile)) {
         const data = fs.readFileSync(pthFile, 'utf8');
         const lines = data.split(/\r?\n/);
-        lines.forEach((line) => {
+        for (const line of lines) {
             const trimmedLine = line.trim();
             if (trimmedLine.length > 0 && !trimmedLine.startsWith('#') && !trimmedLine.match(/^import\s/)) {
                 const pthPath = pthFile.getDirectory().combinePaths(trimmedLine);
@@ -190,7 +190,7 @@ export function readPthSearchPaths(pthFile: Uri, fs: FileSystem): Uri[] {
                     searchPaths.push(fs.realCasePath(pthPath));
                 }
             }
-        });
+        }
     }
 
     return searchPaths;
@@ -205,7 +205,7 @@ export function getPathsFromPthFiles(fs: FileSystem, parentDir: Uri): Uri[] {
         .filter((entry) => (entry.isFile() || entry.isSymbolicLink()) && entry.name.endsWith('.pth'))
         .sort((a, b) => compareComparableValues(a.name, b.name));
 
-    pthFiles.forEach((pthFile) => {
+    for (const pthFile of pthFiles) {
         const filePath = fs.realCasePath(parentDir.combinePaths(pthFile.name));
         const fileStats = tryStat(fs, filePath);
 
@@ -213,7 +213,7 @@ export function getPathsFromPthFiles(fs: FileSystem, parentDir: Uri): Uri[] {
         if (fileStats?.isFile() && fileStats.size > 0 && fileStats.size < 64 * 1024) {
             searchPaths.push(...readPthSearchPaths(filePath, fs));
         }
-    });
+    }
 
     return searchPaths;
 }

--- a/packages/pyright-internal/src/analyzer/scope.ts
+++ b/packages/pyright-internal/src/analyzer/scope.ts
@@ -10,7 +10,7 @@
  */
 
 import { fail } from '../common/debug';
-import { DeclarationType } from './declaration';
+import { Declaration, DeclarationType } from './declaration';
 import { Symbol, SymbolFlags, SymbolTable } from './symbol';
 
 export const enum ScopeType {
@@ -160,10 +160,7 @@ export class Scope {
             // If the symbol is a class variable that is defined only in terms of
             // member accesses, it is not accessible directly by name, so hide it.
             const decls = symbol.getDeclarations();
-            if (
-                decls.length === 0 ||
-                decls.some((decl) => decl.type !== DeclarationType.Variable || !decl.isDefinedByMemberAccess)
-            ) {
+            if (decls.length === 0 || _hasNonMemberAccessDecl(decls)) {
                 return {
                     symbol,
                     isOutsideCallerModule: !!options?.isOutsideCallerModule,
@@ -227,4 +224,13 @@ export class Scope {
     getSlotsNames(): string[] | undefined {
         return this.slotsNames;
     }
+}
+
+function _hasNonMemberAccessDecl(decls: Declaration[]): boolean {
+    for (const decl of decls) {
+        if (decl.type !== DeclarationType.Variable || !decl.isDefinedByMemberAccess) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/packages/pyright-internal/src/analyzer/sentinel.ts
+++ b/packages/pyright-internal/src/analyzer/sentinel.ts
@@ -34,7 +34,11 @@ export function createSentinelType(
         nameArg.valueExpression &&
         nameArg.valueExpression.nodeType === ParseNodeType.StringList
     ) {
-        className = nameArg.valueExpression.d.strings.map((s) => s.d.value).join('');
+        let joined = '';
+        for (const s of nameArg.valueExpression.d.strings) {
+            joined += s.d.value;
+        }
+        className = joined;
     }
 
     if (!className) {

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -566,11 +566,11 @@ export class AnalyzerService {
             // Update the config options to include the auto-excluded directories.
             const excludes = this.options.configOptions?.exclude;
             if (enumResults.autoExcludedDirs && excludes) {
-                enumResults.autoExcludedDirs.forEach((excludedDir) => {
+                for (const excludedDir of enumResults.autoExcludedDirs) {
                     if (!FileSpec.isInPath(excludedDir, excludes)) {
                         excludes.push(getFileSpec(this._configOptions.projectRoot, `${excludedDir}/**`));
                     }
-                });
+                }
                 this._backgroundAnalysisProgram.setConfigOptions(this._configOptions);
             }
 
@@ -694,9 +694,9 @@ export class AnalyzerService {
                 log(this._console, logLevel, `Execution environment: ${execEnv.name}`);
                 log(this._console, logLevel, `  Extra paths:`);
                 if (execEnv.extraPaths.length > 0) {
-                    execEnv.extraPaths.forEach((path) => {
+                    for (const path of execEnv.extraPaths) {
                         log(this._console, logLevel, `    ${path.toUserVisibleString()}`);
-                    });
+                    }
                 } else {
                     log(this._console, logLevel, `    (none)`);
                 }
@@ -704,9 +704,9 @@ export class AnalyzerService {
                 log(this._console, logLevel, `  Python platform: ${execEnv.pythonPlatform ?? 'All'}`);
                 log(this._console, logLevel, `  Search paths:`);
                 const roots = importResolver.getImportRoots(execEnv, /* forLogging */ true);
-                roots.forEach((path) => {
+                for (const path of roots) {
                     log(this._console, logLevel, `    ${path.toUserVisibleString()}`);
-                });
+                }
             }
         }
 
@@ -923,10 +923,10 @@ export class AnalyzerService {
         // If there was no explicit set of excludes, add a few common ones to
         // avoid long scan times.
         if (configOptions.exclude.length === 0) {
-            defaultExcludes.forEach((exclude) => {
+            for (const exclude of defaultExcludes) {
                 this._console.info(`Auto-excluding ${exclude}`);
                 configOptions.exclude.push(getFileSpec(projectRoot, exclude));
-            });
+            }
 
             if (configOptions.autoExcludeVenv === undefined) {
                 configOptions.autoExcludeVenv = true;
@@ -963,10 +963,10 @@ export class AnalyzerService {
             );
 
             this._console.info(`Excluding typeshed stdlib stubs according to VERSIONS file:`);
-            excludeList.forEach((exclude) => {
+            for (const exclude of excludeList) {
                 this._console.info(`    ${exclude}`);
                 configOptions.exclude.push(getFileSpec(executionRoot, exclude.getFilePath()));
-            });
+            }
         }
 
         // If useLibraryCodeForTypes is unspecified, default it to true.
@@ -1013,9 +1013,11 @@ export class AnalyzerService {
                                 `${configOptions.venvPath.toUserVisibleString()} and venv ${configOptions.venv}.`
                         );
 
-                        importLogger?.getLogs().forEach((diag) => {
-                            this._console.error(`  ${diag}`);
-                        });
+                        if (importLogger) {
+                            for (const diag of importLogger.getLogs()) {
+                                this._console.error(`  ${diag}`);
+                            }
+                        }
                     }
                 }
             }
@@ -1127,17 +1129,17 @@ export class AnalyzerService {
             configOptions.pythonEnvironmentName = commandLineOptions.pythonEnvironmentName;
         }
 
-        commandLineOptions.includeFileSpecs.forEach((fileSpec) => {
+        for (const fileSpec of commandLineOptions.includeFileSpecs) {
             configOptions.include.push(getFileSpec(projectRoot, fileSpec));
-        });
+        }
 
-        commandLineOptions.excludeFileSpecs.forEach((fileSpec) => {
+        for (const fileSpec of commandLineOptions.excludeFileSpecs) {
             configOptions.exclude.push(getFileSpec(projectRoot, fileSpec));
-        });
+        }
 
-        commandLineOptions.ignoreFileSpecs.forEach((fileSpec) => {
+        for (const fileSpec of commandLineOptions.ignoreFileSpecs) {
             configOptions.ignore.push(getFileSpec(projectRoot, fileSpec));
-        });
+        }
 
         configOptions.applyDiagnosticOverrides(commandLineOptions.diagnosticSeverityOverrides);
         configOptions.applyDiagnosticOverrides(commandLineOptions.diagnosticBooleanOverrides);
@@ -1151,11 +1153,11 @@ export class AnalyzerService {
         // Override the include based on command-line settings.
         if (commandLineOptions.includeFileSpecsOverride) {
             configOptions.include = [];
-            commandLineOptions.includeFileSpecsOverride.forEach((include) => {
+            for (const include of commandLineOptions.includeFileSpecsOverride) {
                 configOptions.include.push(
                     getFileSpec(Uri.file(include, this.serviceProvider, /* checkRelative */ true), '.')
                 );
-            });
+            }
         }
 
         // Override the venvPath based on the command-line setting.
@@ -1385,11 +1387,12 @@ export class AnalyzerService {
     private _getTrackedFileList(fileMap: Map<string, Uri>): Uri[] {
         // And scan all matching open files. We need to do this since some of files are not backed by
         // files in file system but only exist in memory (ex, virtual workspace)
-        this._backgroundAnalysisProgram.program
-            .getOpened()
-            .map((o) => o.uri)
-            .filter((f) => f.isUntitled() || matchFileSpecs(this._program.configOptions, f))
-            .forEach((f) => fileMap.set(f.key, f));
+        for (const opened of this._backgroundAnalysisProgram.program.getOpened()) {
+            const f = opened.uri;
+            if (f.isUntitled() || matchFileSpecs(this._program.configOptions, f)) {
+                fileMap.set(f.key, f);
+            }
+        }
 
         const fileList = Array.from(fileMap.values());
         return fileList;
@@ -1455,11 +1458,13 @@ export class AnalyzerService {
                 }
 
                 // Add the implicit import paths.
-                importResult.filteredImplicitImports?.forEach((implicitImport) => {
-                    if (ImportResolver.isSupportedImportSourceFile(implicitImport.uri)) {
-                        filesToImport.push(implicitImport.uri);
+                if (importResult.filteredImplicitImports) {
+                    for (const [, implicitImport] of importResult.filteredImplicitImports) {
+                        if (ImportResolver.isSupportedImportSourceFile(implicitImport.uri)) {
+                            filesToImport.push(implicitImport.uri);
+                        }
                     }
-                });
+                }
 
                 this._backgroundAnalysisProgram.setAllowedThirdPartyImports([this._typeStubTargetImportName]);
                 this._backgroundAnalysisProgram.setTrackedFiles(filesToImport);

--- a/packages/pyright-internal/src/analyzer/sourceEnumerator.ts
+++ b/packages/pyright-internal/src/analyzer/sourceEnumerator.ts
@@ -133,7 +133,7 @@ export class SourceEnumerator {
         this._seenDirs.add(realDirPath.key);
 
         if (this._autoExcludeVenv) {
-            if (envMarkers.some((f) => this._fs.existsSync(dir.uri.resolvePaths(...f)))) {
+            if (_someEnvMarker(envMarkers, dir.uri, this._fs)) {
                 this._autoExcludeDirs.push(dir.uri);
                 this._console.info(`Auto-excluding ${dir.uri.toUserVisibleString()}`);
                 return;
@@ -195,4 +195,13 @@ export class SourceEnumerator {
             this._console.info(`Found ${fileCount} ` + `source ${fileCount === 1 ? 'file' : 'files'}`);
         }
     }
+}
+
+function _someEnvMarker(markers: string[][], dirUri: Uri, fs: FileSystem): boolean {
+    for (const f of markers) {
+        if (fs.existsSync(dirUri.resolvePaths(...f))) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -783,7 +783,7 @@ export class SourceFile {
 
                 this._writableData.commentDiagnostics = [];
 
-                commentDiags.forEach((commentDiag) => {
+                for (const commentDiag of commentDiags) {
                     this._writableData.commentDiagnostics.push(
                         new Diagnostic(
                             DiagnosticCategory.Error,
@@ -791,7 +791,7 @@ export class SourceFile {
                             convertTextRangeToRange(commentDiag.range, parseFileResults.tokenizerOutput.lines)
                         )
                     );
-                });
+                }
             } catch (e: any) {
                 const message: string =
                     (e.stack ? e.stack.toString() : undefined) ||
@@ -1177,7 +1177,7 @@ export class SourceFile {
                 }
             }
 
-            typeIgnoreLinesClone.forEach((ignoreComment) => {
+            for (const ignoreComment of typeIgnoreLinesClone.values()) {
                 if (this._writableData.tokenizerLines!) {
                     const rangeStart = ignoreComment.range.start;
                     const rangeEnd = rangeStart + ignoreComment.range.length;
@@ -1189,9 +1189,9 @@ export class SourceFile {
                         unnecessaryTypeIgnoreDiags.push(diag);
                     }
                 }
-            });
+            }
 
-            pyrightIgnoreLinesClone.forEach((ignoreComment) => {
+            for (const ignoreComment of pyrightIgnoreLinesClone.values()) {
                 if (this._writableData.tokenizerLines!) {
                     if (!ignoreComment.rulesList) {
                         const rangeStart = ignoreComment.range.start;
@@ -1204,7 +1204,7 @@ export class SourceFile {
                             unnecessaryTypeIgnoreDiags.push(diag);
                         }
                     } else {
-                        ignoreComment.rulesList.forEach((unusedRule) => {
+                        for (const unusedRule of ignoreComment.rulesList) {
                             const rangeStart = unusedRule.range.start;
                             const rangeEnd = rangeStart + unusedRule.range.length;
                             const range = convertOffsetsToRange(
@@ -1224,10 +1224,10 @@ export class SourceFile {
                                 diag.setRule(DiagnosticRule.reportUnnecessaryTypeIgnoreComment);
                                 unnecessaryTypeIgnoreDiags.push(diag);
                             }
-                        });
+                        }
                     }
                 }
-            });
+            }
         }
 
         if (
@@ -1236,7 +1236,7 @@ export class SourceFile {
         ) {
             const category = convertLevelToCategory(this._diagnosticRuleSet.reportImportCycles);
 
-            this._writableData.circularDependencies.forEach((cirDep) => {
+            for (const cirDep of this._writableData.circularDependencies) {
                 const diag = new Diagnostic(
                     category,
                     LocMessage.importCycleDetected() +
@@ -1249,7 +1249,7 @@ export class SourceFile {
                 );
                 diag.setRule(DiagnosticRule.reportImportCycles);
                 diagList.push(diag);
-            });
+            }
         }
 
         if (this._writableData.hitMaxImportDepth !== undefined) {
@@ -1537,15 +1537,18 @@ export class SourceFile {
     }
 
     private _fireFileDirtyEvent() {
-        this.serviceProvider.tryGet(ServiceKeys.stateMutationListeners)?.forEach((l) => {
-            try {
-                l.onFileDirty?.(this._uri);
-            } catch (ex: any) {
-                const console = this.serviceProvider.tryGet(ServiceKeys.console);
-                if (console) {
-                    console.error(`State mutation listener exception: ${ex.message}`);
+        const listeners = this.serviceProvider.tryGet(ServiceKeys.stateMutationListeners);
+        if (listeners) {
+            for (const l of listeners) {
+                try {
+                    l.onFileDirty?.(this._uri);
+                } catch (ex: any) {
+                    const console = this.serviceProvider.tryGet(ServiceKeys.console);
+                    if (console) {
+                        console.error(`State mutation listener exception: ${ex.message}`);
+                    }
                 }
             }
-        });
+        }
     }
 }

--- a/packages/pyright-internal/src/analyzer/sourceFileInfoUtils.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFileInfoUtils.ts
@@ -29,15 +29,15 @@ export function collectImportedByCells<T extends SourceFileInfo>(program: Progra
 }
 
 export function collectImportedByRecursively(fileInfo: SourceFileInfo, importedBy: Set<SourceFileInfo>) {
-    fileInfo.importedBy.forEach((dep) => {
+    for (const dep of fileInfo.importedBy) {
         if (importedBy.has(dep)) {
             // Already visited.
-            return;
+            continue;
         }
 
         importedBy.add(dep);
         collectImportedByRecursively(dep, importedBy);
-    });
+    }
 }
 
 export function verifyNoCyclesInChainedFiles<T extends SourceFileInfo>(program: ProgramView, fileInfo: T): void {

--- a/packages/pyright-internal/src/analyzer/sourceMapperUtils.ts
+++ b/packages/pyright-internal/src/analyzer/sourceMapperUtils.ts
@@ -43,7 +43,7 @@ function _buildImportTreeImpl(
         return previous.length ? previous : [from];
     }
 
-    if (previous.length > 1 && previous.find((s) => s.equals(from))) {
+    if (previous.length > 1 && previous.some((s) => s.equals(from))) {
         // Fail the search, we're stuck in a loop.
         return [];
     }

--- a/packages/pyright-internal/src/analyzer/staticExpressions.ts
+++ b/packages/pyright-internal/src/analyzer/staticExpressions.ts
@@ -10,7 +10,16 @@
 
 import { ExecutionEnvironment, PythonPlatform } from '../common/configOptions';
 import { PythonReleaseLevel, PythonVersion } from '../common/pythonVersion';
-import { ArgCategory, ExpressionNode, NameNode, NumberNode, ParseNodeType, TupleNode } from '../parser/parseNodes';
+import {
+    ArgCategory,
+    ExpressionNode,
+    FormatStringNode,
+    NameNode,
+    NumberNode,
+    ParseNodeType,
+    StringNode,
+    TupleNode,
+} from '../parser/parseNodes';
 import { KeywordType, OperatorType } from '../parser/tokenizerTypes';
 
 // Returns undefined if the expression cannot be evaluated
@@ -110,14 +119,14 @@ export function evaluateStaticBoolExpression(
             node.d.rightExpr.nodeType === ParseNodeType.StringList
         ) {
             // Handle the special case of "sys.platform != 'X'"
-            const comparisonPlatform = node.d.rightExpr.d.strings.map((s) => s.d.value).join('');
+            const comparisonPlatform = _joinStringNodeValues(node.d.rightExpr.d.strings);
             const expectedPlatformName = _getExpectedPlatformNameFromPlatform(execEnv);
             return _evaluateStringBinaryOperation(node.d.operator, expectedPlatformName, comparisonPlatform);
         }
 
         if (_isOsNameInfoExpression(node.d.leftExpr) && node.d.rightExpr.nodeType === ParseNodeType.StringList) {
             // Handle the special case of "os.name == 'X'"
-            const comparisonOsName = node.d.rightExpr.d.strings.map((s) => s.d.value).join('');
+            const comparisonOsName = _joinStringNodeValues(node.d.rightExpr.d.strings);
             const expectedOsName = _getExpectedOsNameFromPlatform(execEnv);
             if (expectedOsName !== undefined) {
                 return _evaluateStringBinaryOperation(node.d.operator, expectedOsName, comparisonOsName);
@@ -134,7 +143,7 @@ export function evaluateStaticBoolExpression(
                 }
 
                 if (constantValue !== undefined && typeof constantValue === 'string') {
-                    const comparisonStringName = node.d.rightExpr.d.strings.map((s) => s.d.value).join('');
+                    const comparisonStringName = _joinStringNodeValues(node.d.rightExpr.d.strings);
                     return _evaluateStringBinaryOperation(node.d.operator, constantValue, comparisonStringName);
                 }
             }
@@ -159,7 +168,7 @@ export function evaluateStaticBoolExpression(
             typingImportAliases &&
             node.d.member.d.value === 'TYPE_CHECKING' &&
             node.d.leftExpr.nodeType === ParseNodeType.Name &&
-            typingImportAliases.some((alias) => alias === (node.d.leftExpr as NameNode).d.value)
+            typingImportAliases.includes((node.d.leftExpr as NameNode).d.value)
         ) {
             return true;
         }
@@ -303,7 +312,7 @@ function _evaluateStringBinaryOperation(
 function _isSysVersionInfoExpression(node: ExpressionNode, sysImportAliases: string[] = ['sys']): boolean {
     if (node.nodeType === ParseNodeType.MemberAccess) {
         if (node.d.leftExpr.nodeType === ParseNodeType.Name && node.d.member.d.value === 'version_info') {
-            if (sysImportAliases.some((alias) => alias === (node.d.leftExpr as NameNode).d.value)) {
+            if (sysImportAliases.includes((node.d.leftExpr as NameNode).d.value)) {
                 return true;
             }
         }
@@ -315,7 +324,7 @@ function _isSysVersionInfoExpression(node: ExpressionNode, sysImportAliases: str
 function _isSysPlatformInfoExpression(node: ExpressionNode, sysImportAliases: string[] = ['sys']): boolean {
     if (node.nodeType === ParseNodeType.MemberAccess) {
         if (node.d.leftExpr.nodeType === ParseNodeType.Name && node.d.member.d.value === 'platform') {
-            if (sysImportAliases.some((alias) => alias === (node.d.leftExpr as NameNode).d.value)) {
+            if (sysImportAliases.includes((node.d.leftExpr as NameNode).d.value)) {
                 return true;
             }
         }
@@ -360,4 +369,12 @@ function _getExpectedOsNameFromPlatform(execEnv: ExecutionEnvironment): string |
     }
 
     return undefined;
+}
+
+function _joinStringNodeValues(strings: readonly (StringNode | FormatStringNode)[]): string {
+    let result = '';
+    for (const s of strings) {
+        result += s.d.value;
+    }
+    return result;
 }

--- a/packages/pyright-internal/src/analyzer/symbol.ts
+++ b/packages/pyright-internal/src/analyzer/symbol.ts
@@ -243,11 +243,11 @@ export class Symbol {
 
                 // If there is more than one declaration for a symbol, we will
                 // assume it is not a type alias.
-                this._declarations.forEach((decl) => {
+                for (const decl of this._declarations) {
                     if (decl.type === DeclarationType.Variable && decl.typeAliasName) {
                         delete decl.typeAliasName;
                     }
-                });
+                }
             } else {
                 // If the new declaration has a defined type, it should replace
                 // the existing one.
@@ -295,11 +295,24 @@ export class Symbol {
             return true;
         }
 
-        return this.getDeclarations().some((decl) => hasTypeForDeclaration(decl));
+        const decls = this.getDeclarations();
+        for (const decl of decls) {
+            if (hasTypeForDeclaration(decl)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     getTypedDeclarations() {
-        return this.getDeclarations().filter((decl) => hasTypeForDeclaration(decl));
+        const decls = this.getDeclarations();
+        const result: Declaration[] = [];
+        for (const decl of decls) {
+            if (hasTypeForDeclaration(decl)) {
+                result.push(decl);
+            }
+        }
+        return result;
     }
 
     getSynthesizedType() {

--- a/packages/pyright-internal/src/analyzer/testWalker.ts
+++ b/packages/pyright-internal/src/analyzer/testWalker.ts
@@ -29,7 +29,7 @@ export class TestWalker extends ParseTreeWalker {
 
     // Make sure that all of the children point to their parent.
     private _verifyParentChildLinks(node: ParseNode, children: ParseNodeArray) {
-        children.forEach((child) => {
+        for (const child of children) {
             if (child) {
                 if (child.parent !== node) {
                     fail(
@@ -37,7 +37,7 @@ export class TestWalker extends ParseTreeWalker {
                     );
                 }
             }
-        });
+        }
     }
 
     // Verify that:
@@ -48,7 +48,7 @@ export class TestWalker extends ParseTreeWalker {
         let prevNode: ParseNode | undefined;
 
         const compliant = isCompliantWithNodeRangeRules(node);
-        children.forEach((child) => {
+        for (const child of children) {
             if (child) {
                 let skipCheck = false;
 
@@ -100,7 +100,7 @@ export class TestWalker extends ParseTreeWalker {
                     prevNode = child;
                 }
             }
-        });
+        }
     }
 }
 

--- a/packages/pyright-internal/src/analyzer/tuples.ts
+++ b/packages/pyright-internal/src/analyzer/tuples.ts
@@ -158,7 +158,7 @@ export function getTypeOfTupleWithContext(
     }
 
     // Build an array of expected types.
-    let expectedTypes: Type[] = [];
+    const expectedTypes: Type[] = [];
 
     if (isTupleClass(inferenceContext.expectedType) && inferenceContext.expectedType.priv.tupleTypeArgs) {
         const tupleTypeArgs = inferenceContext.expectedType.priv.tupleTypeArgs;

--- a/packages/pyright-internal/src/analyzer/tuples.ts
+++ b/packages/pyright-internal/src/analyzer/tuples.ts
@@ -161,10 +161,17 @@ export function getTypeOfTupleWithContext(
     let expectedTypes: Type[] = [];
 
     if (isTupleClass(inferenceContext.expectedType) && inferenceContext.expectedType.priv.tupleTypeArgs) {
-        expectedTypes = inferenceContext.expectedType.priv.tupleTypeArgs.map((t) =>
-            transformPossibleRecursiveTypeAlias(t.type)
-        );
-        const unboundedIndex = inferenceContext.expectedType.priv.tupleTypeArgs.findIndex((t) => t.isUnbounded);
+        const tupleTypeArgs = inferenceContext.expectedType.priv.tupleTypeArgs;
+        for (const t of tupleTypeArgs) {
+            expectedTypes.push(transformPossibleRecursiveTypeAlias(t.type));
+        }
+        let unboundedIndex = -1;
+        for (let i = 0; i < tupleTypeArgs.length; i++) {
+            if (tupleTypeArgs[i].isUnbounded) {
+                unboundedIndex = i;
+                break;
+            }
+        }
         if (unboundedIndex >= 0) {
             if (expectedTypes.length > node.d.items.length) {
                 expectedTypes.splice(unboundedIndex, 1);
@@ -200,34 +207,59 @@ export function getTypeOfTupleWithContext(
         }
     }
 
-    const entryTypeResults = node.d.items.map((expr, index) =>
-        evaluator.getTypeOfExpression(
-            expr,
-            flags | EvalFlags.StripTupleLiterals,
-            makeInferenceContext(
-                index < expectedTypes.length ? expectedTypes[index] : undefined,
-                inferenceContext.isTypeIncomplete
+    const entryTypeResults: TypeResult[] = [];
+    for (let index = 0; index < node.d.items.length; index++) {
+        entryTypeResults.push(
+            evaluator.getTypeOfExpression(
+                node.d.items[index],
+                flags | EvalFlags.StripTupleLiterals,
+                makeInferenceContext(
+                    index < expectedTypes.length ? expectedTypes[index] : undefined,
+                    inferenceContext.isTypeIncomplete
+                )
             )
-        )
-    );
-    const isIncomplete = entryTypeResults.some((result) => result.isIncomplete);
+        );
+    }
+    let isIncomplete = false;
+    for (const result of entryTypeResults) {
+        if (result.isIncomplete) {
+            isIncomplete = true;
+            break;
+        }
+    }
 
     // Copy any expected type diag addenda for precision error reporting.
     let expectedTypeDiagAddendum: DiagnosticAddendum | undefined;
-    if (entryTypeResults.some((result) => result.expectedTypeDiagAddendum)) {
+    let hasExpectedTypeDiag = false;
+    for (const result of entryTypeResults) {
+        if (result.expectedTypeDiagAddendum) {
+            hasExpectedTypeDiag = true;
+            break;
+        }
+    }
+    if (hasExpectedTypeDiag) {
         expectedTypeDiagAddendum = new DiagnosticAddendum();
-        entryTypeResults.forEach((result) => {
+        for (const result of entryTypeResults) {
             if (result.expectedTypeDiagAddendum) {
-                expectedTypeDiagAddendum!.addAddendum(result.expectedTypeDiagAddendum);
+                expectedTypeDiagAddendum.addAddendum(result.expectedTypeDiagAddendum);
             }
-        });
+        }
     }
 
     // If the tuple contains a very large number of entries, it's probably
     // generated code. If we encounter type errors, don't bother building
     // the full tuple type.
     let type: Type;
-    if (node.d.items.length > maxInferredTupleEntryCount && entryTypeResults.some((result) => result.typeErrors)) {
+    let hasTypeErrors = false;
+    if (node.d.items.length > maxInferredTupleEntryCount) {
+        for (const result of entryTypeResults) {
+            if (result.typeErrors) {
+                hasTypeErrors = true;
+                break;
+            }
+        }
+    }
+    if (hasTypeErrors) {
         type = makeTupleObject(evaluator, [{ type: UnknownType.create(), isUnbounded: true }]);
     } else {
         type = makeTupleObject(
@@ -240,10 +272,17 @@ export function getTypeOfTupleWithContext(
 }
 
 export function getTypeOfTupleInferred(evaluator: TypeEvaluator, node: TupleNode, flags: EvalFlags): TypeResult {
-    const entryTypeResults = node.d.items.map((expr) =>
-        evaluator.getTypeOfExpression(expr, flags | EvalFlags.StripTupleLiterals)
-    );
-    const isIncomplete = entryTypeResults.some((result) => result.isIncomplete);
+    const entryTypeResults: TypeResult[] = [];
+    for (const expr of node.d.items) {
+        entryTypeResults.push(evaluator.getTypeOfExpression(expr, flags | EvalFlags.StripTupleLiterals));
+    }
+    let isIncomplete = false;
+    for (const result of entryTypeResults) {
+        if (result.isIncomplete) {
+            isIncomplete = true;
+            break;
+        }
+    }
 
     // If the tuple contains a very large number of entries, it's probably
     // generated code. Rather than taking the time to evaluate every entry,
@@ -323,9 +362,23 @@ export function assignTupleTypeArgs(
             }
         }
     } else {
-        const isDestIndeterminate = destTypeArgs.some((t) => t.isUnbounded || isTypeVarTuple(t.type));
+        let isDestIndeterminate = false;
+        for (const t of destTypeArgs) {
+            if (t.isUnbounded || isTypeVarTuple(t.type)) {
+                isDestIndeterminate = true;
+                break;
+            }
+        }
 
-        if (srcTypeArgs.some((t) => t.isUnbounded || isTypeVarTuple(t.type))) {
+        let isSrcIndeterminate = false;
+        for (const t of srcTypeArgs) {
+            if (t.isUnbounded || isTypeVarTuple(t.type)) {
+                isSrcIndeterminate = true;
+                break;
+            }
+        }
+
+        if (isSrcIndeterminate) {
             if (isDestIndeterminate) {
                 diag?.addMessage(
                     LocAddendum.tupleSizeIndeterminateSrcDest().format({
@@ -374,11 +427,27 @@ export function adjustTupleTypeArgs(
     srcTypeArgs: TupleTypeArg[],
     flags: AssignTypeFlags
 ): boolean {
-    const destUnboundedOrVariadicIndex = destTypeArgs.findIndex(
-        (t) => t.isUnbounded || isUnpackedTypeVarTuple(t.type) || isUnpackedTypeVar(t.type)
-    );
-    const srcUnboundedIndex = srcTypeArgs.findIndex((t) => t.isUnbounded);
-    const srcVariadicIndex = srcTypeArgs.findIndex((t) => isUnpackedTypeVarTuple(t.type) || isUnpackedTypeVar(t.type));
+    let destUnboundedOrVariadicIndex = -1;
+    for (let i = 0; i < destTypeArgs.length; i++) {
+        if (destTypeArgs[i].isUnbounded || isUnpackedTypeVarTuple(destTypeArgs[i].type) || isUnpackedTypeVar(destTypeArgs[i].type)) {
+            destUnboundedOrVariadicIndex = i;
+            break;
+        }
+    }
+    let srcUnboundedIndex = -1;
+    for (let i = 0; i < srcTypeArgs.length; i++) {
+        if (srcTypeArgs[i].isUnbounded) {
+            srcUnboundedIndex = i;
+            break;
+        }
+    }
+    let srcVariadicIndex = -1;
+    for (let i = 0; i < srcTypeArgs.length; i++) {
+        if (isUnpackedTypeVarTuple(srcTypeArgs[i].type) || isUnpackedTypeVar(srcTypeArgs[i].type)) {
+            srcVariadicIndex = i;
+            break;
+        }
+    }
 
     if (srcUnboundedIndex >= 0) {
         if (isAnyOrUnknown(srcTypeArgs[srcUnboundedIndex].type)) {
@@ -436,17 +505,20 @@ export function adjustTupleTypeArgs(
             if (!skipAdjustment && tupleClass && isInstantiableClass(tupleClass)) {
                 const removedArgs = destTypeArgs.splice(srcVariadicIndex, destArgsToCapture);
 
+                const mappedArgs: TupleTypeArg[] = [];
+                for (const typeArg of removedArgs) {
+                    mappedArgs.push({
+                        type: typeArg.type,
+                        isUnbounded: typeArg.isUnbounded,
+                        isOptional: typeArg.isOptional,
+                    });
+                }
+
                 // Package up the remaining type arguments into a tuple object.
                 const variadicTuple = ClassType.cloneAsInstance(
                     specializeTupleClass(
                         tupleClass,
-                        removedArgs.map((typeArg) => {
-                            return {
-                                type: typeArg.type,
-                                isUnbounded: typeArg.isUnbounded,
-                                isOptional: typeArg.isOptional,
-                            };
-                        }),
+                        mappedArgs,
                         /* isTypeArgExplicit */ true,
                         /* isUnpacked */ true
                     )
@@ -477,17 +549,20 @@ export function adjustTupleTypeArgs(
                     if (removedArgs.length === 1 && isUnpackedTypeVarTuple(removedArgs[0].type)) {
                         variadicTuple = removedArgs[0].type;
                     } else {
+                        const mappedArgs: TupleTypeArg[] = [];
+                        for (const typeArg of removedArgs) {
+                            mappedArgs.push({
+                                type: typeArg.type,
+                                isUnbounded: typeArg.isUnbounded,
+                                isOptional: typeArg.isOptional,
+                            });
+                        }
+
                         // Package up the remaining type arguments into a tuple object.
                         variadicTuple = ClassType.cloneAsInstance(
                             specializeTupleClass(
                                 tupleClass,
-                                removedArgs.map((typeArg) => {
-                                    return {
-                                        type: typeArg.type,
-                                        isUnbounded: typeArg.isUnbounded,
-                                        isOptional: typeArg.isOptional,
-                                    };
-                                }),
+                                mappedArgs,
                                 /* isTypeArgExplicit */ true,
                                 /* isUnpacked */ true
                             )
@@ -514,12 +589,15 @@ export function adjustTupleTypeArgs(
             (srcUnboundedIndex >= destUnboundedOrVariadicIndex &&
                 srcUnboundedIndex < destUnboundedOrVariadicIndex + srcArgsToCapture)
         ) {
-            const removedArgTypes = srcTypeArgs.splice(destUnboundedOrVariadicIndex, srcArgsToCapture).map((t) => {
+            const removedArgs = srcTypeArgs.splice(destUnboundedOrVariadicIndex, srcArgsToCapture);
+            const removedArgTypes: Type[] = [];
+            for (const t of removedArgs) {
                 if (isTypeVar(t.type) && isUnpackedTypeVarTuple(t.type)) {
-                    return TypeVarType.cloneForUnpacked(t.type, /* isInUnion */ true);
+                    removedArgTypes.push(TypeVarType.cloneForUnpacked(t.type, /* isInUnion */ true));
+                } else {
+                    removedArgTypes.push(t.type);
                 }
-                return t.type;
-            });
+            }
 
             srcTypeArgs.splice(destUnboundedOrVariadicIndex, 0, {
                 type: removedArgTypes.length > 0 ? combineTypes(removedArgTypes) : AnyType.create(),
@@ -563,9 +641,19 @@ export function getSlicedTupleType(
 export function expandTuple(tupleType: ClassType, maxExpansion: number): Type[] | undefined {
     if (
         !isTupleClass(tupleType) ||
-        !tupleType.priv.tupleTypeArgs ||
-        tupleType.priv.tupleTypeArgs.some((typeArg) => typeArg.isUnbounded || isTypeVarTuple(typeArg.type))
+        !tupleType.priv.tupleTypeArgs
     ) {
+        return undefined;
+    }
+
+    let hasIndeterminateArg = false;
+    for (const typeArg of tupleType.priv.tupleTypeArgs) {
+        if (typeArg.isUnbounded || isTypeVarTuple(typeArg.type)) {
+            hasIndeterminateArg = true;
+            break;
+        }
+    }
+    if (hasIndeterminateArg) {
         return undefined;
     }
 
@@ -612,9 +700,13 @@ function getTupleSliceParam(
         }
 
         value = valType.priv.literalValue as number;
-        const unboundedIndex = tupleTypeArgs.findIndex(
-            (typeArg) => typeArg.isUnbounded || isTypeVarTuple(typeArg.type)
-        );
+        let unboundedIndex = -1;
+        for (let i = 0; i < tupleTypeArgs.length; i++) {
+            if (tupleTypeArgs[i].isUnbounded || isTypeVarTuple(tupleTypeArgs[i].type)) {
+                unboundedIndex = i;
+                break;
+            }
+        }
 
         if (value < 0) {
             value = tupleTypeArgs.length + value;

--- a/packages/pyright-internal/src/analyzer/typeCacheUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeCacheUtils.ts
@@ -100,9 +100,9 @@ export class SpeculativeTypeTracker {
 
         // Delete all of the speculative type cache entries
         // that were tracked in this context.
-        context!.entriesToUndo.forEach((entry) => {
+        for (const entry of context!.entriesToUndo) {
             entry.cache.delete(entry.id);
-        });
+        }
     }
 
     isSpeculative(node: ParseNode | undefined, ignoreIfDiagnosticsAllowed = false) {
@@ -206,11 +206,7 @@ export class SpeculativeTypeTracker {
     }
 
     getSpeculativeType(node: ParseNode, expectedType: Type | undefined): SpeculativeTypeEntry | undefined {
-        if (
-            this._speculativeContextStack.some((context) =>
-                ParseTreeUtils.isNodeContainedWithin(node, context.speculativeRootNode)
-            )
-        ) {
+        if (_isNodeInSpeculativeContext(this._speculativeContextStack, node)) {
             const entries = this._speculativeTypeCache.get(node.id);
             if (entries) {
                 for (const entry of entries) {
@@ -241,13 +237,27 @@ export class SpeculativeTypeTracker {
             return false;
         }
 
-        return cachedDependentTypes.every((cachedDepType, index) => {
+        for (let index = 0; index < cachedDependentTypes.length; index++) {
+            const cachedDepType = cachedDependentTypes[index];
             const activeDepType = this._activeDependentTypes[index];
             if (cachedDepType.speculativeRootNode !== activeDepType.speculativeRootNode) {
                 return false;
             }
 
-            return isTypeSame(cachedDepType.dependentType, activeDepType.dependentType);
-        });
+            if (!isTypeSame(cachedDepType.dependentType, activeDepType.dependentType)) {
+                return false;
+            }
+        }
+
+        return true;
     }
+}
+
+function _isNodeInSpeculativeContext(stack: SpeculativeContext[], node: ParseNode): boolean {
+    for (const context of stack) {
+        if (ParseTreeUtils.isNodeContainedWithin(node, context.speculativeRootNode)) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/packages/pyright-internal/src/analyzer/typeComplexity.ts
+++ b/packages/pyright-internal/src/analyzer/typeComplexity.ts
@@ -49,10 +49,10 @@ export function getComplexityScoreForType(type: Type, recursionCount = 0): numbe
             // If this union has a very large number of subtypes, don't bother
             // accurately computing the score. Assume a fixed value.
             if (type.priv.subtypes.length < 16) {
-                type.priv.subtypes.forEach((subtype) => {
+                for (const subtype of type.priv.subtypes) {
                     const subtypeScore = getComplexityScoreForType(subtype, recursionCount);
                     maxScore = Math.max(maxScore, subtypeScore);
-                });
+                }
             } else {
                 maxScore = 0.5;
             }
@@ -74,20 +74,20 @@ function getComplexityScoreForClass(classType: ClassType, recursionCount: number
     let typeArgCount = 0;
 
     if (classType.priv.tupleTypeArgs) {
-        classType.priv.tupleTypeArgs.forEach((typeArg) => {
+        for (const typeArg of classType.priv.tupleTypeArgs) {
             typeArgScoreSum += getComplexityScoreForType(typeArg.type, recursionCount);
             typeArgCount++;
-        });
+        }
     } else if (classType.priv.typeArgs) {
-        classType.priv.typeArgs.forEach((type) => {
+        for (const type of classType.priv.typeArgs) {
             typeArgScoreSum += getComplexityScoreForType(type, recursionCount);
             typeArgCount++;
-        });
+        }
     } else if (classType.shared.typeParams) {
-        classType.shared.typeParams.forEach((type) => {
+        for (const _type of classType.shared.typeParams) {
             typeArgScoreSum += getComplexityScoreForType(AnyType.create(), recursionCount);
             typeArgCount++;
-        });
+        }
     }
 
     const averageTypeArgComplexity = typeArgCount > 0 ? typeArgScoreSum / typeArgCount : 0;

--- a/packages/pyright-internal/src/analyzer/typeComplexity.ts
+++ b/packages/pyright-internal/src/analyzer/typeComplexity.ts
@@ -84,7 +84,7 @@ function getComplexityScoreForClass(classType: ClassType, recursionCount: number
             typeArgCount++;
         }
     } else if (classType.shared.typeParams) {
-        for (const _type of classType.shared.typeParams) {
+        for (let i = 0; i < classType.shared.typeParams.length; i++) {
             typeArgScoreSum += getComplexityScoreForType(AnyType.create(), recursionCount);
             typeArgCount++;
         }

--- a/packages/pyright-internal/src/analyzer/typeDocStringUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeDocStringUtils.ts
@@ -257,7 +257,12 @@ export function getClassDocString(
     if (!docString && resolvedDecl) {
         const implDecls = sourceMapper.findClassDeclarationsByType(resolvedDecl.uri, classType);
         if (implDecls) {
-            const classDecls = implDecls.filter((d) => isClassDeclaration(d)).map((d) => d);
+            const classDecls: ClassDeclaration[] = [];
+            for (const d of implDecls) {
+                if (isClassDeclaration(d)) {
+                    classDecls.push(d);
+                }
+            }
             docString = _getFunctionOrClassDeclsDocString(classDecls);
         }
     }
@@ -280,7 +285,13 @@ export function getVariableDocString(
     if (decl.docString !== undefined) {
         return decl.docString;
     } else {
-        return getVariableInStubFileDocStrings(decl, sourceMapper).find((doc) => doc);
+        const docs = getVariableInStubFileDocStrings(decl, sourceMapper);
+        for (const doc of docs) {
+            if (doc) {
+                return doc;
+            }
+        }
+        return undefined;
     }
 }
 
@@ -293,12 +304,20 @@ export function getOverloadedDocStrings(type: Type, resolvedDecl: Declaration | 
     const overloads = OverloadedType.getOverloads(type);
     const impl = OverloadedType.getImplementation(type);
 
-    if (overloads.some((o) => o.shared.docString)) {
-        overloads.forEach((overload) => {
+    let hasOverloadDocString = false;
+    for (const o of overloads) {
+        if (o.shared.docString) {
+            hasOverloadDocString = true;
+            break;
+        }
+    }
+
+    if (hasOverloadDocString) {
+        for (const overload of overloads) {
             if (overload.shared.docString) {
                 docStrings.push(overload.shared.docString);
             }
-        });
+        }
     }
 
     if (impl && isFunction(impl) && impl.shared.docString) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -24854,7 +24854,7 @@ export function createTypeEvaluator(
                 srcType.priv.tupleTypeArgs &&
                 srcType.priv.tupleTypeArgs.length === 1
             ) {
-                if (isTypeSame(destType, srcType.priv.tupleTypeArgs[0].type, {}, recursionCount)) {
+                if (isTypeSame(destType, srcType.priv.tupleTypeArgs[0].type, undefined, recursionCount)) {
                     return true;
                 }
             }
@@ -25588,7 +25588,7 @@ export function createTypeEvaluator(
     ): boolean {
         // Start by checking for an exact match. This is needed to handle unions
         // that contain recursive type aliases.
-        if (isTypeSame(srcType, destType, {}, recursionCount)) {
+        if (isTypeSame(srcType, destType, undefined, recursionCount)) {
             return true;
         }
 
@@ -25628,7 +25628,7 @@ export function createTypeEvaluator(
                     remainingDestSubtypes.push(destSubtype);
                 } else {
                     const srcTypeIndex = remainingSrcSubtypes.findIndex((srcSubtype) =>
-                        isTypeSame(srcSubtype, destSubtype, {}, recursionCount)
+                        isTypeSame(srcSubtype, destSubtype, undefined, recursionCount)
                     );
 
                     if (srcTypeIndex >= 0) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -227,6 +227,7 @@ import { enumerateLiteralsForType } from './typeGuards';
 import * as TypePrinter from './typePrinter';
 import {
     AnyType,
+    CallSiteInferenceTypeCacheEntry,
     ClassType,
     ClassTypeFlags,
     combineTypes,
@@ -852,9 +853,13 @@ export function createTypeEvaluator(
     }
 
     function getIndexOfSymbolResolution(symbol: Symbol, declaration: Declaration) {
-        return symbolResolutionStack.findIndex(
-            (entry) => entry.symbolId === symbol.id && entry.declaration === declaration
-        );
+        for (let i = 0; i < symbolResolutionStack.length; i++) {
+            const entry = symbolResolutionStack[i];
+            if (entry.symbolId === symbol.id && entry.declaration === declaration) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     function pushSymbolResolution(symbol: Symbol, declaration: Declaration) {
@@ -922,9 +927,13 @@ export function createTypeEvaluator(
                 if (classTypeResult) {
                     inferVarianceForClass(classTypeResult.classType);
 
-                    const typeParam = classTypeResult.classType.shared.typeParams.find((param) =>
-                        isTypeSame(param, typeVarType, { ignoreTypeFlags: true })
-                    );
+                    let typeParam: TypeVarType | undefined;
+                    for (const param of classTypeResult.classType.shared.typeParams) {
+                        if (isTypeSame(param, typeVarType, { ignoreTypeFlags: true })) {
+                            typeParam = param;
+                            break;
+                        }
+                    }
 
                     if (typeParam?.priv.computedVariance !== undefined) {
                         type = TypeVarType.cloneWithComputedVariance(type, typeParam.priv.computedVariance);
@@ -932,7 +941,13 @@ export function createTypeEvaluator(
                 }
             } else if (typeParamListNode?.parent?.nodeType === ParseNodeType.TypeAlias) {
                 const typeAliasType = getTypeOfTypeAlias(typeParamListNode.parent);
-                const typeParamIndex = typeParamListNode.d.params.findIndex((param) => param.d.name === node);
+                let typeParamIndex = -1;
+                for (let i = 0; i < typeParamListNode.d.params.length; i++) {
+                    if (typeParamListNode.d.params[i].d.name === node) {
+                        typeParamIndex = i;
+                        break;
+                    }
+                }
 
                 if (typeParamIndex >= 0) {
                     inferVarianceForTypeAlias(typeAliasType);
@@ -1640,8 +1655,15 @@ export function createTypeEvaluator(
             (node.d.token.flags & StringTokenFlags.Bytes) !== 0;
 
         // Check for mixing of bytes and str, which is not allowed.
-        const firstStrIndex = node.d.strings.findIndex((str) => !isBytesNode(str));
-        const firstBytesIndex = node.d.strings.findIndex((str) => isBytesNode(str));
+        let firstStrIndex = -1;
+        let firstBytesIndex = -1;
+        for (let i = 0; i < node.d.strings.length; i++) {
+            if (isBytesNode(node.d.strings[i])) {
+                if (firstBytesIndex < 0) firstBytesIndex = i;
+            } else {
+                if (firstStrIndex < 0) firstStrIndex = i;
+            }
+        }
         if (firstStrIndex >= 0 && firstBytesIndex >= 0) {
             addDiagnostic(
                 DiagnosticRule.reportGeneralTypeIssues,
@@ -1657,7 +1679,7 @@ export function createTypeEvaluator(
         let isIncomplete = false;
         let isTemplate = false;
 
-        node.d.strings.forEach((expr) => {
+        for (const expr of node.d.strings) {
             // Handle implicit concatenation.
             const typeResult = getTypeOfString(expr);
 
@@ -1682,7 +1704,7 @@ export function createTypeEvaluator(
             if (!isExprLiteralString) {
                 isLiteralString = false;
             }
-        });
+        }
 
         if (isTemplate) {
             const templateType =
@@ -1710,7 +1732,7 @@ export function createTypeEvaluator(
                 type: cloneBuiltinObjectWithLiteral(
                     node,
                     isBytes ? 'bytes' : 'str',
-                    node.d.strings.map((s) => s.d.value).join('')
+                    _joinStringNodeValues(node.d.strings)
                 ),
                 isIncomplete,
             };
@@ -1837,7 +1859,7 @@ export function createTypeEvaluator(
 
             // If all of the format expressions are of type LiteralString, then
             // the resulting formatted string is also LiteralString.
-            node.d.fieldExprs.forEach((expr) => {
+            for (const expr of node.d.fieldExprs) {
                 const exprTypeResult = getTypeOfExpression(expr);
                 const exprType = exprTypeResult.type;
 
@@ -1861,7 +1883,7 @@ export function createTypeEvaluator(
 
                     isLiteralString = false;
                 });
-            });
+            }
 
             if (isTemplateString) {
                 const templateType =
@@ -2584,7 +2606,8 @@ export function createTypeEvaluator(
             });
         }
 
-        callNode.d.args.forEach((arg, index) => {
+        for (let index = 0; index < callNode.d.args.length; index++) {
+            const arg = callNode.d.args[index];
             let active = false;
             if (index === activeIndex) {
                 if (activeOrFake) {
@@ -2602,7 +2625,7 @@ export function createTypeEvaluator(
                 name: arg.d.name,
                 active: active,
             });
-        });
+        }
 
         if (callNode.d.args.length < activeIndex) {
             addFakeArg();
@@ -2634,9 +2657,9 @@ export function createTypeEvaluator(
             if (isFunction(type)) {
                 addOneFunctionToSignature(type);
             } else {
-                OverloadedType.getOverloads(type).forEach((func) => {
+                for (const func of OverloadedType.getOverloads(type)) {
                     addOneFunctionToSignature(func);
-                });
+                }
             }
         }
 
@@ -2728,7 +2751,7 @@ export function createTypeEvaluator(
             FunctionType.addKeywordOnlyParamSeparator(newFunction);
         }
 
-        tdEntries.forEach((tdEntry, name) => {
+        for (const [name, tdEntry] of tdEntries) {
             FunctionType.addParam(
                 newFunction,
                 FunctionParam.create(
@@ -2739,7 +2762,7 @@ export function createTypeEvaluator(
                     tdEntry.isRequired ? undefined : tdEntry.valueType
                 )
             );
-        });
+        }
 
         const extraItemsType = kwargsType.shared.typedDictEntries?.extraItems?.valueType;
 
@@ -2947,12 +2970,12 @@ export function createTypeEvaluator(
                     !expression.d.items.some((item) => item.nodeType === ParseNodeType.Unpack)
                 ) {
                     const itemTypes: Type[] = [];
-                    expression.d.items.forEach((expr) => {
+                    for (const expr of expression.d.items) {
                         const itemType = getDeclaredTypeForExpression(expr, usage);
                         if (itemType) {
                             itemTypes.push(itemType);
                         }
-                    });
+                    }
 
                     if (itemTypes.length === expression.d.items.length) {
                         // If all items have a declared type, return a tuple of those types.
@@ -3817,9 +3840,12 @@ export function createTypeEvaluator(
                             target.d.member.d.value
                         );
                         if (memberSymbol) {
-                            const classLevelDecls = memberSymbol.getDeclarations().filter((decl) => {
-                                return !ParseTreeUtils.getEnclosingFunction(decl.node);
-                            });
+                            const classLevelDecls: Declaration[] = [];
+                            for (const decl of memberSymbol.getDeclarations()) {
+                                if (!ParseTreeUtils.getEnclosingFunction(decl.node)) {
+                                    classLevelDecls.push(decl);
+                                }
+                            }
                             if (classLevelDecls.length === 0) {
                                 addDiagnostic(
                                     DiagnosticRule.reportGeneralTypeIssues,
@@ -4010,11 +4036,23 @@ export function createTypeEvaluator(
         for (let i = 0; i < targetExpressions.length; i++) {
             targetTypes[i] = [];
         }
-        const targetUnpackIndex = targetExpressions.findIndex((expr) => expr.nodeType === ParseNodeType.Unpack);
+        let targetUnpackIndex = -1;
+        for (let i = 0; i < targetExpressions.length; i++) {
+            if (targetExpressions[i].nodeType === ParseNodeType.Unpack) {
+                targetUnpackIndex = i;
+                break;
+            }
+        }
 
         // Do any of the targets use an unpack operator? If so, it will consume all of the
         // entries at that location.
-        const unpackIndex = targetExpressions.findIndex((expr) => expr.nodeType === ParseNodeType.Unpack);
+        let unpackIndex = -1;
+        for (let i = 0; i < targetExpressions.length; i++) {
+            if (targetExpressions[i].nodeType === ParseNodeType.Unpack) {
+                unpackIndex = i;
+                break;
+            }
+        }
 
         typeResult = { ...typeResult, type: makeTopLevelTypeVarsConcrete(typeResult.type) };
 
@@ -4065,11 +4103,11 @@ export function createTypeEvaluator(
                     }
                 }
 
-                sourceEntryTypes.forEach((type, targetIndex) => {
+                for (let targetIndex = 0; targetIndex < sourceEntryTypes.length; targetIndex++) {
                     if (targetIndex < targetTypes.length) {
-                        targetTypes[targetIndex].push(type);
+                        targetTypes[targetIndex].push(sourceEntryTypes[targetIndex]);
                     }
-                });
+                }
 
                 // Have we accounted for all of the targets and sources? If not, we have a size mismatch.
                 if (sourceEntryTypes.length !== targetExpressions.length) {
@@ -4123,7 +4161,8 @@ export function createTypeEvaluator(
 
         // Assign the resulting types to the individual names in the tuple
         // or list target expression.
-        targetExpressions.forEach((expr, index) => {
+        for (let index = 0; index < targetExpressions.length; index++) {
+            const expr = targetExpressions[index];
             const typeList = targetTypes[index];
             const targetType = typeList.length === 0 ? UnknownType.create() : combineTypes(typeList);
 
@@ -4133,7 +4172,7 @@ export function createTypeEvaluator(
                 srcExpr,
                 /* ignoreEmptyContainers */ true
             );
-        });
+        }
 
         writeTypeCache(target, typeResult, EvalFlags.None);
     }
@@ -4251,17 +4290,22 @@ export function createTypeEvaluator(
 
                     // Expand the list of constrained subtypes, filtering out any that are
                     // disallowed by the conditionFilter.
-                    subtype.shared.constraints.forEach((constraintType, constraintIndex) => {
+                    for (let constraintIndex = 0; constraintIndex < subtype.shared.constraints.length; constraintIndex++) {
+                        let constraintType = subtype.shared.constraints[constraintIndex];
                         if (conditionFilter) {
                             const typeVarName = TypeVarType.getNameWithScope(subtype);
-                            const applicableConstraint = conditionFilter.find(
-                                (filter) => filter.typeVar.priv.nameWithScope === typeVarName
-                            );
+                            let applicableConstraint: TypeCondition | undefined;
+                            for (const filter of conditionFilter) {
+                                if (filter.typeVar.priv.nameWithScope === typeVarName) {
+                                    applicableConstraint = filter;
+                                    break;
+                                }
+                            }
 
                             // If this type variable is being constrained to a single index,
                             // don't include the other indices.
                             if (applicableConstraint && applicableConstraint.constraintIndex !== constraintIndex) {
-                                return;
+                                continue;
                             }
                         }
 
@@ -4272,7 +4316,7 @@ export function createTypeEvaluator(
                         typesToCombine.push(
                             addConditionToType(constraintType, [{ typeVar: subtype, constraintIndex }])
                         );
-                    });
+                    }
 
                     return combineTypes(typesToCombine);
                 }
@@ -4389,9 +4433,9 @@ export function createTypeEvaluator(
 
         if (isUnion(type)) {
             const subtypes = options?.sortSubtypes ? sortTypes(type.priv.subtypes) : type.priv.subtypes;
-            subtypes.forEach((subtype, index) => {
-                expandSubtype(subtype, index === type.priv.subtypes.length - 1);
-            });
+            for (let index = 0; index < subtypes.length; index++) {
+                expandSubtype(subtypes[index], index === type.priv.subtypes.length - 1);
+            }
         } else {
             expandSubtype(type, /* isLastSubtype */ true);
         }
@@ -4478,12 +4522,12 @@ export function createTypeEvaluator(
         const scope = ScopeUtils.getScopeForNode(node);
 
         if (scope) {
-            names.forEach((symbolName) => {
+            for (const symbolName of names) {
                 const symbolInScope = scope.lookUpSymbolRecursive(symbolName);
                 if (symbolInScope) {
                     setSymbolAccessed(fileInfo, symbolInScope.symbol, node);
                 }
-            });
+            }
         }
     }
 
@@ -6762,9 +6806,9 @@ export function createTypeEvaluator(
                 // If diagnostics were recorded when suppressed, add them to the
                 // diagnostic as messages.
                 if (diag) {
-                    suppressedDiags.forEach((message) => {
+                    for (const message of suppressedDiags) {
                         diag?.addMessageMultiline(message);
-                    });
+                    }
                 }
             }
         );
@@ -7240,17 +7284,17 @@ export function createTypeEvaluator(
                 if (variadicTypeResults.length === 1 && isTypeVarTuple(variadicTypeResults[0].type)) {
                     validateTypeVarTupleIsUnpacked(variadicTypeResults[0].type, variadicTypeResults[0].node);
                 } else {
-                    variadicTypeResults.forEach((arg, index) => {
-                        validateTypeArg(arg, {
+                    for (let index = 0; index < variadicTypeResults.length; index++) {
+                        validateTypeArg(variadicTypeResults[index], {
                             allowEmptyTuple: index === 0,
                             allowTypeVarTuple: true,
                             allowUnpackedTuples: true,
                         });
-                    });
+                    }
 
                     const variadicTypes: TupleTypeArg[] = [];
                     if (variadicTypeResults.length !== 1 || !variadicTypeResults[0].isEmptyTupleShorthand) {
-                        variadicTypeResults.forEach((typeResult) => {
+                        for (const typeResult of variadicTypeResults) {
                             if (isUnpackedClass(typeResult.type) && typeResult.type.priv.tupleTypeArgs) {
                                 appendArray(variadicTypes, typeResult.type.priv.tupleTypeArgs);
                             } else {
@@ -7259,7 +7303,7 @@ export function createTypeEvaluator(
                                     isUnbounded: false,
                                 });
                             }
-                        });
+                        }
                     }
 
                     const tupleObject = makeTupleObject(evaluatorInterface, variadicTypes, /* isUnpacked */ true);
@@ -7318,7 +7362,7 @@ export function createTypeEvaluator(
         const defaultTypeArgs: Type[] = [];
         const constraints = new ConstraintTracker();
 
-        aliasInfo.shared.typeParams.forEach((param) => {
+        for (const param of aliasInfo.shared.typeParams) {
             if (!param.shared.isDefaultExplicit) {
                 reportDiag = true;
             }
@@ -7343,7 +7387,7 @@ export function createTypeEvaluator(
 
             defaultTypeArgs.push(defaultType);
             constraints.setBounds(param, defaultType);
-        });
+        }
 
         if (reportDiag && errorNode) {
             addDiagnostic(
@@ -7452,14 +7496,16 @@ export function createTypeEvaluator(
         const constraints = new ConstraintTracker();
         const diag = new DiagnosticAddendum();
 
-        typeParams.forEach((param, index) => {
+        for (let index = 0; index < typeParams.length; index++) {
+            const param = typeParams[index];
             if (isParamSpec(param) && index < typeArgs.length) {
                 const typeArgType = typeArgs[index].type;
                 const typeList = typeArgs[index].typeList;
 
                 if (typeList) {
                     const functionType = FunctionType.createSynthesizedInstance('', FunctionTypeFlags.ParamSpecValue);
-                    typeList.forEach((paramTypeResult, paramIndex) => {
+                    for (let paramIndex = 0; paramIndex < typeList.length; paramIndex++) {
+                        const paramTypeResult = typeList[paramIndex];
                         let paramType = paramTypeResult.type;
 
                         if (!validateTypeArg(paramTypeResult)) {
@@ -7475,7 +7521,7 @@ export function createTypeEvaluator(
                                 `__p${paramIndex}`
                             )
                         );
-                    });
+                    }
 
                     if (typeList.length > 0) {
                         FunctionType.addPositionOnlyParamSeparator(functionType);
@@ -7503,7 +7549,8 @@ export function createTypeEvaluator(
                     const functionType = FunctionType.createInstance('', '', '', FunctionTypeFlags.None);
 
                     if (concatTypeArgs && concatTypeArgs.length > 0) {
-                        concatTypeArgs.forEach((typeArg, index) => {
+                        for (let index = 0; index < concatTypeArgs.length; index++) {
+                            const typeArg = concatTypeArgs[index];
                             if (index === concatTypeArgs.length - 1) {
                                 FunctionType.addPositionOnlyParamSeparator(functionType);
 
@@ -7524,7 +7571,7 @@ export function createTypeEvaluator(
                                     )
                                 );
                             }
-                        });
+                        }
                     }
 
                     assignTypeVar(
@@ -7608,7 +7655,7 @@ export function createTypeEvaluator(
                     AssignTypeFlags.RetainLiteralsForTypeVar
                 );
             }
-        });
+        }
 
         if (!diag.isEmpty()) {
             addDiagnostic(
@@ -7623,7 +7670,7 @@ export function createTypeEvaluator(
         const solutionSet = solveConstraints(evaluatorInterface, constraints).getMainSolutionSet();
         const aliasTypeArgs: Type[] = [];
 
-        aliasInfo.shared.typeParams?.forEach((typeParam) => {
+        for (const typeParam of aliasInfo.shared.typeParams) {
             let typeVarType = solutionSet.getType(typeParam);
 
             // Fill in any unsolved type arguments with unknown.
@@ -7633,7 +7680,7 @@ export function createTypeEvaluator(
             }
 
             aliasTypeArgs.push(typeVarType);
-        });
+        }
 
         let type = TypeBase.cloneForTypeAlias(solveAndApplyConstraints(aliasBaseType, constraints), {
             ...aliasInfo,
@@ -7692,7 +7739,11 @@ export function createTypeEvaluator(
         }
 
         if (isTypeVar(baseTypeResult.type) && isTypeAliasPlaceholder(baseTypeResult.type)) {
-            const typeArgTypes = getTypeArgs(node, flags).map((t) => convertToInstance(t.type));
+            const typeArgResults = getTypeArgs(node, flags);
+            const typeArgTypes: Type[] = [];
+            for (const t of typeArgResults) {
+                typeArgTypes.push(convertToInstance(t.type));
+            }
             const type = TypeBase.cloneForTypeAlias(baseTypeResult.type, {
                 shared: baseTypeResult.type.shared.recursiveAlias!,
                 typeArgs: typeArgTypes,
@@ -7932,11 +7983,11 @@ export function createTypeEvaluator(
         // In case we didn't walk the list items above, do so now.
         // If we have, this information will be cached.
         if (!baseTypeResult.isIncomplete) {
-            node.d.items.forEach((item) => {
+            for (const item of node.d.items) {
                 if (!isTypeCached(item.d.valueExpr)) {
                     getTypeOfExpression(item.d.valueExpr, flags & EvalFlags.ForwardRefs);
                 }
-            });
+            }
         }
 
         return { type, isIncomplete, isReadOnly, isRequired, isNotRequired };
@@ -7962,7 +8013,10 @@ export function createTypeEvaluator(
         const typeParams = aliasInfo.shared.typeParams;
 
         // Start with all of the usage variances unknown.
-        const usageVariances: Variance[] = typeParams.map(() => Variance.Unknown);
+        const usageVariances: Variance[] = [];
+        for (let i = 0; i < typeParams.length; i++) {
+            usageVariances.push(Variance.Unknown);
+        }
 
         // Prepopulate the cached value for the type alias to handle
         // recursive type aliases.
@@ -7997,7 +8051,12 @@ export function createTypeEvaluator(
         // seen it once before in the recursion stack. If so, don't recurse
         // further.
         if (isRecursiveTypeAlias) {
-            const pendingOverlaps = pendingTypes.filter((pendingType) => isTypeSame(pendingType, type));
+            const pendingOverlaps: Type[] = [];
+            for (const pendingType of pendingTypes) {
+                if (isTypeSame(pendingType, type)) {
+                    pendingOverlaps.push(pendingType);
+                }
+            }
             if (pendingOverlaps.length > 1) {
                 return;
             }
@@ -8028,10 +8087,11 @@ export function createTypeEvaluator(
 
         doForEachSubtype(transformedType, (subtype) => {
             if (subtype.category === TypeCategory.Function) {
-                subtype.shared.parameters.forEach((param, index) => {
+                for (let index = 0; index < subtype.shared.parameters.length; index++) {
+                    const param = subtype.shared.parameters[index];
                     const paramType = FunctionType.getParamType(subtype, index);
                     updateUsageVarianceForType(paramType, invertVariance(varianceContext));
-                });
+                }
 
                 const returnType = FunctionType.getEffectiveReturnType(subtype);
                 if (returnType) {
@@ -8045,15 +8105,16 @@ export function createTypeEvaluator(
 
                     // Is the class specialized using any type arguments that correspond to
                     // the type alias' type parameters?
-                    subtype.priv.typeArgs.forEach((typeArg, classParamIndex) => {
+                    for (let classParamIndex = 0; classParamIndex < subtype.priv.typeArgs.length; classParamIndex++) {
+                        const typeArg = subtype.priv.typeArgs[classParamIndex];
                         if (isTupleClass(subtype)) {
                             updateUsageVarianceForType(typeArg, varianceContext);
                         } else if (classParamIndex < subtype.shared.typeParams.length) {
                             const classTypeParam = subtype.shared.typeParams[classParamIndex];
                             if (isUnpackedClass(typeArg) && typeArg.priv.tupleTypeArgs) {
-                                typeArg.priv.tupleTypeArgs.forEach((tupleTypeArg) => {
+                                for (const tupleTypeArg of typeArg.priv.tupleTypeArgs) {
                                     updateUsageVarianceForType(tupleTypeArg.type, Variance.Invariant);
-                                });
+                                }
                             } else {
                                 const effectiveVariance =
                                     classTypeParam.priv.computedVariance ?? classTypeParam.shared.declaredVariance;
@@ -8065,7 +8126,7 @@ export function createTypeEvaluator(
                                 );
                             }
                         }
-                    });
+                    }
                 }
             }
         });
@@ -8162,8 +8223,15 @@ export function createTypeEvaluator(
             }
         }
 
-        const positionalArgs = node.d.items.filter((item) => item.d.argCategory === ArgCategory.Simple);
-        const unpackedListArgs = node.d.items.filter((item) => item.d.argCategory === ArgCategory.UnpackedList);
+        const positionalArgs: typeof node.d.items = [];
+        const unpackedListArgs: typeof node.d.items = [];
+        for (const item of node.d.items) {
+            if (item.d.argCategory === ArgCategory.Simple) {
+                positionalArgs.push(item);
+            } else if (item.d.argCategory === ArgCategory.UnpackedList) {
+                unpackedListArgs.push(item);
+            }
+        }
 
         let positionalIndexType: Type;
         let isPositionalIndexTypeIncomplete = false;
@@ -8224,14 +8292,14 @@ export function createTypeEvaluator(
                 return aggregatedArgs;
             };
 
-            node.d.items.forEach((arg) => {
+            for (const arg of node.d.items) {
                 if (arg.d.argCategory === ArgCategory.Simple) {
                     const typeResult = getTypeOfExpression(arg.d.valueExpr);
                     tupleTypeArgs.push({ type: typeResult.type, isUnbounded: false });
                     if (typeResult.isIncomplete) {
                         isPositionalIndexTypeIncomplete = true;
                     }
-                    return;
+                    continue;
                 }
 
                 if (arg.d.argCategory === ArgCategory.UnpackedList) {
@@ -8243,7 +8311,7 @@ export function createTypeEvaluator(
                     const deterministicEntries = getDeterministicTupleEntries(typeResult.type);
                     if (deterministicEntries) {
                         appendArray(tupleTypeArgs, deterministicEntries);
-                        return;
+                        continue;
                     }
 
                     const iterableType =
@@ -8251,14 +8319,27 @@ export function createTypeEvaluator(
                         UnknownType.create();
                     tupleTypeArgs.push({ type: iterableType, isUnbounded: true });
                 }
-            });
+            }
 
-            const unboundedCount = tupleTypeArgs.filter((typeArg) => typeArg.isUnbounded).length;
+            let unboundedCount = 0;
+            for (const typeArg of tupleTypeArgs) {
+                if (typeArg.isUnbounded) unboundedCount++;
+            }
             if (unboundedCount > 1) {
-                const firstUnboundedIndex = tupleTypeArgs.findIndex((typeArg) => typeArg.isUnbounded);
+                let firstUnboundedIndex = -1;
+                for (let i = 0; i < tupleTypeArgs.length; i++) {
+                    if (tupleTypeArgs[i].isUnbounded) {
+                        firstUnboundedIndex = i;
+                        break;
+                    }
+                }
                 const removedEntries = tupleTypeArgs.splice(firstUnboundedIndex);
+                const removedTypes: Type[] = [];
+                for (const entry of removedEntries) {
+                    removedTypes.push(entry.type);
+                }
                 tupleTypeArgs.push({
-                    type: combineTypes(removedEntries.map((entry) => entry.type)),
+                    type: combineTypes(removedTypes),
                     isUnbounded: true,
                 });
             }
@@ -8397,9 +8478,10 @@ export function createTypeEvaluator(
             !node.d.items[0].d.name &&
             node.d.items[0].d.valueExpr.nodeType === ParseNodeType.Tuple
         ) {
-            node.d.items[0].d.valueExpr.d.items.forEach((item, index) => {
+            for (let index = 0; index < node.d.items[0].d.valueExpr.d.items.length; index++) {
+                const item = node.d.items[0].d.valueExpr.d.items[index];
                 typeArgs.push(getTypeArgTypeResult(item, index));
-            });
+            }
 
             // Set the node's type so it isn't reevaluated later.
             setTypeResultForNode(node.d.items[0].d.valueExpr, { type: UnknownType.create() });
@@ -8407,7 +8489,8 @@ export function createTypeEvaluator(
             return typeArgs;
         }
 
-        node.d.items.forEach((arg, index) => {
+        for (let index = 0; index < node.d.items.length; index++) {
+            const arg = node.d.items[index];
             const typeResult = getTypeArgTypeResult(arg.d.valueExpr, index);
 
             if (arg.d.argCategory !== ArgCategory.Simple) {
@@ -8452,7 +8535,7 @@ export function createTypeEvaluator(
             ) {
                 typeArgs.push(typeResult);
             }
-        });
+        }
 
         return typeArgs;
     }
@@ -8502,11 +8585,13 @@ export function createTypeEvaluator(
         }
 
         if (node.nodeType === ParseNodeType.List) {
+            const typeList: TypeResultWithNode[] = [];
+            for (const entry of node.d.items) {
+                typeList.push({ ...getTypeOfExpression(entry, adjustedFlags), node: entry });
+            }
             typeResult = {
                 type: UnknownType.create(),
-                typeList: node.d.items.map((entry) => {
-                    return { ...getTypeOfExpression(entry, adjustedFlags), node: entry };
-                }),
+                typeList,
                 node,
             };
 
@@ -8588,10 +8673,24 @@ export function createTypeEvaluator(
         // If there are multiple unbounded entries, combine all of them into a single
         // unbounded entry to avoid violating the invariant that there can be at most
         // one unbounded entry in a tuple.
-        if (entryTypes.filter((t) => t.isUnbounded).length > 1) {
-            const firstUnboundedEntryIndex = entryTypes.findIndex((t) => t.isUnbounded);
+        let unboundedEntryCount = 0;
+        for (const t of entryTypes) {
+            if (t.isUnbounded) unboundedEntryCount++;
+        }
+        if (unboundedEntryCount > 1) {
+            let firstUnboundedEntryIndex = -1;
+            for (let i = 0; i < entryTypes.length; i++) {
+                if (entryTypes[i].isUnbounded) {
+                    firstUnboundedEntryIndex = i;
+                    break;
+                }
+            }
             const removedEntries = entryTypes.splice(firstUnboundedEntryIndex);
-            entryTypes.push({ type: combineTypes(removedEntries.map((t) => t.type)), isUnbounded: true });
+            const removedTypes: Type[] = [];
+            for (const t of removedEntries) {
+                removedTypes.push(t.type);
+            }
+            entryTypes.push({ type: combineTypes(removedTypes), isUnbounded: true });
         }
 
         return entryTypes;
@@ -8758,7 +8857,8 @@ export function createTypeEvaluator(
             : UnknownType.create();
 
         let isArgTypeIncomplete = false;
-        node.d.args.forEach((arg, index) => {
+        for (let index = 0; index < node.d.args.length; index++) {
+            const arg = node.d.args[index];
             const argTypeResult = getTypeOfExpression(arg.d.valueExpr);
             if (argTypeResult.isIncomplete) {
                 isArgTypeIncomplete = true;
@@ -8773,7 +8873,7 @@ export function createTypeEvaluator(
                     `p${index.toString()}`
                 )
             );
-        });
+        }
 
         // If the lambda's param list ends with a "/" positional parameter separator,
         // add a corresponding separator to the expected type.
@@ -8896,7 +8996,8 @@ export function createTypeEvaluator(
         let expectedText: string | undefined;
 
         // Make sure there is only one positional argument passed as arg 0.
-        node.d.args.forEach((arg, index) => {
+        for (let index = 0; index < node.d.args.length; index++) {
+            const arg = node.d.args[index];
             if (index === 0) {
                 if (arg.d.argCategory === ArgCategory.Simple && !arg.d.name) {
                     arg0Value = arg.d.valueExpr;
@@ -8928,7 +9029,7 @@ export function createTypeEvaluator(
                     }).type
                 );
             }
-        });
+        }
 
         if (!arg0Value) {
             addDiagnostic(DiagnosticRule.reportCallIssue, LocMessage.revealTypeArgs(), node);
@@ -8994,7 +9095,7 @@ export function createTypeEvaluator(
         const infoMessages: string[] = [];
 
         if (scope) {
-            scope.symbolTable.forEach((symbol, name) => {
+            for (const [name, symbol] of scope.symbolTable) {
                 if (!symbol.isIgnoredForProtocolMatch()) {
                     const typeOfSymbol = getEffectiveTypeOfSymbol(symbol);
                     infoMessages.push(
@@ -9004,7 +9105,7 @@ export function createTypeEvaluator(
                         })
                     );
                 }
-            });
+            }
         }
 
         if (infoMessages.length > 0) {
@@ -9519,7 +9620,13 @@ export function createTypeEvaluator(
                         }
                     }
 
-                    dedupedMatchResults = dedupedMatchResults.filter((t) => !isNever(t));
+                    const filteredResults: Type[] = [];
+                    for (const t of dedupedMatchResults) {
+                        if (!isNever(t)) {
+                            filteredResults.push(t);
+                        }
+                    }
+                    dedupedMatchResults = filteredResults;
                     const combinedTypes = combineTypes(dedupedMatchResults);
 
                     let returnType = combinedTypes;
@@ -9590,7 +9697,12 @@ export function createTypeEvaluator(
         }
 
         // Is there at least one overload that relies on unpacked args for a match?
-        const unpackedArgsOverloads = matches.filter((match) => match.matchResults.unpackedArgMapsToVariadic);
+        const unpackedArgsOverloads: MatchedOverloadInfo[] = [];
+        for (const match of matches) {
+            if (match.matchResults.unpackedArgMapsToVariadic) {
+                unpackedArgsOverloads.push(match);
+            }
+        }
         if (unpackedArgsOverloads.length === matches.length || unpackedArgsOverloads.length === 0) {
             return matches;
         }
@@ -9606,9 +9718,13 @@ export function createTypeEvaluator(
         }
 
         // If all of the return types match, select the first one.
+        const returnTypes: Type[] = [];
+        for (const match of matches) {
+            returnTypes.push(match.returnType);
+        }
         if (
             areTypesSame(
-                matches.map((match) => match.returnType),
+                returnTypes,
                 { treatAnySameAsUnknown: true }
             )
         ) {
@@ -9625,11 +9741,14 @@ export function createTypeEvaluator(
             // If the arg is Any or Unknown, see if the corresponding
             // parameter types differ in any way.
             if (isAnyOrUnknown(firstArgResults[i].argType)) {
-                const paramTypes = matches.map((match) =>
-                    i < match.matchResults.argParams.length
-                        ? match.matchResults.argParams[i].paramType
-                        : UnknownType.create()
-                );
+                const paramTypes: Type[] = [];
+                for (const match of matches) {
+                    paramTypes.push(
+                        i < match.matchResults.argParams.length
+                            ? match.matchResults.argParams[i].paramType
+                            : UnknownType.create()
+                    );
+                }
                 if (!areTypesSame(paramTypes, { treatAnySameAsUnknown: true })) {
                     foundAmbiguousAnyArg = true;
                 }
@@ -9641,7 +9760,14 @@ export function createTypeEvaluator(
         // that one of the arguments is an unpacked iterator, and it maps to
         // an indeterminate number of parameters, which means that the overload
         // selection is ambiguous.
-        if (foundAmbiguousAnyArg || matches.some((match) => match.argResults.length !== firstArgResults.length)) {
+        let hasLengthMismatch = false;
+        for (const match of matches) {
+            if (match.argResults.length !== firstArgResults.length) {
+                hasLengthMismatch = true;
+                break;
+            }
+        }
+        if (foundAmbiguousAnyArg || hasLengthMismatch) {
             return matches;
         }
 
@@ -9750,19 +9876,18 @@ export function createTypeEvaluator(
                         ? overloads[0].shared.name
                         : '<anonymous function>';
                 const diagAddendum = new DiagnosticAddendum();
-                const argTypes = argList.map((t) => {
+                const argTypes: string[] = [];
+                for (const t of argList) {
                     const typeString = printType(getTypeOfArg(t, /* inferenceContext */ undefined).type);
 
                     if (t.argCategory === ArgCategory.UnpackedList) {
-                        return `*${typeString}`;
+                        argTypes.push(`*${typeString}`);
+                    } else if (t.argCategory === ArgCategory.UnpackedDictionary) {
+                        argTypes.push(`**${typeString}`);
+                    } else {
+                        argTypes.push(typeString);
                     }
-
-                    if (t.argCategory === ArgCategory.UnpackedDictionary) {
-                        return `**${typeString}`;
-                    }
-
-                    return typeString;
-                });
+                }
 
                 diagAddendum.addMessage(LocAddendum.argumentTypes().format({ types: argTypes.join(', ') }));
                 addDiagnostic(
@@ -9781,12 +9906,17 @@ export function createTypeEvaluator(
             // Find the match with the smallest argument match score. If there
             // are more than one with the same score, use the one with the
             // largest index. Later overloads tend to be more general.
-            const bestMatch = filteredMatchResults.reduce((previous, current) => {
-                if (current.argumentMatchScore === previous.argumentMatchScore) {
-                    return current.overloadIndex > previous.overloadIndex ? current : previous;
+            let bestMatch = filteredMatchResults[0];
+            for (let i = 1; i < filteredMatchResults.length; i++) {
+                const current = filteredMatchResults[i];
+                if (current.argumentMatchScore === bestMatch.argumentMatchScore) {
+                    if (current.overloadIndex > bestMatch.overloadIndex) {
+                        bestMatch = current;
+                    }
+                } else if (current.argumentMatchScore < bestMatch.argumentMatchScore) {
+                    bestMatch = current;
                 }
-                return current.argumentMatchScore < previous.argumentMatchScore ? current : previous;
-            });
+            }
 
             // If there is more than one filtered match, report that no match
             // was possible and emit a diagnostic that provides the most likely.
@@ -9856,20 +9986,20 @@ export function createTypeEvaluator(
                     // Evaluate the types of each argument expression without regard to
                     // the context. We'll use this to determine whether we need to do
                     // union expansion.
-                    contextFreeArgTypes = argList.map((arg) => {
+                    const types: Type[] = [];
+                    for (const arg of argList) {
                         if (arg.typeResult) {
-                            return arg.typeResult.type;
-                        }
-
-                        if (arg.valueExpression) {
+                            types.push(arg.typeResult.type);
+                        } else if (arg.valueExpression) {
                             const valueExpressionNode = arg.valueExpression;
-                            return useSpeculativeMode(valueExpressionNode, () => {
+                            types.push(useSpeculativeMode(valueExpressionNode, () => {
                                 return getTypeOfExpression(valueExpressionNode).type;
-                            });
+                            }));
+                        } else {
+                            types.push(AnyType.create());
                         }
-
-                        return AnyType.create();
-                    });
+                    }
+                    contextFreeArgTypes = types;
                 });
             }
 
@@ -10644,7 +10774,8 @@ export function createTypeEvaluator(
                 const diagAddendum = new DiagnosticAddendum();
                 const errorsToDisplay = 2;
 
-                abstractSymbols.forEach((abstractMethod, index) => {
+                for (let index = 0; index < abstractSymbols.length; index++) {
+                    const abstractMethod = abstractSymbols[index];
                     if (index === errorsToDisplay) {
                         diagAddendum.addMessage(
                             LocAddendum.memberIsAbstractMore().format({
@@ -10662,7 +10793,7 @@ export function createTypeEvaluator(
                             );
                         }
                     }
-                });
+                }
 
                 addDiagnostic(
                     DiagnosticRule.reportAbstractUsage,
@@ -10962,9 +11093,13 @@ export function createTypeEvaluator(
 
         // Determine how many positional args are being passed before
         // we see a keyword arg.
-        let positionalArgCount = argList.findIndex(
-            (arg) => arg.argCategory === ArgCategory.UnpackedDictionary || arg.name !== undefined
-        );
+        let positionalArgCount = -1;
+        for (let i = 0; i < argList.length; i++) {
+            if (argList[i].argCategory === ArgCategory.UnpackedDictionary || argList[i].name !== undefined) {
+                positionalArgCount = i;
+                break;
+            }
+        }
         if (positionalArgCount < 0) {
             positionalArgCount = argList.length;
         }
@@ -11021,13 +11156,18 @@ export function createTypeEvaluator(
             for (let ali = 0; ali < argList.length; ali++) {
                 const arg = argList[ali];
                 if (arg.name) {
-                    const keywordParamIndex = paramDetails.params.findIndex((paramInfo) => {
+                    let keywordParamIndex = -1;
+                    for (let kpi = 0; kpi < paramDetails.params.length; kpi++) {
+                        const paramInfo = paramDetails.params[kpi];
                         assert(paramInfo, 'paramInfo entry is undefined fork kwargs check');
-                        return (
+                        if (
                             paramInfo.param.name === arg.name!.d.value &&
                             paramInfo.param.category === ParamCategory.Simple
-                        );
-                    });
+                        ) {
+                            keywordParamIndex = kpi;
+                            break;
+                        }
+                    }
 
                     // Is this a parameter that can be interpreted as either a keyword or a positional?
                     // If so, we'll treat it as a keyword parameter in this case because it's being
@@ -11390,7 +11530,13 @@ export function createTypeEvaluator(
             paramIndex < positionalOnlyLimitIndex &&
             (!foundUnpackedListArg || hasParamSpecArgsKwargs)
         ) {
-            const firstParamWithDefault = paramDetails.params.findIndex((paramInfo) => !!paramInfo.defaultType);
+            let firstParamWithDefault = -1;
+            for (let fpi = 0; fpi < paramDetails.params.length; fpi++) {
+                if (paramDetails.params[fpi].defaultType) {
+                    firstParamWithDefault = fpi;
+                    break;
+                }
+            }
             const positionOnlyWithoutDefaultsCount =
                 firstParamWithDefault >= 0 && firstParamWithDefault < positionalOnlyLimitIndex
                     ? firstParamWithDefault
@@ -11458,7 +11604,7 @@ export function createTypeEvaluator(
                         const tdEntries = getTypedDictMembersForClass(evaluatorInterface, argType);
                         const diag = new DiagnosticAddendum();
 
-                        tdEntries.knownItems.forEach((entry, name) => {
+                        for (const [name, entry] of tdEntries.knownItems) {
                             const paramEntry = paramTracker.lookupName(name);
                             if (paramEntry) {
                                 if (paramEntry.argsReceived > 0) {
@@ -11466,9 +11612,13 @@ export function createTypeEvaluator(
                                 } else {
                                     paramEntry.argsReceived++;
 
-                                    const paramInfoIndex = paramDetails.params.findIndex(
-                                        (paramInfo) => paramInfo.param.name === name
-                                    );
+                                    let paramInfoIndex = -1;
+                                    for (let pi = 0; pi < paramDetails.params.length; pi++) {
+                                        if (paramDetails.params[pi].param.name === name) {
+                                            paramInfoIndex = pi;
+                                            break;
+                                        }
+                                    }
                                     assert(paramInfoIndex >= 0);
                                     const paramType = paramDetails.params[paramInfoIndex].type;
 
@@ -11509,7 +11659,7 @@ export function createTypeEvaluator(
                                     diag.addMessage(LocMessage.paramNameMissing().format({ name }));
                                 }
                             }
-                        });
+                        }
 
                         const extraItemsType = tdEntries.extraItems?.valueType ?? getObjectType();
                         if (!isNever(extraItemsType)) {
@@ -11658,11 +11808,16 @@ export function createTypeEvaluator(
                             } else {
                                 paramEntry.argsReceived++;
 
-                                const paramInfoIndex = paramDetails.params.findIndex(
-                                    (paramInfo) =>
-                                        paramInfo.param.name === paramNameValue &&
-                                        paramInfo.kind !== ParamKind.Positional
-                                );
+                                let paramInfoIndex = -1;
+                                for (let pi = 0; pi < paramDetails.params.length; pi++) {
+                                    if (
+                                        paramDetails.params[pi].param.name === paramNameValue &&
+                                        paramDetails.params[pi].kind !== ParamKind.Positional
+                                    ) {
+                                        paramInfoIndex = pi;
+                                        break;
+                                    }
+                                }
                                 assert(paramInfoIndex >= 0);
                                 const paramType = paramDetails.params[paramInfoIndex].type;
 
@@ -11772,7 +11927,8 @@ export function createTypeEvaluator(
                 // Don't consider any position-only parameters, since they cannot be matched to
                 // **kwargs arguments. Consider parameters that are either positional or keyword
                 // if there is no *args argument.
-                paramDetails.params.forEach((paramInfo, paramIndex) => {
+                for (let paramIndex = 0; paramIndex < paramDetails.params.length; paramIndex++) {
+                    const paramInfo = paramDetails.params[paramIndex];
                     const param = paramInfo.param;
                     if (
                         paramIndex >= paramDetails.firstPositionOrKeywordIndex &&
@@ -11783,6 +11939,13 @@ export function createTypeEvaluator(
                         const paramType = paramDetails.params[paramIndex].type;
 
                         if (!unpackedDictKeyNames || unpackedDictKeyNames.includes(param.name)) {
+                            let unpackedDictErrorNode: ExpressionNode | undefined;
+                            for (const arg of argList) {
+                                if (arg.argCategory === ArgCategory.UnpackedDictionary) {
+                                    unpackedDictErrorNode = arg.valueExpression;
+                                    break;
+                                }
+                            }
                             validateArgTypeParams.push({
                                 paramCategory: ParamCategory.Simple,
                                 paramType,
@@ -11791,9 +11954,7 @@ export function createTypeEvaluator(
                                     argCategory: ArgCategory.Simple,
                                     typeResult: { type: unpackedDictArgType! },
                                 },
-                                errorNode:
-                                    argList.find((arg) => arg.argCategory === ArgCategory.UnpackedDictionary)
-                                        ?.valueExpression ?? errorNode,
+                                errorNode: unpackedDictErrorNode ?? errorNode,
                                 paramName: param.name,
                                 isParamNameSynthesized: FunctionParam.isNameSynthesized(param),
                             });
@@ -11801,7 +11962,7 @@ export function createTypeEvaluator(
                             paramTracker.markArgReceived(paramDetails.params[paramIndex]);
                         }
                     }
-                });
+                }
             }
 
             // Determine whether there are any parameters that require arguments
@@ -11813,7 +11974,11 @@ export function createTypeEvaluator(
 
                 if (unassignedParams.length > 0) {
                     if (!canSkipDiagnosticForNode(errorNode)) {
-                        const missingParamNames = unassignedParams.map((p) => `"${p}"`).join(', ');
+                        let missingParamNames = '';
+                        for (let i = 0; i < unassignedParams.length; i++) {
+                            if (i > 0) missingParamNames += ', ';
+                            missingParamNames += `"${unassignedParams[i]}"`;
+                        }
                         if (!canSkipDiagnosticForNode(errorNode) && !isTypeIncomplete) {
                             addDiagnostic(
                                 DiagnosticRule.reportCallIssue,
@@ -11832,7 +11997,7 @@ export function createTypeEvaluator(
                 // def foo(v1: _T = 'default')
                 // and _T is a TypeVar, we need to match the TypeVar to the default
                 // value's type if it's not provided by the caller.
-                paramDetails.params.forEach((paramInfo) => {
+                for (const paramInfo of paramDetails.params) {
                     const param = paramInfo.param;
                     if (param.category === ParamCategory.Simple && param.name) {
                         const entry = paramTracker.lookupDetails(paramInfo);
@@ -11861,7 +12026,7 @@ export function createTypeEvaluator(
                             }
                         }
                     }
-                });
+                }
             }
         }
 
@@ -12196,14 +12361,15 @@ export function createTypeEvaluator(
         ) {
             const typeParams = type.priv.strippedFirstParamType.shared.typeParams;
             specializedInitSelfType = type.priv.strippedFirstParamType;
-            type.priv.strippedFirstParamType.priv.typeArgs.forEach((typeArg, index) => {
+            for (let index = 0; index < type.priv.strippedFirstParamType.priv.typeArgs.length; index++) {
+                const typeArg = type.priv.strippedFirstParamType.priv.typeArgs[index];
                 if (index < typeParams.length) {
                     const typeParam = typeParams[index];
                     if (!isTypeSame(typeParam, typeArg, { ignorePseudoGeneric: true })) {
                         constraints.setBounds(typeParams[index], typeArg);
                     }
                 }
-            });
+            }
         }
 
         // Special-case a few built-in calls that are often used for
@@ -12417,19 +12583,19 @@ export function createTypeEvaluator(
         // If the function includes a ParamSpec and the captured signature(s) includes
         // generic types, we may need to apply those solved TypeVars.
         if (paramSpecConstraints.length > 0) {
-            paramSpecConstraints.forEach((paramSpecConstraints) => {
-                if (paramSpecConstraints) {
-                    specializedReturnType = solveAndApplyConstraints(specializedReturnType, paramSpecConstraints);
+            for (const paramSpecConstraint of paramSpecConstraints) {
+                if (paramSpecConstraint) {
+                    specializedReturnType = solveAndApplyConstraints(specializedReturnType, paramSpecConstraint);
 
                     // It's possible that one or more of the TypeVars or ParamSpecs
                     // in the constraints refer to TypeVars that were solved in
                     // the paramSpecConstraints. Apply these solved TypeVars accordingly.
                     applySourceSolutionToConstraints(
                         constraints,
-                        solveConstraints(evaluatorInterface, paramSpecConstraints)
+                        solveConstraints(evaluatorInterface, paramSpecConstraint)
                     );
                 }
-            });
+            }
         }
 
         // If the final return type is an unpacked tuple, turn it into a normal (unpacked) tuple.
@@ -12594,7 +12760,7 @@ export function createTypeEvaluator(
             // Evaluate types of all args. This will ensure that referenced symbols are
             // not reported as unaccessed. Also pass the expected parameter type as
             // inference context to enable proper completions even when there are errors.
-            matchResults.argParams.forEach((argParam) => {
+            for (const argParam of matchResults.argParams) {
                 if (argParam.argument.valueExpression && !isSpeculativeModeInUse(argParam.argument.valueExpression)) {
                     getTypeOfExpression(
                         argParam.argument.valueExpression,
@@ -12602,18 +12768,24 @@ export function createTypeEvaluator(
                         makeInferenceContext(argParam.paramType)
                     );
                 }
-            });
+            }
 
             // Also evaluate any arguments that weren't matched to parameters
-            argList.forEach((arg) => {
+            for (const arg of argList) {
                 if (arg.valueExpression && !isSpeculativeModeInUse(arg.valueExpression)) {
                     // Check if this argument was already evaluated above
-                    const wasEvaluated = matchResults.argParams.some((argParam) => argParam.argument === arg);
+                    let wasEvaluated = false;
+                    for (const argParam of matchResults.argParams) {
+                        if (argParam.argument === arg) {
+                            wasEvaluated = true;
+                            break;
+                        }
+                    }
                     if (!wasEvaluated) {
                         getTypeOfExpression(arg.valueExpression);
                     }
                 }
-            });
+            }
             // Use a return type of Unknown but attach a "possible type" to it
             // so the completion provider can suggest better completions.
             const possibleType = FunctionType.getEffectiveReturnType(typeResult.type);
@@ -12660,7 +12832,7 @@ export function createTypeEvaluator(
         const constraintTrackers: (ConstraintTracker | undefined)[] = [];
         const speculativeNode = getSpeculativeNodeForCall(errorNode);
 
-        sets.forEach((context) => {
+        for (const context of sets) {
             // Use speculative mode to avoid emitting errors or caching types.
             useSpeculativeMode(speculativeNode, () => {
                 const paramSpecArgResult = validateArgTypesForParamSpecSignature(
@@ -12676,7 +12848,7 @@ export function createTypeEvaluator(
 
                 appendArray(constraintTrackers, paramSpecArgResult.constraintTrackers);
             });
-        });
+        }
 
         // Copy back any compatible signature contexts if any were compatible.
         if (filteredSets.length > 0) {
@@ -12711,11 +12883,11 @@ export function createTypeEvaluator(
         if (matchResults.argumentErrors) {
             // Evaluate types of all args. This will ensure that referenced symbols are
             // not reported as unaccessed.
-            argList.forEach((arg) => {
+            for (const arg of argList) {
                 if (arg.valueExpression && !isSpeculativeModeInUse(arg.valueExpression)) {
                     getTypeOfExpression(arg.valueExpression);
                 }
-            });
+            }
 
             return { argumentErrors: true, constraintTrackers: [constraints] };
         }
@@ -13088,7 +13260,7 @@ export function createTypeEvaluator(
 
         const firstArg = argList[0];
         if (firstArg.valueExpression && firstArg.valueExpression.nodeType === ParseNodeType.StringList) {
-            typeVarName = firstArg.valueExpression.d.strings.map((s) => s.d.value).join('');
+            typeVarName = _joinStringNodeValues(firstArg.valueExpression.d.strings);
         } else {
             addDiagnostic(
                 DiagnosticRule.reportGeneralTypeIssues,
@@ -13327,7 +13499,7 @@ export function createTypeEvaluator(
 
         const firstArg = argList[0];
         if (firstArg.valueExpression && firstArg.valueExpression.nodeType === ParseNodeType.StringList) {
-            typeVarName = firstArg.valueExpression.d.strings.map((s) => s.d.value).join('');
+            typeVarName = _joinStringNodeValues(firstArg.valueExpression.d.strings);
         } else {
             addDiagnostic(
                 DiagnosticRule.reportGeneralTypeIssues,
@@ -13418,7 +13590,7 @@ export function createTypeEvaluator(
         const firstArg = argList[0];
         let paramSpecName = '';
         if (firstArg.valueExpression && firstArg.valueExpression.nodeType === ParseNodeType.StringList) {
-            paramSpecName = firstArg.valueExpression.d.strings.map((s) => s.d.value).join('');
+            paramSpecName = _joinStringNodeValues(firstArg.valueExpression.d.strings);
         } else {
             addDiagnostic(
                 DiagnosticRule.reportGeneralTypeIssues,
@@ -13492,7 +13664,8 @@ export function createTypeEvaluator(
         }
 
         if (node.nodeType === ParseNodeType.List) {
-            node.d.items.forEach((paramExpr, index) => {
+            for (let index = 0; index < node.d.items.length; index++) {
+                const paramExpr = node.d.items[index];
                 const typeResult = getTypeOfExpressionExpectingType(paramExpr, {
                     allowTypeVarsWithoutScopeId: true,
                     forwardRefs: isPep695Syntax,
@@ -13508,7 +13681,7 @@ export function createTypeEvaluator(
                         `__p${index}`
                     )
                 );
-            });
+            }
 
             if (node.d.items.length > 0) {
                 FunctionType.addPositionOnlyParamSeparator(functionType);
@@ -13582,7 +13755,7 @@ export function createTypeEvaluator(
 
         const firstArg = argList[0];
         if (firstArg.valueExpression && firstArg.valueExpression.nodeType === ParseNodeType.StringList) {
-            const typeAliasName = firstArg.valueExpression.d.strings.map((s) => s.d.value).join('');
+            const typeAliasName = _joinStringNodeValues(firstArg.valueExpression.d.strings);
             if (typeAliasName !== nameNode.d.value) {
                 addDiagnostic(
                     DiagnosticRule.reportGeneralTypeIssues,
@@ -13640,7 +13813,7 @@ export function createTypeEvaluator(
 
             typeParams = [];
             let isTypeParamListValid = true;
-            typeParamsExpr.d.items.map((expr) => {
+            for (const expr of typeParamsExpr.d.items) {
                 let entryType = getTypeOfExpression(
                     expr,
                     EvalFlags.InstantiableType | EvalFlags.AllowTypeVarWithoutScopeId
@@ -13662,7 +13835,7 @@ export function createTypeEvaluator(
                 } else {
                     isTypeParamListValid = false;
                 }
-            });
+            }
 
             if (!isTypeParamListValid) {
                 addDiagnostic(
@@ -13733,7 +13906,7 @@ export function createTypeEvaluator(
             nameArg.valueExpression &&
             nameArg.valueExpression.nodeType === ParseNodeType.StringList
         ) {
-            className = nameArg.valueExpression.d.strings.map((s) => s.d.value).join('');
+            className = _joinStringNodeValues(nameArg.valueExpression.d.strings);
         }
 
         if (!className) {
@@ -13886,7 +14059,7 @@ export function createTypeEvaluator(
             metaclass,
             arg1Type.shared.effectiveMetaclass
         );
-        arg1Type.priv.tupleTypeArgs.forEach((typeArg) => {
+        for (const typeArg of arg1Type.priv.tupleTypeArgs) {
             const specializedType = makeTopLevelTypeVarsConcrete(typeArg.type);
 
             if (isEffectivelyInstantiable(specializedType)) {
@@ -13894,7 +14067,7 @@ export function createTypeEvaluator(
             } else {
                 classType.shared.baseClasses.push(UnknownType.create());
             }
-        });
+        }
 
         if (!computeMroLinearization(classType)) {
             addDiagnostic(DiagnosticRule.reportGeneralTypeIssues, LocMessage.methodOrdering(), errorNode);
@@ -13961,12 +14134,13 @@ export function createTypeEvaluator(
             }
 
             if (magicMethodType) {
-                const functionArgs: Arg[] = argList.map((arg) => {
-                    return {
+                const functionArgs: Arg[] = [];
+                for (const arg of argList) {
+                    functionArgs.push({
                         argCategory: ArgCategory.Simple,
                         typeResult: arg,
-                    };
-                });
+                    });
+                }
 
                 let callResult: CallResult | undefined;
 
@@ -14264,14 +14438,22 @@ export function createTypeEvaluator(
             typeErrors = true;
         }
 
+        const keyTypeArray: Type[] = [];
+        for (const result of keyTypes) {
+            keyTypeArray.push(result.type);
+        }
         const specializedKeyType = inferTypeArgFromExpectedEntryType(
             makeInferenceContext(expectedKeyType),
-            keyTypes.map((result) => result.type),
+            keyTypeArray,
             /* isNarrowable */ false
         );
+        const valueTypeArray: Type[] = [];
+        for (const result of valueTypes) {
+            valueTypeArray.push(result.type);
+        }
         const specializedValueType = inferTypeArgFromExpectedEntryType(
             makeInferenceContext(expectedValueType),
-            valueTypes.map((result) => result.type),
+            valueTypeArray,
             !isValueTypeInvariant
         );
         if (!specializedKeyType || !specializedValueType) {
@@ -14315,12 +14497,14 @@ export function createTypeEvaluator(
         }
 
         // Strip any literal values and TypeForm types.
-        const keyTypes = keyTypeResults.map((t) =>
-            stripTypeForm(convertSpecialFormToRuntimeValue(stripLiteralValue(t.type), flags, !hasExpectedType))
-        );
-        const valueTypes = valueTypeResults.map((t) =>
-            stripTypeForm(convertSpecialFormToRuntimeValue(stripLiteralValue(t.type), flags, !hasExpectedType))
-        );
+        const keyTypes: Type[] = [];
+        for (const t of keyTypeResults) {
+            keyTypes.push(stripTypeForm(convertSpecialFormToRuntimeValue(stripLiteralValue(t.type), flags, !hasExpectedType)));
+        }
+        const valueTypes: Type[] = [];
+        for (const t of valueTypeResults) {
+            valueTypes.push(stripTypeForm(convertSpecialFormToRuntimeValue(stripLiteralValue(t.type), flags, !hasExpectedType)));
+        }
 
         if (keyTypes.length > 0) {
             if (AnalyzerNodeInfo.getFileInfo(node).diagnosticRuleSet.strictDictionaryInference || hasExpectedType) {
@@ -14391,7 +14575,8 @@ export function createTypeEvaluator(
         const keyFlags = flags & ~(EvalFlags.TypeExpression | EvalFlags.StrLiteralAsType | EvalFlags.InstantiableType);
 
         // Infer the key and value types if possible.
-        node.d.items.forEach((entryNode, index) => {
+        for (let index = 0; index < node.d.items.length; index++) {
+            const entryNode = node.d.items[index];
             let addUnknown = true;
 
             if (entryNode.nodeType === ParseNodeType.DictionaryKeyEntry) {
@@ -14489,7 +14674,13 @@ export function createTypeEvaluator(
                     // If an existing key has the same literal type, delete the previous
                     // key since we're overwriting it here.
                     if (isClass(keyType) && isLiteralType(keyType)) {
-                        const existingIndex = keyTypes.findIndex((kt) => isTypeSame(keyType, kt.type));
+                        let existingIndex = -1;
+                        for (let i = 0; i < keyTypes.length; i++) {
+                            if (isTypeSame(keyType, keyTypes[i].type)) {
+                                existingIndex = i;
+                                break;
+                            }
+                        }
                         if (existingIndex >= 0) {
                             keyTypes.splice(existingIndex, 1);
                             valueTypes.splice(existingIndex, 1);
@@ -14562,7 +14753,7 @@ export function createTypeEvaluator(
                             /* allowNarrowed */ true
                         );
 
-                        tdEntries.knownItems.forEach((entry, name) => {
+                        for (const [name, entry] of tdEntries.knownItems) {
                             if (entry.isRequired || entry.isProvided) {
                                 keyTypes.push({
                                     node: entryNode,
@@ -14570,7 +14761,7 @@ export function createTypeEvaluator(
                                 });
                                 valueTypes.push({ node: entryNode, type: entry.valueType });
                             }
-                        });
+                        }
 
                         if (!expectedTypedDictEntries) {
                             keyTypes.push({ node: entryNode, type: ClassType.cloneAsInstance(strObject) });
@@ -14637,7 +14828,13 @@ export function createTypeEvaluator(
 
                 // The result should be a tuple.
                 if (isClassInstance(dictEntryType) && isTupleClass(dictEntryType)) {
-                    const typeArgs = dictEntryType.priv.tupleTypeArgs?.map((t) => t.type);
+                    let typeArgs: Type[] | undefined;
+                    if (dictEntryType.priv.tupleTypeArgs) {
+                        typeArgs = [];
+                        for (const t of dictEntryType.priv.tupleTypeArgs) {
+                            typeArgs.push(t.type);
+                        }
+                    }
                     if (typeArgs && typeArgs.length === 2) {
                         if (forceStrictInference || index < maxEntriesToUseForInference) {
                             keyTypes.push({ node: entryNode, type: typeArgs[0] });
@@ -14654,7 +14851,7 @@ export function createTypeEvaluator(
                     valueTypes.push({ node: entryNode, type: UnknownType.create() });
                 }
             }
-        });
+        }
 
         return { type: AnyType.create(), isIncomplete, typeErrors };
     }
@@ -14754,7 +14951,7 @@ export function createTypeEvaluator(
 
         const entryTypes: Type[] = [];
         const expectedTypeDiagAddendum = new DiagnosticAddendum();
-        node.d.items.forEach((entry) => {
+        for (const entry of node.d.items) {
             let entryTypeResult: TypeResult;
 
             if (entry.nodeType === ParseNodeType.Comprehension) {
@@ -14788,18 +14985,21 @@ export function createTypeEvaluator(
             if (verifyHashable && !entryTypeResult.isIncomplete && !entryTypeResult.typeErrors) {
                 verifySetEntryOrDictKeyIsHashable(entry, entryTypeResult.type, /* isDictKey */ false);
             }
-        });
+        }
 
         let isTypeInvariant = false;
 
         if (isClassInstance(inferenceContext.expectedType)) {
             inferVarianceForClass(inferenceContext.expectedType);
 
-            if (
-                inferenceContext.expectedType.shared.typeParams.some(
-                    (t) => TypeVarType.getVariance(t) === Variance.Invariant
-                )
-            ) {
+            let hasInvariantParam = false;
+            for (const t of inferenceContext.expectedType.shared.typeParams) {
+                if (TypeVarType.getVariance(t) === Variance.Invariant) {
+                    hasInvariantParam = true;
+                    break;
+                }
+            }
+            if (hasInvariantParam) {
                 isTypeInvariant = true;
             }
         }
@@ -14873,7 +15073,8 @@ export function createTypeEvaluator(
         let typeErrors = false;
 
         let entryTypes: Type[] = [];
-        node.d.items.forEach((entry, index) => {
+        for (let index = 0; index < node.d.items.length; index++) {
+            const entry = node.d.items[index];
             let entryTypeResult: TypeResult;
 
             if (entry.nodeType === ParseNodeType.Comprehension && !entry.d.isGenerator) {
@@ -14901,9 +15102,13 @@ export function createTypeEvaluator(
             if (verifyHashable && !entryTypeResult.isIncomplete && !entryTypeResult.typeErrors) {
                 verifySetEntryOrDictKeyIsHashable(entry, entryTypeResult.type, /* isDictKey */ false);
             }
-        });
+        }
 
-        entryTypes = entryTypes.map((t) => stripLiteralValue(t));
+        const strippedEntryTypes: Type[] = [];
+        for (const t of entryTypes) {
+            strippedEntryTypes.push(stripLiteralValue(t));
+        }
+        entryTypes = strippedEntryTypes;
 
         let inferredEntryType: Type = hasExpectedType ? AnyType.create() : UnknownType.create();
         if (entryTypes.length > 0) {
@@ -14975,11 +15180,11 @@ export function createTypeEvaluator(
         const expectedType = inferenceContext.expectedType;
         let isCompatible = true;
 
-        entryTypes.forEach((entryType) => {
+        for (const entryType of entryTypes) {
             if (isCompatible && !assignType(expectedType, entryType, /* diag */ undefined, constraints)) {
                 isCompatible = false;
             }
-        });
+        }
 
         if (!isCompatible) {
             return undefined;
@@ -15172,7 +15377,8 @@ export function createTypeEvaluator(
             // all of the permutations.
             let sawParamMismatch = false;
 
-            node.d.params.forEach((param, index) => {
+            for (let index = 0; index < node.d.params.length; index++) {
+                const param = node.d.params[index];
                 let paramType: Type | undefined;
 
                 if (expectedParamDetails && !sawParamMismatch) {
@@ -15255,7 +15461,7 @@ export function createTypeEvaluator(
                 );
 
                 FunctionType.addParam(functionType, functionParam);
-            });
+            }
 
             if (paramsArePositionOnly && functionType.shared.parameters.length > 0) {
                 FunctionType.addPositionOnlyParamSeparator(functionType);
@@ -15338,12 +15544,18 @@ export function createTypeEvaluator(
         // If any of the "for" clauses are marked async or any of the "if" clauses
         // or any clause other than the leftmost "for" contain an "await" operator,
         // it is treated as an async generator.
-        let isAsync = node.d.forIfNodes.some((comp, index) => {
+        let isAsync = false;
+        for (let index = 0; index < node.d.forIfNodes.length; index++) {
+            const comp = node.d.forIfNodes[index];
             if (comp.nodeType === ParseNodeType.ComprehensionFor && comp.d.isAsync) {
-                return true;
+                isAsync = true;
+                break;
             }
-            return index > 0 && ParseTreeUtils.containsAwaitNode(comp);
-        });
+            if (index > 0 && ParseTreeUtils.containsAwaitNode(comp)) {
+                isAsync = true;
+                break;
+            }
+        }
         let type: Type = UnknownType.create();
 
         if (ParseTreeUtils.containsAwaitNode(node.d.expr)) {
@@ -15584,9 +15796,9 @@ export function createTypeEvaluator(
                 addDiagnostic(DiagnosticRule.reportInvalidTypeForm, LocMessage.typeArgListNotAllowed(), argResult.node);
                 return false;
             } else {
-                argResult.typeList.forEach((typeArg) => {
+                for (const typeArg of argResult.typeList) {
                     validateTypeArg(typeArg);
-                });
+                }
             }
         }
 
@@ -15677,7 +15889,8 @@ export function createTypeEvaluator(
                     sawUnpacked = true;
                 };
 
-                typeList.forEach((entry, index) => {
+                for (let index = 0; index < typeList.length; index++) {
+                    const entry = typeList[index];
                     let entryType = entry.type;
                     let paramCategory: ParamCategory = ParamCategory.Simple;
                     const paramName = `__p${index.toString()}`;
@@ -15690,12 +15903,17 @@ export function createTypeEvaluator(
                         if (isUnpackedClass(entryType)) {
                             paramCategory = ParamCategory.ArgsList;
 
-                            if (
-                                entryType.priv.tupleTypeArgs?.some(
-                                    (typeArg) => isTypeVarTuple(typeArg.type) || typeArg.isUnbounded
-                                )
-                            ) {
-                                noteSawUnpacked(entry);
+                            if (entryType.priv.tupleTypeArgs) {
+                                let hasUnpackedTypeArg = false;
+                                for (const typeArg of entryType.priv.tupleTypeArgs) {
+                                    if (isTypeVarTuple(typeArg.type) || typeArg.isUnbounded) {
+                                        hasUnpackedTypeArg = true;
+                                        break;
+                                    }
+                                }
+                                if (hasUnpackedTypeArg) {
+                                    noteSawUnpacked(entry);
+                                }
                             }
                         }
                     } else {
@@ -15711,7 +15929,7 @@ export function createTypeEvaluator(
                             paramName
                         )
                     );
-                });
+                }
 
                 if (typeList.length > 0) {
                     FunctionType.addPositionOnlyParamSeparator(functionType);
@@ -15725,7 +15943,8 @@ export function createTypeEvaluator(
                 if (isInstantiableClass(typeArgs[0].type) && ClassType.isBuiltIn(typeArgs[0].type, 'Concatenate')) {
                     const concatTypeArgs = typeArgs[0].type.priv.typeArgs;
                     if (concatTypeArgs && concatTypeArgs.length > 0) {
-                        concatTypeArgs.forEach((typeArg, index) => {
+                        for (let index = 0; index < concatTypeArgs.length; index++) {
+                            const typeArg = concatTypeArgs[index];
                             if (index === concatTypeArgs.length - 1) {
                                 FunctionType.addPositionOnlyParamSeparator(functionType);
 
@@ -15746,7 +15965,7 @@ export function createTypeEvaluator(
                                     )
                                 );
                             }
-                        });
+                        }
                     }
                 } else {
                     addDiagnostic(
@@ -15906,7 +16125,7 @@ export function createTypeEvaluator(
                 }
             } else if (itemExpr.nodeType === ParseNodeType.StringList) {
                 const isBytes = (itemExpr.d.strings[0].d.token.flags & StringTokenFlags.Bytes) !== 0;
-                const value = itemExpr.d.strings.map((s) => s.d.value).join('');
+                const value = _joinStringNodeValues(itemExpr.d.strings);
                 if (isBytes) {
                     type = cloneBuiltinClassWithLiteral(node, classType, 'bytes', value);
                 } else {
@@ -15914,7 +16133,7 @@ export function createTypeEvaluator(
                 }
 
                 if ((flags & EvalFlags.TypeExpression) !== 0) {
-                    itemExpr.d.strings.forEach((stringNode) => {
+                    for (const stringNode of itemExpr.d.strings) {
                         if ((stringNode.d.token.flags & StringTokenFlags.NamedUnicodeEscape) !== 0) {
                             addDiagnostic(
                                 DiagnosticRule.reportInvalidTypeForm,
@@ -15923,7 +16142,7 @@ export function createTypeEvaluator(
                             );
                             isValidTypeForm = false;
                         }
-                    });
+                    }
                 }
             } else if (itemExpr.nodeType === ParseNodeType.Number) {
                 if (!itemExpr.d.isImaginary && itemExpr.d.isInteger) {
@@ -16070,9 +16289,10 @@ export function createTypeEvaluator(
             return UnknownType.create();
         }
 
-        const convertedTypeArgs = typeArgs.map((typeArg) => {
-            return convertToInstance(validateTypeArg(typeArg) ? typeArg.type : UnknownType.create());
-        });
+        const convertedTypeArgs: Type[] = [];
+        for (const typeArg of typeArgs) {
+            convertedTypeArgs.push(convertToInstance(validateTypeArg(typeArg) ? typeArg.type : UnknownType.create()));
+        }
         let resultType = ClassType.specialize(classType, convertedTypeArgs);
 
         if (isTypeFormSupported(errorNode)) {
@@ -16103,9 +16323,10 @@ export function createTypeEvaluator(
             return UnknownType.create();
         }
 
-        const convertedTypeArgs = typeArgs.map((typeArg) => {
-            return convertToInstance(validateTypeArg(typeArg) ? typeArg.type : UnknownType.create());
-        });
+        const convertedTypeArgs: Type[] = [];
+        for (const typeArg of typeArgs) {
+            convertedTypeArgs.push(convertToInstance(validateTypeArg(typeArg) ? typeArg.type : UnknownType.create()));
+        }
 
         let resultType = ClassType.specialize(classType, convertedTypeArgs);
 
@@ -16395,7 +16616,8 @@ export function createTypeEvaluator(
         if (!typeArgs || typeArgs.length === 0) {
             addDiagnostic(DiagnosticRule.reportInvalidTypeForm, LocMessage.concatenateTypeArgsMissing(), errorNode);
         } else {
-            typeArgs.forEach((typeArg, index) => {
+            for (let index = 0; index < typeArgs.length; index++) {
+                const typeArg = typeArgs[index];
                 if (index === typeArgs.length - 1) {
                     if (!isParamSpec(typeArg.type) && !isEllipsisType(typeArg.type)) {
                         addDiagnostic(
@@ -16425,7 +16647,7 @@ export function createTypeEvaluator(
                         );
                     }
                 }
-            });
+            }
         }
 
         return createSpecialType(classType, typeArgs, /* paramLimit */ undefined, /* allowParamSpec */ true);
@@ -16529,7 +16751,8 @@ export function createTypeEvaluator(
                 let reportedUnpackedError = false;
 
                 // Verify that we didn't receive any inappropriate types.
-                typeArgs.forEach((typeArg, index) => {
+                for (let index = 0; index < typeArgs.length; index++) {
+                    const typeArg = typeArgs[index];
                     assert(typeArgs !== undefined);
                     if (isEllipsisType(typeArg.type)) {
                         if (!isTupleTypeParam) {
@@ -16576,11 +16799,16 @@ export function createTypeEvaluator(
                     } else {
                         validateTypeArg(typeArg);
                     }
-                });
+                }
             }
         }
 
-        let typeArgTypes = typeArgs ? typeArgs.map((t) => convertToInstance(t.type)) : [];
+        let typeArgTypes: Type[] = [];
+        if (typeArgs) {
+            for (const t of typeArgs) {
+                typeArgTypes.push(convertToInstance(t.type));
+            }
+        }
 
         // Make sure the argument list count is correct.
         if (paramLimit !== undefined) {
@@ -16710,12 +16938,23 @@ export function createTypeEvaluator(
             unionType = TypeBase.cloneAsSpecialForm(unionType, ClassType.cloneAsInstance(prefetched.unionTypeClass));
         }
 
-        if (!isValidTypeForm || types.some((t) => !t.props?.typeForm)) {
+        let hasNonTypeFormType = false;
+        for (const t of types) {
+            if (!t.props?.typeForm) {
+                hasNonTypeFormType = true;
+                break;
+            }
+        }
+        if (!isValidTypeForm || hasNonTypeFormType) {
             if (unionType.props?.typeForm) {
                 unionType = TypeBase.cloneWithTypeForm(unionType, undefined);
             }
         } else if (isTypeFormSupported(errorNode)) {
-            const typeFormType = combineTypes(types.map((t) => t.props!.typeForm!));
+            const typeFormTypes: Type[] = [];
+            for (const t of types) {
+                typeFormTypes.push(t.props!.typeForm!);
+            }
+            const typeFormType = combineTypes(typeFormTypes);
             unionType = TypeBase.cloneWithTypeForm(unionType, typeFormType);
         }
 
@@ -16749,7 +16988,7 @@ export function createTypeEvaluator(
             }
 
             // Make sure that all of the type args are typeVars and are unique.
-            typeArgs.forEach((typeArg) => {
+            for (const typeArg of typeArgs) {
                 if (!isTypeVar(typeArg.type)) {
                     addDiagnostic(
                         DiagnosticRule.reportInvalidTypeForm,
@@ -16757,7 +16996,14 @@ export function createTypeEvaluator(
                         typeArg.node
                     );
                 } else {
-                    if (uniqueTypeVars.some((t) => isTypeSame(t, typeArg.type))) {
+                    let isDuplicate = false;
+                    for (const t of uniqueTypeVars) {
+                        if (isTypeSame(t, typeArg.type)) {
+                            isDuplicate = true;
+                            break;
+                        }
+                    }
+                    if (isDuplicate) {
                         addDiagnostic(
                             DiagnosticRule.reportInvalidTypeForm,
                             LocMessage.genericTypeArgUnique(),
@@ -16767,7 +17013,7 @@ export function createTypeEvaluator(
 
                     uniqueTypeVars.push(typeArg.type);
                 }
-            });
+            }
         }
 
         return createSpecialType(classType, typeArgs, /* paramLimit */ undefined, /* allowParamSpec */ true);
@@ -16798,25 +17044,43 @@ export function createTypeEvaluator(
             addTypeVarsToListIfUnique(typeParams, getTypeVarArgsRecursive(type));
 
             // Don't include any synthesized type variables.
-            typeParams = typeParams.filter((typeVar) => !typeVar.shared.isSynthesized);
+            const filteredTypeParams: TypeVarType[] = [];
+            for (const typeVar of typeParams) {
+                if (!typeVar.shared.isSynthesized) {
+                    filteredTypeParams.push(typeVar);
+                }
+            }
+            typeParams = filteredTypeParams;
         }
 
         // Convert all type variables to instances.
-        typeParams = typeParams.map((typeVar) => {
+        const instanceTypeParams: TypeVarType[] = [];
+        for (const typeVar of typeParams) {
             if (TypeBase.isInstance(typeVar)) {
-                return typeVar;
+                instanceTypeParams.push(typeVar);
+            } else {
+                instanceTypeParams.push(convertToInstance(typeVar) as TypeVarType);
             }
-            return convertToInstance(typeVar);
-        });
+        }
+        typeParams = instanceTypeParams;
 
         // See if the type alias includes a TypeVarTuple followed by a TypeVar
         // with a default value. This isn't allowed.
-        const firstTypeVarTupleIndex = typeParams.findIndex((typeVar) => isTypeVarTuple(typeVar));
+        let firstTypeVarTupleIndex = -1;
+        for (let i = 0; i < typeParams.length; i++) {
+            if (isTypeVarTuple(typeParams[i])) {
+                firstTypeVarTupleIndex = i;
+                break;
+            }
+        }
         if (firstTypeVarTupleIndex >= 0) {
-            const typeVarWithDefaultIndex = typeParams.findIndex(
-                (typeVar, index) =>
-                    index > firstTypeVarTupleIndex && !isParamSpec(typeVar) && typeVar.shared.isDefaultExplicit
-            );
+            let typeVarWithDefaultIndex = -1;
+            for (let i = firstTypeVarTupleIndex + 1; i < typeParams.length; i++) {
+                if (!isParamSpec(typeParams[i]) && typeParams[i].shared.isDefaultExplicit) {
+                    typeVarWithDefaultIndex = i;
+                    break;
+                }
+            }
 
             if (typeVarWithDefaultIndex >= 0) {
                 addDiagnostic(
@@ -16831,39 +17095,59 @@ export function createTypeEvaluator(
         }
 
         // Validate the default types for all type parameters.
-        typeParams.forEach((typeParam, index) => {
+        for (let index = 0; index < typeParams.length; index++) {
+            const typeParam = typeParams[index];
             assert(typeParams !== undefined);
             let bestErrorNode = errorNode;
             if (typeParamNodes && index < typeParamNodes.length) {
                 bestErrorNode = typeParamNodes[index].d.defaultExpr ?? typeParamNodes[index].d.name;
             }
             validateTypeParamDefault(bestErrorNode, typeParam, typeParams.slice(0, index), sharedInfo.typeVarScopeId);
-        });
+        }
 
         // Verify that we have at most one TypeVarTuple.
-        const variadics = typeParams.filter((param) => isTypeVarTuple(param));
+        const variadics: TypeVarType[] = [];
+        for (const param of typeParams) {
+            if (isTypeVarTuple(param)) {
+                variadics.push(param);
+            }
+        }
         if (variadics.length > 1) {
+            let variadicNames = '';
+            for (let i = 0; i < variadics.length; i++) {
+                if (i > 0) variadicNames += ', ';
+                variadicNames += `"${variadics[i].shared.name}"`;
+            }
             addDiagnostic(
                 DiagnosticRule.reportInvalidTypeForm,
                 LocMessage.variadicTypeParamTooManyAlias().format({
-                    names: variadics.map((v) => `"${v.shared.name}"`).join(', '),
+                    names: variadicNames,
                 }),
                 errorNode
             );
         }
 
         if (!sharedInfo.isTypeAliasType && !isPep695TypeVarType) {
-            const boundTypeVars = typeParams.filter(
-                (typeVar) =>
+            const boundTypeVars: TypeVarType[] = [];
+            for (const typeVar of typeParams) {
+                if (
                     typeVar.priv.scopeId !== sharedInfo.typeVarScopeId &&
                     typeVar.priv.scopeType === TypeVarScopeType.Class
-            );
+                ) {
+                    boundTypeVars.push(typeVar);
+                }
+            }
 
             if (boundTypeVars.length > 0) {
+                let boundNames = '';
+                for (let i = 0; i < boundTypeVars.length; i++) {
+                    if (i > 0) boundNames += ', ';
+                    boundNames += `${boundTypeVars[i].shared.name}`;
+                }
                 addDiagnostic(
                     DiagnosticRule.reportInvalidTypeForm,
                     LocMessage.genericTypeAliasBoundTypeVar().format({
-                        names: boundTypeVars.map((t) => `${t.shared.name}`).join(', '),
+                        names: boundNames,
                     }),
                     errorNode
                 );
@@ -17608,7 +17892,10 @@ export function createTypeEvaluator(
             let typeParams: TypeVarType[] = [];
 
             if (node.d.typeParams) {
-                typeParams = evaluateTypeParamList(node.d.typeParams).map((t) => TypeVarType.cloneAsInstance(t));
+                const rawTypeParams = evaluateTypeParamList(node.d.typeParams);
+                for (const t of rawTypeParams) {
+                    typeParams.push(TypeVarType.cloneAsInstance(t));
+                }
             }
 
             // If the class derives from "Generic" directly, it will provide
@@ -17631,13 +17918,13 @@ export function createTypeEvaluator(
             }
             let sawClosedOrExtraItems = false;
 
-            node.d.arguments.forEach((arg) => {
+            for (const arg of node.d.arguments) {
                 // Ignore unpacked arguments.
                 if (arg.d.argCategory === ArgCategory.UnpackedDictionary) {
                     // Evaluate the expression's type so symbols are marked accessed
                     // and errors are reported.
                     getTypeOfExpression(arg.d.valueExpr);
-                    return;
+                    continue;
                 }
 
                 if (!arg.d.name) {
@@ -17698,10 +17985,16 @@ export function createTypeEvaluator(
                             addDiagnostic(DiagnosticRule.reportGeneralTypeIssues, LocMessage.baseClassInvalid(), arg);
                             argType = UnknownType.create();
                         } else {
-                            if (
-                                ClassType.isPartiallyEvaluated(argType) ||
-                                argType.shared.mro.some((t) => isClass(t) && ClassType.isPartiallyEvaluated(t))
-                            ) {
+                            let hasDeferredBase = ClassType.isPartiallyEvaluated(argType);
+                            if (!hasDeferredBase) {
+                                for (const t of argType.shared.mro) {
+                                    if (isClass(t) && ClassType.isPartiallyEvaluated(t)) {
+                                        hasDeferredBase = true;
+                                        break;
+                                    }
+                                }
+                            }
+                            if (hasDeferredBase) {
                                 // If the base class is partially evaluated, install a callback
                                 // so we can fix up this class (e.g. compute the MRO) when the
                                 // dependent class is completed.
@@ -17786,15 +18079,18 @@ export function createTypeEvaluator(
                     }
 
                     // Check for a duplicate class.
-                    if (
-                        classType.shared.baseClasses.some((prevBaseClass) => {
-                            return (
-                                isInstantiableClass(prevBaseClass) &&
-                                isInstantiableClass(argType) &&
-                                ClassType.isSameGenericClass(argType, prevBaseClass)
-                            );
-                        })
-                    ) {
+                    let hasDuplicateBaseClass = false;
+                    for (const prevBaseClass of classType.shared.baseClasses) {
+                        if (
+                            isInstantiableClass(prevBaseClass) &&
+                            isInstantiableClass(argType) &&
+                            ClassType.isSameGenericClass(argType, prevBaseClass)
+                        ) {
+                            hasDuplicateBaseClass = true;
+                            break;
+                        }
+                    }
+                    if (hasDuplicateBaseClass) {
                         addDiagnostic(
                             DiagnosticRule.reportGeneralTypeIssues,
                             LocMessage.duplicateBaseClass(),
@@ -17983,14 +18279,14 @@ export function createTypeEvaluator(
                         valueExpression: arg.d.valueExpr,
                     });
                 }
-            });
+            }
 
             // Check for NamedTuple multiple inheritance.
             if (classType.shared.baseClasses.length > 1) {
                 let derivesFromNamedTuple = false;
                 let foundIllegalBaseClass = false;
 
-                classType.shared.baseClasses.forEach((baseClass) => {
+                for (const baseClass of classType.shared.baseClasses) {
                     if (isInstantiableClass(baseClass)) {
                         if (ClassType.isBuiltIn(baseClass, 'NamedTuple')) {
                             derivesFromNamedTuple = true;
@@ -17998,7 +18294,7 @@ export function createTypeEvaluator(
                             foundIllegalBaseClass = true;
                         }
                     }
-                });
+                }
 
                 if (derivesFromNamedTuple && foundIllegalBaseClass) {
                     addDiagnostic(
@@ -18011,12 +18307,18 @@ export function createTypeEvaluator(
 
             // Make sure we don't have 'object' derive from itself. Infinite
             // recursion will result.
-            if (
-                !ClassType.isBuiltIn(classType, 'object') &&
-                classType.shared.baseClasses.filter((baseClass) => isClass(baseClass)).length === 0
-            ) {
-                // If there are no other (known) base classes, the class implicitly derives from object.
-                classType.shared.baseClasses.push(getBuiltInType(node, 'object'));
+            if (!ClassType.isBuiltIn(classType, 'object')) {
+                let hasKnownBaseClass = false;
+                for (const baseClass of classType.shared.baseClasses) {
+                    if (isClass(baseClass)) {
+                        hasKnownBaseClass = true;
+                        break;
+                    }
+                }
+                if (!hasKnownBaseClass) {
+                    // If there are no other (known) base classes, the class implicitly derives from object.
+                    classType.shared.baseClasses.push(getBuiltInType(node, 'object'));
+                }
             }
 
             // If genericTypeParams or protocolTypeParams are provided,
@@ -18028,33 +18330,54 @@ export function createTypeEvaluator(
             classType.shared.typeParams = genericTypeParams ?? typeParams;
 
             // Determine if one or more type parameters is autovariance.
-            if (
-                classType.shared.typeParams.some(
-                    (param) =>
-                        param.shared.declaredVariance === Variance.Auto && param.priv.computedVariance === undefined
-                )
-            ) {
+            let hasAutoVariance = false;
+            for (const param of classType.shared.typeParams) {
+                if (param.shared.declaredVariance === Variance.Auto && param.priv.computedVariance === undefined) {
+                    hasAutoVariance = true;
+                    break;
+                }
+            }
+            if (hasAutoVariance) {
                 classType.shared.requiresVarianceInference = true;
             }
 
             // Make sure there's at most one TypeVarTuple.
-            const variadics = typeParams.filter((param) => isTypeVarTuple(param));
+            const variadics: TypeVarType[] = [];
+            for (const param of typeParams) {
+                if (isTypeVarTuple(param)) {
+                    variadics.push(param);
+                }
+            }
             if (variadics.length > 1) {
+                let variadicNames = '';
+                for (let i = 0; i < variadics.length; i++) {
+                    if (i > 0) variadicNames += ', ';
+                    variadicNames += `"${variadics[i].shared.name}"`;
+                }
                 addDiagnostic(
                     DiagnosticRule.reportGeneralTypeIssues,
                     LocMessage.variadicTypeParamTooManyClass().format({
-                        names: variadics.map((v) => `"${v.shared.name}"`).join(', '),
+                        names: variadicNames,
                     }),
                     node.d.name,
                     TextRange.combine(node.d.arguments) || node.d.name
                 );
             } else if (variadics.length > 0) {
                 // Make sure a TypeVar with a default doesn't come after a TypeVarTuple.
-                const firstVariadicIndex = typeParams.findIndex((param) => isTypeVarTuple(param));
-                const typeVarWithDefaultIndex = typeParams.findIndex(
-                    (param, index) =>
-                        index > firstVariadicIndex && !isParamSpec(param) && param.shared.isDefaultExplicit
-                );
+                let firstVariadicIndex = -1;
+                for (let i = 0; i < typeParams.length; i++) {
+                    if (isTypeVarTuple(typeParams[i])) {
+                        firstVariadicIndex = i;
+                        break;
+                    }
+                }
+                let typeVarWithDefaultIndex = -1;
+                for (let i = firstVariadicIndex + 1; i < typeParams.length; i++) {
+                    if (!isParamSpec(typeParams[i]) && typeParams[i].shared.isDefaultExplicit) {
+                        typeVarWithDefaultIndex = i;
+                        break;
+                    }
+                }
 
                 if (typeVarWithDefaultIndex >= 0) {
                     addDiagnostic(
@@ -18069,7 +18392,8 @@ export function createTypeEvaluator(
             }
 
             // Validate the default types for all type parameters.
-            classType.shared.typeParams.forEach((typeParam, index) => {
+            for (let index = 0; index < classType.shared.typeParams.length; index++) {
+                const typeParam = classType.shared.typeParams[index];
                 let bestErrorNode: ExpressionNode = node.d.name;
                 if (node.d.typeParams && index < node.d.typeParams.d.params.length) {
                     const typeParamNode = node.d.typeParams.d.params[index];
@@ -18081,7 +18405,7 @@ export function createTypeEvaluator(
                     classType.shared.typeParams.slice(0, index),
                     classType.shared.typeVarScopeId!
                 );
-            });
+            }
 
             if (!computeMroLinearization(classType)) {
                 addDiagnostic(DiagnosticRule.reportGeneralTypeIssues, LocMessage.methodOrdering(), node.d.name);
@@ -18129,39 +18453,50 @@ export function createTypeEvaluator(
                         const initDeclNode = initDecls[0].node;
                         const initParams = initDeclNode.d.params;
 
-                        if (
-                            initParams.length > 1 &&
-                            !initParams.some(
-                                (param, index) => !!ParseTreeUtils.getTypeAnnotationForParam(initDeclNode, index)
-                            )
-                        ) {
-                            const genericParams = initParams.filter(
-                                (param, index) =>
-                                    index > 0 &&
-                                    param.d.name &&
-                                    param.d.category === ParamCategory.Simple &&
-                                    !param.d.defaultValue
-                            );
+                        if (initParams.length > 1) {
+                            let hasAnnotation = false;
+                            for (let index = 0; index < initParams.length; index++) {
+                                if (ParseTreeUtils.getTypeAnnotationForParam(initDeclNode, index)) {
+                                    hasAnnotation = true;
+                                    break;
+                                }
+                            }
+                            if (!hasAnnotation) {
+                                const genericParams: typeof initParams = [];
+                                for (let index = 0; index < initParams.length; index++) {
+                                    const param = initParams[index];
+                                    if (
+                                        index > 0 &&
+                                        param.d.name &&
+                                        param.d.category === ParamCategory.Simple &&
+                                        !param.d.defaultValue
+                                    ) {
+                                        genericParams.push(param);
+                                    }
+                                }
 
-                            if (genericParams.length > 0) {
-                                classType.shared.flags |= ClassTypeFlags.PseudoGenericClass;
+                                if (genericParams.length > 0) {
+                                    classType.shared.flags |= ClassTypeFlags.PseudoGenericClass;
 
-                                // Create a type parameter for each simple, named parameter
-                                // in the __init__ method.
-                                classType.shared.typeParams = genericParams.map((param) => {
-                                    const typeVar = TypeVarType.createInstance(
-                                        getPseudoGenericTypeVarName(param.d.name!.d.value)
-                                    );
-                                    typeVar.shared.isSynthesized = true;
-                                    typeVar.priv.scopeId = ParseTreeUtils.getScopeIdForNode(initDeclNode);
-                                    typeVar.shared.boundType = UnknownType.create();
-                                    return TypeVarType.cloneForScopeId(
-                                        typeVar,
-                                        ParseTreeUtils.getScopeIdForNode(node),
-                                        node.d.name.d.value,
-                                        TypeVarScopeType.Class
-                                    );
-                                });
+                                    // Create a type parameter for each simple, named parameter
+                                    // in the __init__ method.
+                                    const typeParamsResult: TypeVarType[] = [];
+                                    for (const param of genericParams) {
+                                        const typeVar = TypeVarType.createInstance(
+                                            getPseudoGenericTypeVarName(param.d.name!.d.value)
+                                        );
+                                        typeVar.shared.isSynthesized = true;
+                                        typeVar.priv.scopeId = ParseTreeUtils.getScopeIdForNode(initDeclNode);
+                                        typeVar.shared.boundType = UnknownType.create();
+                                        typeParamsResult.push(TypeVarType.cloneForScopeId(
+                                            typeVar,
+                                            ParseTreeUtils.getScopeIdForNode(node),
+                                            node.d.name.d.value,
+                                            TypeVarScopeType.Class
+                                        ));
+                                    }
+                                    classType.shared.typeParams = typeParamsResult;
+                                }
                             }
                         }
                     }
@@ -18172,10 +18507,15 @@ export function createTypeEvaluator(
             // only to classes that have no type parameters, since those with type parameters
             // are assumed to follow normal subscripting semantics for generic classes.
             if (classType.shared.typeParams.length === 0 && !ClassType.isBuiltIn(classType, 'type')) {
+                let hasCustomClassGetItem = false;
+                for (const baseClass of classType.shared.baseClasses) {
+                    if (isInstantiableClass(baseClass) && ClassType.hasCustomClassGetItem(baseClass)) {
+                        hasCustomClassGetItem = true;
+                        break;
+                    }
+                }
                 if (
-                    classType.shared.baseClasses.some(
-                        (baseClass) => isInstantiableClass(baseClass) && ClassType.hasCustomClassGetItem(baseClass)
-                    ) ||
+                    hasCustomClassGetItem ||
                     classType.shared.fields.has('__class_getitem__')
                 ) {
                     classType.shared.flags |= ClassTypeFlags.HasCustomClassGetItem;
@@ -18258,16 +18598,20 @@ export function createTypeEvaluator(
             if (isInstantiableClass(effectiveMetaclass) && effectiveMetaclass.shared.classDataClassTransform) {
                 dataClassBehaviors = effectiveMetaclass.shared.classDataClassTransform;
             } else {
-                const baseClassDataTransform = classType.shared.mro.find((mroClass) => {
-                    return (
+                let baseClassDataTransform: ClassType | undefined;
+                for (const mroClass of classType.shared.mro) {
+                    if (
                         isClass(mroClass) &&
                         mroClass.shared.classDataClassTransform !== undefined &&
                         !ClassType.isSameGenericClass(mroClass, classType)
-                    );
-                });
+                    ) {
+                        baseClassDataTransform = mroClass;
+                        break;
+                    }
+                }
 
                 if (baseClassDataTransform) {
-                    dataClassBehaviors = (baseClassDataTransform as ClassType).shared.classDataClassTransform;
+                    dataClassBehaviors = baseClassDataTransform.shared.classDataClassTransform;
                 }
             }
 
@@ -18295,7 +18639,7 @@ export function createTypeEvaluator(
                 let foundInvalidBaseClass = false;
                 const diag = new DiagnosticAddendum();
 
-                classType.shared.baseClasses.forEach((baseClass) => {
+                for (const baseClass of classType.shared.baseClasses) {
                     if (
                         isClass(baseClass) &&
                         !ClassType.isTypedDictClass(baseClass) &&
@@ -18304,7 +18648,7 @@ export function createTypeEvaluator(
                         foundInvalidBaseClass = true;
                         diag.addMessage(LocAddendum.typedDictBaseClass().format({ type: baseClass.shared.name }));
                     }
-                });
+                }
 
                 if (foundInvalidBaseClass) {
                     addDiagnostic(
@@ -18373,7 +18717,7 @@ export function createTypeEvaluator(
                     let isLimitedToSlots = true;
                     const extendedSlotsNames = Array.from(classType.shared.localSlotsNames);
 
-                    classType.shared.baseClasses.forEach((baseClass) => {
+                    for (const baseClass of classType.shared.baseClasses) {
                         if (isInstantiableClass(baseClass)) {
                             if (
                                 !ClassType.isBuiltIn(baseClass, 'object') &&
@@ -18390,7 +18734,7 @@ export function createTypeEvaluator(
                         } else {
                             isLimitedToSlots = false;
                         }
-                    });
+                    }
 
                     if (isLimitedToSlots) {
                         classType.shared.inheritedSlotsNamesCached = extendedSlotsNames;
@@ -18417,17 +18761,18 @@ export function createTypeEvaluator(
         const typeParams: TypeVarType[] = [];
         const typeArgs = classType.priv.typeArgs ?? [];
 
-        typeArgs.forEach((typeArg, index) => {
+        for (let index = 0; index < typeArgs.length; index++) {
+            const typeArg = typeArgs[index];
             if (isTypeVar(typeArg)) {
                 typeParams.push(typeArg);
-                return;
+                continue;
             }
 
             // Synthesize a dummy type parameter.
             const typeVar = TypeVarType.createInstance(`__P${index}`);
             typeVar.shared.isSynthesized = true;
             typeParams.push(typeVar);
-        });
+        }
 
         return typeParams;
     }
@@ -18466,9 +18811,9 @@ export function createTypeEvaluator(
         // If we found one or more unapplied type variable, report an error.
         if (invalidTypeVars.size > 0) {
             const diag = new DiagnosticAddendum();
-            invalidTypeVars.forEach((name) => {
+            for (const name of invalidTypeVars) {
                 diag.addMessage(LocAddendum.typeVarDefaultOutOfScope().format({ name }));
-            });
+            }
 
             addDiagnostic(
                 DiagnosticRule.reportGeneralTypeIssues,
@@ -18491,11 +18836,11 @@ export function createTypeEvaluator(
 
         // Presumptively mark the computed variance to "unknown". We'll
         // replace this below once the variance has been inferred.
-        classType.shared.typeParams.forEach((param) => {
+        for (const param of classType.shared.typeParams) {
             if (param.shared.declaredVariance === Variance.Auto) {
                 param.priv.computedVariance = Variance.Unknown;
             }
-        });
+        }
 
         const dummyTypeObject = ClassType.createInstantiable(
             '__varianceDummy',
@@ -18508,31 +18853,37 @@ export function createTypeEvaluator(
             undefined
         );
 
-        classType.shared.typeParams.forEach((param, paramIndex) => {
+        for (let paramIndex = 0; paramIndex < classType.shared.typeParams.length; paramIndex++) {
+            const param = classType.shared.typeParams[paramIndex];
             // Skip TypeVarTuples and ParamSpecs.
             if (isTypeVarTuple(param) || isParamSpec(param)) {
-                return;
+                continue;
             }
 
             // Skip type variables without auto-variance.
             if (param.shared.declaredVariance !== Variance.Auto) {
-                return;
+                continue;
             }
 
             // Replace all type arguments with a dummy type except for the
             // TypeVar of interest, which is replaced with an object instance.
-            const srcTypeArgs = classType.shared.typeParams.map((p, i) => {
+            const srcTypeArgs: Type[] = [];
+            for (let i = 0; i < classType.shared.typeParams.length; i++) {
+                const p = classType.shared.typeParams[i];
                 if (isTypeVarTuple(p)) {
-                    return p;
+                    srcTypeArgs.push(p);
+                } else {
+                    srcTypeArgs.push(i === paramIndex ? getObjectType() : dummyTypeObject);
                 }
-                return i === paramIndex ? getObjectType() : dummyTypeObject;
-            });
+            }
 
             // Replace all type arguments with a dummy type except for the
             // TypeVar of interest, which is replaced with itself.
-            const destTypeArgs = classType.shared.typeParams.map((p, i) => {
-                return i === paramIndex || isTypeVarTuple(p) ? p : dummyTypeObject;
-            });
+            const destTypeArgs: Type[] = [];
+            for (let i = 0; i < classType.shared.typeParams.length; i++) {
+                const p = classType.shared.typeParams[i];
+                destTypeArgs.push(i === paramIndex || isTypeVarTuple(p) ? p : dummyTypeObject);
+            }
 
             const srcType = ClassType.specialize(classType, srcTypeArgs);
             const destType = ClassType.specialize(classType, destTypeArgs);
@@ -18565,28 +18916,28 @@ export function createTypeEvaluator(
             // because it was already cloned when it was associated with this
             // class scope.
             classType.shared.typeParams[paramIndex].priv.computedVariance = inferredVariance;
-        });
+        }
     }
 
     function evaluateTypeParamList(node: TypeParameterListNode): TypeVarType[] {
         const paramTypes: TypeVarType[] = [];
         const typeParamScope = AnalyzerNodeInfo.getScope(node);
 
-        node.d.params.forEach((param) => {
+        for (const param of node.d.params) {
             const paramSymbol = typeParamScope?.symbolTable.get(param.d.name.d.value);
             if (!paramSymbol) {
                 // This can happen if the code is unreachable.
-                return;
+                continue;
             }
 
             const typeOfParam = getDeclaredTypeOfSymbol(paramSymbol, param.d.name)?.type;
             if (!typeOfParam || !isTypeVar(typeOfParam)) {
-                return;
+                continue;
             }
 
             writeTypeCache(param.d.name, { type: typeOfParam }, EvalFlags.None);
             paramTypes.push(typeOfParam);
-        });
+        }
 
         return paramTypes;
     }
@@ -18664,15 +19015,30 @@ export function createTypeEvaluator(
         typeVars: TypeVarType[],
         genericTypeVars: TypeVarType[]
     ) {
-        const missingFromGeneric = typeVars.filter((typeVar) => {
-            return !genericTypeVars.some((genericTypeVar) => genericTypeVar.shared.name === typeVar.shared.name);
-        });
+        const missingFromGeneric: TypeVarType[] = [];
+        for (const typeVar of typeVars) {
+            let foundInGeneric = false;
+            for (const genericTypeVar of genericTypeVars) {
+                if (genericTypeVar.shared.name === typeVar.shared.name) {
+                    foundInGeneric = true;
+                    break;
+                }
+            }
+            if (!foundInGeneric) {
+                missingFromGeneric.push(typeVar);
+            }
+        }
 
         if (missingFromGeneric.length > 0) {
             const diag = new DiagnosticAddendum();
+            let missingNames = '';
+            for (let i = 0; i < missingFromGeneric.length; i++) {
+                if (i > 0) missingNames += ', ';
+                missingNames += `"${missingFromGeneric[i].shared.name}"`;
+            }
             diag.addMessage(
                 LocAddendum.typeVarsMissing().format({
-                    names: missingFromGeneric.map((typeVar) => `"${typeVar.shared.name}"`).join(', '),
+                    names: missingNames,
                 })
             );
             addDiagnostic(
@@ -18690,18 +19056,22 @@ export function createTypeEvaluator(
     function registerDeferredClassCompletion(classToComplete: ClassNode, dependsUpon: ClassType | undefined) {
         if (dependsUpon) {
             // See if there is an existing entry for this dependency.
-            const entry = deferredClassCompletions.find((e) =>
-                ClassType.isSameGenericClass(e.dependsUpon, dependsUpon)
-            );
+            let entry: { dependsUpon: ClassType; classesToComplete: ClassNode[] } | undefined;
+            for (const e of deferredClassCompletions) {
+                if (ClassType.isSameGenericClass(e.dependsUpon, dependsUpon)) {
+                    entry = e;
+                    break;
+                }
+            }
             if (entry) {
                 entry.classesToComplete.push(classToComplete);
             } else {
                 deferredClassCompletions.push({ dependsUpon, classesToComplete: [classToComplete] });
             }
         } else {
-            deferredClassCompletions.forEach((e) => {
+            for (const e of deferredClassCompletions) {
                 e.classesToComplete.push(classToComplete);
-            });
+            }
         }
     }
 
@@ -18709,21 +19079,25 @@ export function createTypeEvaluator(
     // class type. This allows us to complete any work that requires dependent classes
     // to be completed.
     function runDeferredClassCompletions(type: ClassType) {
-        deferredClassCompletions.forEach((e) => {
+        for (const e of deferredClassCompletions) {
             if (ClassType.isSameGenericClass(e.dependsUpon, type)) {
-                e.classesToComplete.forEach((classNode) => {
+                for (const classNode of e.classesToComplete) {
                     const classType = readTypeCache(classNode.d.name, EvalFlags.None);
                     if (classType) {
                         completeClassTypeDeferred(classType as ClassType, classNode.d.name);
                     }
-                });
+                }
             }
-        });
+        }
 
         // Remove any completions that depend on this type.
-        deferredClassCompletions = deferredClassCompletions.filter(
-            (e) => !ClassType.isSameGenericClass(e.dependsUpon, type)
-        );
+        const remainingCompletions: typeof deferredClassCompletions = [];
+        for (const e of deferredClassCompletions) {
+            if (!ClassType.isSameGenericClass(e.dependsUpon, type)) {
+                remainingCompletions.push(e);
+            }
+        }
+        deferredClassCompletions = remainingCompletions;
     }
 
     // Recomputes the MRO and effective metaclass for the class after dependent
@@ -18743,7 +19117,7 @@ export function createTypeEvaluator(
         // method described in PEP 487 and validate it.
         const argList: Arg[] = [];
 
-        node.d.arguments.forEach((arg) => {
+        for (const arg of node.d.arguments) {
             if (arg.d.name && arg.d.name.d.value !== 'metaclass') {
                 argList.push({
                     argCategory: ArgCategory.Simple,
@@ -18752,7 +19126,7 @@ export function createTypeEvaluator(
                     valueExpression: arg.d.valueExpr,
                 });
             }
-        });
+        }
 
         let newMethodMember: ClassMember | undefined;
 
@@ -18796,7 +19170,7 @@ export function createTypeEvaluator(
                         }
                     }
 
-                    argList.forEach((arg) => {
+                    for (const arg of argList) {
                         if (arg.argCategory === ArgCategory.Simple && arg.name) {
                             const paramIndex = paramMap.get(arg.name.d.value) ?? paramListDetails.kwargsIndex;
 
@@ -18825,20 +19199,24 @@ export function createTypeEvaluator(
                                 );
                             }
                         }
-                    });
+                    }
 
                     // See if we have any remaining unmatched parameters without
                     // default values.
                     const unassignedParams: string[] = [];
-                    paramMap.forEach((index, paramName) => {
+                    for (const [paramName, index] of paramMap) {
                         const paramInfo = paramListDetails.params[index];
                         if (!paramInfo.defaultType) {
                             unassignedParams.push(paramName);
                         }
-                    });
+                    }
 
                     if (unassignedParams.length > 0) {
-                        const missingParamNames = unassignedParams.map((p) => `"${p}"`).join(', ');
+                        let missingParamNames = '';
+                        for (let i = 0; i < unassignedParams.length; i++) {
+                            if (i > 0) missingParamNames += ', ';
+                            missingParamNames += `"${unassignedParams[i]}"`;
+                        }
                         addDiagnostic(
                             DiagnosticRule.reportGeneralTypeIssues,
                             unassignedParams.length === 1
@@ -18905,11 +19283,11 @@ export function createTypeEvaluator(
         }
 
         // Evaluate all of the expressions so they are checked and marked referenced.
-        argList.forEach((arg) => {
+        for (const arg of argList) {
             if (arg.valueExpression) {
                 getTypeOfExpression(arg.valueExpression);
             }
-        });
+        }
     }
 
     function getTypeOfFunction(node: FunctionNode): FunctionTypeResult | undefined {
@@ -18982,9 +19360,9 @@ export function createTypeEvaluator(
 
             if (FunctionType.isOverloaded(decoratedType)) {
                 // Mark all the parameters as accessed.
-                node.d.params.forEach((param) => {
+                for (const param of node.d.params) {
                     markParamAccessed(param);
-                });
+                }
             }
         }
 
@@ -19118,9 +19496,12 @@ export function createTypeEvaluator(
             // accumulate the list of type parameters upfront.
             const typeParamsSeen: TypeVarType[] = [];
             if (node.d.typeParams) {
-                functionType.shared.typeParams = evaluateTypeParamList(node.d.typeParams).map((typeParam) =>
-                    convertToInstance(typeParam)
-                );
+                const rawParams = evaluateTypeParamList(node.d.typeParams);
+                const convertedParams: TypeVarType[] = [];
+                for (const typeParam of rawParams) {
+                    convertedParams.push(convertToInstance(typeParam) as TypeVarType);
+                }
+                functionType.shared.typeParams = convertedParams;
             } else {
                 functionType.shared.typeParams = typeParamsSeen;
             }
@@ -19133,7 +19514,8 @@ export function createTypeEvaluator(
                     FunctionType.isConstructorMethod(functionType));
             const firstNonClsSelfParamIndex = isFirstParamClsOrSelf ? 1 : 0;
 
-            node.d.params.forEach((param, index) => {
+            for (let index = 0; index < node.d.params.length; index++) {
+                const param = node.d.params[index];
                 let paramType: Type | undefined;
                 let annotatedType: Type | undefined;
                 let paramTypeNode: ExpressionNode | undefined;
@@ -19198,9 +19580,12 @@ export function createTypeEvaluator(
                         !param.d.defaultValue
                     ) {
                         const typeParamName = getPseudoGenericTypeVarName(param.d.name.d.value);
-                        annotatedType = containingClassType!.shared.typeParams.find(
-                            (param) => param.shared.name === typeParamName
-                        );
+                        for (const tp of containingClassType!.shared.typeParams) {
+                            if (tp.shared.name === typeParamName) {
+                                annotatedType = tp;
+                                break;
+                            }
+                        }
                     }
                 }
 
@@ -19259,17 +19644,31 @@ export function createTypeEvaluator(
                     let isImplicitPositionOnlyParam = false;
 
                     if (param.d.category === ParamCategory.Simple && param.d.name) {
+                        let hasSlashParam = false;
+                        for (const p of node.d.params) {
+                            if (p.d.category === ParamCategory.Simple && !p.d.name) {
+                                hasSlashParam = true;
+                                break;
+                            }
+                        }
                         if (
                             isPrivateName(param.d.name.d.value) &&
-                            !node.d.params.some((p) => p.d.category === ParamCategory.Simple && !p.d.name)
+                            !hasSlashParam
                         ) {
                             isImplicitPositionOnlyParam = true;
 
                             // If the parameter name indicates an implicit position-only parameter
                             // but we have already seen non-position-only parameters, report an error.
+                            let allParamsSimple = true;
+                            for (const p of functionType.shared.parameters) {
+                                if (p.category !== ParamCategory.Simple) {
+                                    allParamsSimple = false;
+                                    break;
+                                }
+                            }
                             if (
                                 !paramsArePositionOnly &&
-                                functionType.shared.parameters.every((p) => p.category === ParamCategory.Simple)
+                                allParamsSimple
                             ) {
                                 addDiagnostic(
                                     DiagnosticRule.reportGeneralTypeIssues,
@@ -19333,7 +19732,7 @@ export function createTypeEvaluator(
                 } else {
                     paramTypes.push(paramType);
                 }
-            });
+            }
 
             if (paramsArePositionOnly && functionType.shared.parameters.length > firstNonClsSelfParamIndex) {
                 FunctionType.addPositionOnlyParamSeparator(functionType);
@@ -19341,18 +19740,19 @@ export function createTypeEvaluator(
 
             // Update the types for the nodes associated with the parameters.
             const scopeIds = ParseTreeUtils.getTypeVarScopesForNode(node);
-            paramTypes.forEach((paramType, index) => {
+            for (let index = 0; index < paramTypes.length; index++) {
+                const paramType = paramTypes[index];
                 const paramNameNode = node.d.params[index].d.name;
                 if (paramNameNode) {
                     if (isUnknown(paramType)) {
                         functionType.shared.flags |= FunctionTypeFlags.UnannotatedParams;
                     }
 
-                    paramType = makeTypeVarsBound(paramType, scopeIds);
+                    const boundParamType = makeTypeVarsBound(paramType, scopeIds);
 
-                    writeTypeCache(paramNameNode, { type: paramType }, EvalFlags.None);
+                    writeTypeCache(paramNameNode, { type: boundParamType }, EvalFlags.None);
                 }
-            });
+            }
 
             // If the function ends in P.args and P.kwargs parameters, make it exempt from
             // args/kwargs compatibility checks. This is important for protocol comparisons.
@@ -19372,12 +19772,17 @@ export function createTypeEvaluator(
             // If the function contains an *args and a **kwargs parameter and both
             // are annotated as Any or are unannotated, make it exempt from
             // args/kwargs compatibility checks.
-            const variadicsWithAnyType = functionType.shared.parameters.filter(
-                (param, index) =>
+            const variadicsWithAnyType: FunctionParam[] = [];
+            for (let index = 0; index < functionType.shared.parameters.length; index++) {
+                const param = functionType.shared.parameters[index];
+                if (
                     param.category !== ParamCategory.Simple &&
                     param.name &&
                     isAnyOrUnknown(FunctionType.getParamType(functionType, index))
-            );
+                ) {
+                    variadicsWithAnyType.push(param);
+                }
+            }
             if (variadicsWithAnyType.length >= 2) {
                 functionType.shared.flags |= FunctionTypeFlags.GradualCallableForm;
             }
@@ -19420,7 +19825,8 @@ export function createTypeEvaluator(
             }
 
             // Validate the default types for all type parameters.
-            functionType.shared.typeParams.forEach((typeParam, index) => {
+            for (let index = 0; index < functionType.shared.typeParams.length; index++) {
+                const typeParam = functionType.shared.typeParams[index];
                 let bestErrorNode: ExpressionNode = node.d.name;
                 if (node.d.typeParams && index < node.d.typeParams.d.params.length) {
                     const typeParamNode = node.d.typeParams.d.params[index];
@@ -19433,7 +19839,7 @@ export function createTypeEvaluator(
                     functionType.shared.typeParams.slice(0, index),
                     functionType.shared.typeVarScopeId!
                 );
-            });
+            }
 
             // Clear the "partially evaluated" flag to indicate that the functionType
             // is fully evaluated.
@@ -19718,7 +20124,7 @@ export function createTypeEvaluator(
                             ClassType.specialize(asyncGeneratorType, typeArgs)
                         );
                     }
-                } else if (['AsyncIterator', 'AsyncIterable'].some((name) => name === returnType.shared.name)) {
+                } else if (returnType.shared.name === 'AsyncIterator' || returnType.shared.name === 'AsyncIterable') {
                     // If it's already an AsyncIterator or AsyncIterable, leave it as is.
                     awaitableReturnType = returnType;
                 } else if (returnType.shared.name === 'AsyncGenerator') {
@@ -19774,10 +20180,18 @@ export function createTypeEvaluator(
 
         const recursionEntry = functionRecursionMap.get(node.id) ?? [];
 
+        let hasRecursionEntry = false;
+        for (const entry of recursionEntry) {
+            if (entry.callerNode === callerNode) {
+                hasRecursionEntry = true;
+                break;
+            }
+        }
+
         if (functionRecursionMap.size >= maxInferFunctionReturnRecursionCount) {
             inferredReturnType = UnknownType.create();
             isIncomplete = true;
-        } else if (recursionEntry.some((entry) => entry.callerNode === callerNode)) {
+        } else if (hasRecursionEntry) {
             inferredReturnType = UnknownType.create();
             isIncomplete = true;
         } else {
@@ -19813,7 +20227,7 @@ export function createTypeEvaluator(
                     } else {
                         const inferredReturnTypes: Type[] = [];
                         if (functionDecl?.returnStatements) {
-                            functionDecl.returnStatements.forEach((returnNode) => {
+                            for (const returnNode of functionDecl.returnStatements) {
                                 if (isNodeReachable(returnNode)) {
                                     if (returnNode.d.expr) {
                                         const returnTypeResult = getTypeOfExpression(returnNode.d.expr);
@@ -19853,7 +20267,7 @@ export function createTypeEvaluator(
                                         inferredReturnTypes.push(getNoneType());
                                     }
                                 }
-                            });
+                            }
                         }
 
                         if (!functionNeverReturns && implicitlyReturnsNone) {
@@ -19874,7 +20288,7 @@ export function createTypeEvaluator(
                         let isYieldResultUsed = false;
 
                         if (functionDecl.yieldStatements) {
-                            functionDecl.yieldStatements.forEach((yieldNode) => {
+                            for (const yieldNode of functionDecl.yieldStatements) {
                                 if (isNodeReachable(yieldNode)) {
                                     if (yieldNode.nodeType === ParseNodeType.YieldFrom) {
                                         isYieldResultUsed = true;
@@ -19916,7 +20330,7 @@ export function createTypeEvaluator(
                                         }
                                     }
                                 }
-                            });
+                            }
                         }
 
                         const inferredYieldType = combineTypes(inferredYieldTypes);
@@ -19994,7 +20408,14 @@ export function createTypeEvaluator(
         }
 
         const statements = functionDecl.node.d.suite.d.statements;
-        if (statements.some((statement) => statement.nodeType !== ParseNodeType.StatementList)) {
+        let hasNonStatementList = false;
+        for (const statement of statements) {
+            if (statement.nodeType !== ParseNodeType.StatementList) {
+                hasNonStatementList = true;
+                break;
+            }
+        }
+        if (hasNonStatementList) {
             return false;
         }
 
@@ -20086,9 +20507,10 @@ export function createTypeEvaluator(
             // a specialized tuple object here.
             const tupleType = getSpecializedTupleType(subType);
             if (tupleType && tupleType.priv.tupleTypeArgs) {
-                const entryTypes = tupleType.priv.tupleTypeArgs.map((t) => {
-                    return getExceptionType(t.type, node.d.typeExpr!);
-                });
+                const entryTypes: Type[] = [];
+                for (const t of tupleType.priv.tupleTypeArgs) {
+                    entryTypes.push(getExceptionType(t.type, node.d.typeExpr!));
+                }
                 return combineTypes(entryTypes);
             }
 
@@ -20454,21 +20876,21 @@ export function createTypeEvaluator(
             const flowNode = AnalyzerNodeInfo.getFlowNode(node);
             if (flowNode && (flowNode.flags & FlowFlags.WildcardImport) !== 0) {
                 const wildcardFlowNode = flowNode as FlowWildcardImport;
-                wildcardFlowNode.names.forEach((name) => {
+                for (const name of wildcardFlowNode.names) {
                     const importedSymbolType = getAliasedSymbolTypeForName(node, name);
 
                     if (!importedSymbolType) {
-                        return;
+                        continue;
                     }
 
                     const symbolWithScope = lookUpSymbolRecursive(node, name, /* honorCodeFlow */ false);
                     if (!symbolWithScope) {
-                        return;
+                        continue;
                     }
 
                     const declaredType = getDeclaredTypeOfSymbol(symbolWithScope.symbol)?.type;
                     if (!declaredType) {
-                        return;
+                        continue;
                     }
 
                     const diagAddendum = new DiagnosticAddendum();
@@ -20484,7 +20906,7 @@ export function createTypeEvaluator(
                             node.d.wildcardToken ?? node
                         );
                     }
-                });
+                }
             }
         } else {
             // Use the first element of the name parts as the symbol.
@@ -20540,11 +20962,12 @@ export function createTypeEvaluator(
         // Normally there will be at most one decl associated with the import node, but
         // there can be multiple in the case of the "from .X import X" statement. In such
         // case, we want to choose the last declaration.
-        const filteredDecls = symbolWithScope.symbol
-            .getDeclarations()
-            .filter(
-                (decl) => ParseTreeUtils.isNodeContainedWithin(node, decl.node) && decl.type === DeclarationType.Alias
-            );
+        const filteredDecls: Declaration[] = [];
+        for (const decl of symbolWithScope.symbol.getDeclarations()) {
+            if (ParseTreeUtils.isNodeContainedWithin(node, decl.node) && decl.type === DeclarationType.Alias) {
+                filteredDecls.push(decl);
+            }
+        }
         let aliasDecl = filteredDecls.length > 0 ? filteredDecls[filteredDecls.length - 1] : undefined;
 
         // If we didn't find an exact match, look for any alias associated with
@@ -20552,7 +20975,12 @@ export function createTypeEvaluator(
         // the same first-part name (e.g. "import asyncio" and "import asyncio.tasks"),
         // we may not find the declaration associated with this node.
         if (!aliasDecl) {
-            aliasDecl = symbolWithScope.symbol.getDeclarations().find((decl) => decl.type === DeclarationType.Alias);
+            for (const decl of symbolWithScope.symbol.getDeclarations()) {
+                if (decl.type === DeclarationType.Alias) {
+                    aliasDecl = decl;
+                    break;
+                }
+            }
         }
 
         if (!aliasDecl) {
@@ -20948,7 +21376,13 @@ export function createTypeEvaluator(
         assert(parent.nodeType === ParseNodeType.Function);
         const functionNode = parent as FunctionNode;
 
-        const paramIndex = functionNode.d.params.findIndex((param) => param === node);
+        let paramIndex = -1;
+        for (let i = 0; i < functionNode.d.params.length; i++) {
+            if (functionNode.d.params[i] === node) {
+                paramIndex = i;
+                break;
+            }
+        }
         const typeAnnotation = ParseTreeUtils.getTypeAnnotationForParam(functionNode, paramIndex);
 
         if (typeAnnotation) {
@@ -20977,9 +21411,13 @@ export function createTypeEvaluator(
             functionNode.d.name.d.value === '__init__'
         ) {
             const typeParamName = getPseudoGenericTypeVarName(node.d.name.d.value);
-            const paramType = classInfo.classType.shared.typeParams.find(
-                (param) => param.shared.name === typeParamName
-            );
+            let paramType: TypeVarType | undefined;
+            for (const param of classInfo.classType.shared.typeParams) {
+                if (param.shared.name === typeParamName) {
+                    paramType = param;
+                    break;
+                }
+            }
 
             if (paramType) {
                 writeTypeCache(node.d.name, { type: TypeVarType.cloneAsBound(paramType) }, EvalFlags.None);
@@ -21171,17 +21609,21 @@ export function createTypeEvaluator(
         let entries = codeFlowAnalyzerCache.get(node.id);
 
         if (entries) {
-            const cachedEntry = entries.find((entry) => {
+            let cachedEntry: (typeof entries)[number] | undefined;
+            for (const entry of entries) {
+                let isMatch: boolean;
                 if (!typeAtStart || !entry.typeAtStart) {
-                    return !typeAtStart && !entry.typeAtStart;
+                    isMatch = !typeAtStart && !entry.typeAtStart;
+                } else if (!typeAtStart.isIncomplete !== !entry.typeAtStart.isIncomplete) {
+                    isMatch = false;
+                } else {
+                    isMatch = isTypeSame(typeAtStart.type, entry.typeAtStart.type);
                 }
-
-                if (!typeAtStart.isIncomplete !== !entry.typeAtStart.isIncomplete) {
-                    return false;
+                if (isMatch) {
+                    cachedEntry = entry;
+                    break;
                 }
-
-                return isTypeSame(typeAtStart.type, entry.typeAtStart.type);
-            });
+            }
 
             if (cachedEntry) {
                 return cachedEntry.codeFlowAnalyzer;
@@ -21326,15 +21768,17 @@ export function createTypeEvaluator(
                         addDiagnostic(DiagnosticRule.reportInvalidTypeForm, LocMessage.protocolNotAllowed(), errorNode);
                     }
 
-                    typeArgs?.forEach((typeArg) => {
-                        if (typeArg.typeList || !isTypeVar(typeArg.type)) {
-                            addDiagnostic(
-                                DiagnosticRule.reportInvalidTypeForm,
-                                LocMessage.protocolTypeArgMustBeTypeParam(),
-                                typeArg.node
-                            );
+                    if (typeArgs) {
+                        for (const typeArg of typeArgs) {
+                            if (typeArg.typeList || !isTypeVar(typeArg.type)) {
+                                addDiagnostic(
+                                    DiagnosticRule.reportInvalidTypeForm,
+                                    LocMessage.protocolTypeArgMustBeTypeParam(),
+                                    typeArg.node
+                                );
+                            }
                         }
-                    });
+                    }
 
                     return {
                         type: createSpecialType(
@@ -21513,11 +21957,23 @@ export function createTypeEvaluator(
             return { type: classType };
         }
 
-        const variadicTypeParamIndex = typeParams.findIndex((param) => isTypeVarTuple(param));
+        let variadicTypeParamIndex = -1;
+        for (let i = 0; i < typeParams.length; i++) {
+            if (isTypeVarTuple(typeParams[i])) {
+                variadicTypeParamIndex = i;
+                break;
+            }
+        }
 
         if (typeArgs) {
             let minTypeArgCount = typeParams.length;
-            const firstDefaultParamIndex = typeParams.findIndex((param) => !!param.shared.isDefaultExplicit);
+            let firstDefaultParamIndex = -1;
+            for (let i = 0; i < typeParams.length; i++) {
+                if (typeParams[i].shared.isDefaultExplicit) {
+                    firstDefaultParamIndex = i;
+                    break;
+                }
+            }
 
             if (firstDefaultParamIndex >= 0) {
                 minTypeArgCount = firstDefaultParamIndex;
@@ -21577,7 +22033,8 @@ export function createTypeEvaluator(
                 );
             }
 
-            typeArgs.forEach((typeArg, index) => {
+            for (let index = 0; index < typeArgs.length; index++) {
+                const typeArg = typeArgs[index];
                 if (!typeArg.type.props?.typeForm) {
                     isValidTypeForm = false;
                 }
@@ -21587,14 +22044,14 @@ export function createTypeEvaluator(
                     // TypeVarTuple have already been validated when the tuple
                     // object was created in adjustTypeArgsForTypeVarTuple.
                     if (isClassInstance(typeArg.type) && isTupleClass(typeArg.type)) {
-                        return;
+                        continue;
                     }
 
                     if (isTypeVarTuple(typeArg.type)) {
                         if (!validateTypeVarTupleIsUnpacked(typeArg.type, typeArg.node)) {
                             isValidTypeForm = false;
                         }
-                        return;
+                        continue;
                     }
                 }
 
@@ -21609,7 +22066,7 @@ export function createTypeEvaluator(
                 ) {
                     isValidTypeForm = false;
                 }
-            });
+            }
         }
 
         // Handle ParamSpec arguments and fill in any missing type arguments with Unknown.
@@ -21623,7 +22080,8 @@ export function createTypeEvaluator(
 
         const constraints = new ConstraintTracker();
 
-        fullTypeParams.forEach((typeParam, index) => {
+        for (let index = 0; index < fullTypeParams.length; index++) {
+            const typeParam = fullTypeParams[index];
             if (typeArgs && index < typeArgs.length) {
                 if (isParamSpec(typeParam)) {
                     const typeArg = typeArgs[index];
@@ -21634,21 +22092,21 @@ export function createTypeEvaluator(
                         functionType.shared.flags |= FunctionTypeFlags.GradualCallableForm;
                         typeArgTypes.push(functionType);
                         constraints.setBounds(typeParam, functionType);
-                        return;
+                        continue;
                     }
 
                     if (typeArg.typeList) {
-                        typeArg.typeList!.forEach((paramType, paramIndex) => {
+                        for (let paramIndex = 0; paramIndex < typeArg.typeList.length; paramIndex++) {
                             FunctionType.addParam(
                                 functionType,
                                 FunctionParam.create(
                                     ParamCategory.Simple,
-                                    convertToInstance(paramType.type),
+                                    convertToInstance(typeArg.typeList[paramIndex].type),
                                     FunctionParamFlags.NameSynthesized | FunctionParamFlags.TypeDeclared,
                                     `__p${paramIndex}`
                                 )
                             );
-                        });
+                        }
 
                         if (typeArg.typeList.length > 0) {
                             FunctionType.addPositionOnlyParamSeparator(functionType);
@@ -21656,17 +22114,18 @@ export function createTypeEvaluator(
 
                         typeArgTypes.push(functionType);
                         constraints.setBounds(typeParam, functionType);
-                        return;
+                        continue;
                     }
 
                     if (isInstantiableClass(typeArg.type) && ClassType.isBuiltIn(typeArg.type, 'Concatenate')) {
                         const concatTypeArgs = typeArg.type.priv.typeArgs;
                         if (concatTypeArgs && concatTypeArgs.length > 0) {
-                            concatTypeArgs.forEach((typeArg, index) => {
-                                if (index === concatTypeArgs.length - 1) {
-                                    if (isParamSpec(typeArg)) {
-                                        FunctionType.addParamSpecVariadics(functionType, typeArg);
-                                    } else if (isEllipsisType(typeArg)) {
+                            for (let concatIndex = 0; concatIndex < concatTypeArgs.length; concatIndex++) {
+                                const concatArg = concatTypeArgs[concatIndex];
+                                if (concatIndex === concatTypeArgs.length - 1) {
+                                    if (isParamSpec(concatArg)) {
+                                        FunctionType.addParamSpecVariadics(functionType, concatArg);
+                                    } else if (isEllipsisType(concatArg)) {
                                         FunctionType.addDefaultParams(functionType);
                                         functionType.shared.flags |= FunctionTypeFlags.GradualCallableForm;
                                     }
@@ -21675,24 +22134,24 @@ export function createTypeEvaluator(
                                         functionType,
                                         FunctionParam.create(
                                             ParamCategory.Simple,
-                                            typeArg,
+                                            concatArg,
                                             FunctionParamFlags.NameSynthesized | FunctionParamFlags.TypeDeclared,
-                                            `__p${index}`
+                                            `__p${concatIndex}`
                                         )
                                     );
                                 }
-                            });
+                            }
                         }
 
                         typeArgTypes.push(functionType);
-                        return;
+                        continue;
                     }
                 }
 
                 const typeArgType = convertToInstance(typeArgs[index].type);
                 typeArgTypes.push(typeArgType);
                 constraints.setBounds(typeParam, typeArgType);
-                return;
+                continue;
             }
 
             const solvedDefaultType = solveAndApplyConstraints(typeParam, constraints, {
@@ -21703,9 +22162,10 @@ export function createTypeEvaluator(
             });
             typeArgTypes.push(solvedDefaultType);
             constraints.setBounds(typeParam, solvedDefaultType);
-        });
+        }
 
-        typeArgTypes = typeArgTypes.map((typeArgType, index) => {
+        for (let index = 0; index < typeArgTypes.length; index++) {
+            let typeArgType = typeArgTypes[index];
             if (index < typeArgCount) {
                 const diag = new DiagnosticAddendum();
                 let adjustedTypeArgType = applyTypeArgToTypeVar(typeParams[index], typeArgType, diag);
@@ -21745,14 +22205,18 @@ export function createTypeEvaluator(
                 }
             }
 
-            return typeArgType;
-        });
+            typeArgTypes[index] = typeArgType;
+        }
 
         // If the class is partially constructed and doesn't yet have
         // type parameters, assume that the number and types of supplied type
         // arguments are correct.
         if (typeArgs && classType.shared.typeParams.length === 0 && ClassType.isPartiallyEvaluated(classType)) {
-            typeArgTypes = typeArgs.map((t) => convertToInstance(t.type));
+            const convertedTypeArgs: Type[] = [];
+            for (const t of typeArgs) {
+                convertedTypeArgs.push(convertToInstance(t.type));
+            }
+            typeArgTypes = convertedTypeArgs;
         }
 
         let specializedClass = ClassType.specialize(classType, typeArgTypes, typeArgs !== undefined);
@@ -22001,7 +22465,9 @@ export function createTypeEvaluator(
 
         if (symbolWithScope && honorCodeFlow && scopeTypeHonorsCodeFlow) {
             // Filter the declarations based on flow reachability.
-            const reachableDecl = symbolWithScope.symbol.getDeclarations().find((decl) => {
+            let reachableDecl: Declaration | undefined;
+            for (const decl of symbolWithScope.symbol.getDeclarations()) {
+                let isReachableDecl = true;
                 if (decl.type !== DeclarationType.Alias && decl.type !== DeclarationType.Intrinsic) {
                     // Determine if the declaration is in the same execution scope as the "usageNode" node.
                     let usageScopeNode = ParseTreeUtils.getExecutionScopeNode(node);
@@ -22036,12 +22502,15 @@ export function createTypeEvaluator(
                                     /* sourceFlowNode */ undefined,
                                     /* ignoreNoReturn */ true
                                 ) === Reachability.Reachable;
-                            return !isReachable;
+                            isReachableDecl = !isReachable;
                         }
                     }
                 }
-                return true;
-            });
+                if (isReachableDecl) {
+                    reachableDecl = decl;
+                    break;
+                }
+            }
 
             // If none of the declarations are reachable from the current node,
             // search for the symbol in outer scopes.
@@ -22246,7 +22715,11 @@ export function createTypeEvaluator(
                     if (functionScope) {
                         const paramSymbol = functionScope.lookUpSymbol(paramName)!;
                         if (paramSymbol) {
-                            return paramSymbol.getDeclarations().find((decl) => decl.type === DeclarationType.Param);
+                            for (const decl of paramSymbol.getDeclarations()) {
+                                if (decl.type === DeclarationType.Param) {
+                                    return decl;
+                                }
+                            }
                         }
 
                         const parameterDetails = getParamListDetails(type);
@@ -22256,9 +22729,11 @@ export function createTypeEvaluator(
                                 paramName
                             );
                             if (lookupResults) {
-                                return lookupResults.symbol
-                                    .getDeclarations()
-                                    .find((decl) => decl.type === DeclarationType.Variable);
+                                for (const decl of lookupResults.symbol.getDeclarations()) {
+                                if (decl.type === DeclarationType.Variable) {
+                                    return decl;
+                                }
+                            }
                             }
                         }
                     }
@@ -22336,9 +22811,12 @@ export function createTypeEvaluator(
                 if (symbolInScope) {
                     // The alias could have more decls that don't refer to this import. Filter
                     // out the one(s) that specifically associated with this import statement.
-                    const declsForThisImport = symbolInScope.symbol.getDeclarations().filter((decl) => {
-                        return decl.type === DeclarationType.Alias && decl.node === node.parent;
-                    });
+                    const declsForThisImport: Declaration[] = [];
+                    for (const decl of symbolInScope.symbol.getDeclarations()) {
+                        if (decl.type === DeclarationType.Alias && decl.node === node.parent) {
+                            declsForThisImport.push(decl);
+                        }
+                    }
 
                     appendArray(decls, getDeclarationsWithUsesLocalNameRemoved(declsForThisImport));
                 }
@@ -22408,7 +22886,13 @@ export function createTypeEvaluator(
                 });
             }
         } else if (node.parent && node.parent.nodeType === ParseNodeType.ModuleName) {
-            const namePartIndex = node.parent.d.nameParts.findIndex((part) => part === node);
+            let namePartIndex = -1;
+            for (let i = 0; i < node.parent.d.nameParts.length; i++) {
+                if (node.parent.d.nameParts[i] === node) {
+                    namePartIndex = i;
+                    break;
+                }
+            }
             const importInfo = AnalyzerNodeInfo.getImportInfo(node.parent);
             if (
                 namePartIndex >= 0 &&
@@ -22440,12 +22924,12 @@ export function createTypeEvaluator(
                             decls.push(paramDecl);
                         }
                     } else if (isOverloaded(baseType)) {
-                        OverloadedType.getOverloads(baseType).forEach((f) => {
+                        for (const f of OverloadedType.getOverloads(baseType)) {
                             const paramDecl = getDeclarationFromKeywordParam(f, paramName);
                             if (paramDecl) {
                                 decls.push(paramDecl);
                             }
-                        });
+                        }
                     } else if (isInstantiableClass(baseType)) {
                         const initMethodType = getBoundInitMethod(
                             evaluatorInterface,
@@ -22624,7 +23108,13 @@ export function createTypeEvaluator(
                             functionNode.d.funcAnnotationComment &&
                             !functionNode.d.funcAnnotationComment.d.isEllipsis
                         ) {
-                            const paramIndex = functionNode.d.params.findIndex((param) => param === declaration.node);
+                            let paramIndex = -1;
+                            for (let i = 0; i < functionNode.d.params.length; i++) {
+                                if (functionNode.d.params[i] === declaration.node) {
+                                    paramIndex = i;
+                                    break;
+                                }
+                            }
                             typeAnnotationNode = ParseTreeUtils.getTypeAnnotationForParam(functionNode, paramIndex);
                         }
                     }
@@ -22752,7 +23242,8 @@ export function createTypeEvaluator(
 
         if (node.d.boundExpr) {
             if (node.d.boundExpr.nodeType === ParseNodeType.Tuple) {
-                const constraints = node.d.boundExpr.d.items.map((constraint) => {
+                const constraints: Type[] = [];
+                for (const constraint of node.d.boundExpr.d.items) {
                     const constraintType = getTypeOfExpressionExpectingType(constraint, {
                         noNonTypeSpecialForms: true,
                         forwardRefs: true,
@@ -22772,8 +23263,8 @@ export function createTypeEvaluator(
                         );
                     }
 
-                    return convertToInstance(constraintType);
-                });
+                    constraints.push(convertToInstance(constraintType));
+                }
 
                 if (constraints.length < 2) {
                     addDiagnostic(
@@ -22920,7 +23411,7 @@ export function createTypeEvaluator(
             }
 
             if (loaderActions.implicitImports) {
-                loaderActions.implicitImports.forEach((implicitImport, name) => {
+                for (const [name, implicitImport] of loaderActions.implicitImports) {
                     const existingLoaderField = moduleType.priv.loaderFields.get(name);
 
                     // Recursively apply loader actions.
@@ -22948,7 +23439,7 @@ export function createTypeEvaluator(
                         const importedModuleSymbol = Symbol.createWithType(SymbolFlags.None, symbolType);
                         moduleType.priv.loaderFields.set(name, importedModuleSymbol);
                     }
-                });
+                }
             }
 
             return moduleType;
@@ -23040,11 +23531,13 @@ export function createTypeEvaluator(
 
                     if (isInstantiableClass(callType) && ClassType.isBuiltIn(callType, exemptBuiltins)) {
                         isUnambiguousType = true;
-                    } else if (
-                        isFunction(callType) &&
-                        exemptBuiltins.some((name) => FunctionType.isBuiltIn(callType, name))
-                    ) {
-                        isUnambiguousType = true;
+                    } else if (isFunction(callType)) {
+                        for (const name of exemptBuiltins) {
+                            if (FunctionType.isBuiltIn(callType, name)) {
+                                isUnambiguousType = true;
+                                break;
+                            }
+                        }
                     }
                 }
             }
@@ -23115,9 +23608,12 @@ export function createTypeEvaluator(
     // Applies some heuristics to determine whether it's likely that all Python
     // type checkers will infer the same type.
     function isUnambiguousInference(symbol: Symbol, decl: Declaration, inferredType: Type): boolean {
-        const nonSlotsDecls = symbol.getDeclarations().filter((decl) => {
-            return decl.type !== DeclarationType.Variable || !decl.isInferenceAllowedInPyTyped;
-        });
+        const nonSlotsDecls: Declaration[] = [];
+        for (const decl of symbol.getDeclarations()) {
+            if (decl.type !== DeclarationType.Variable || !decl.isInferenceAllowedInPyTyped) {
+                nonSlotsDecls.push(decl);
+            }
+        }
 
         // Any symbol with more than one assignment is considered ambiguous.
         if (nonSlotsDecls.length > 1) {
@@ -23248,11 +23744,19 @@ export function createTypeEvaluator(
                     !declaredTypeInfo.exceedsMaxDecls &&
                     !speculativeTypeTracker.isSpeculative(/* node */ undefined);
 
+                let hasIllegalTypeAliasDecl = false;
+                for (const decl of typedDecls) {
+                    if (!isPossibleTypeAliasDeclaration(decl)) {
+                        hasIllegalTypeAliasDecl = true;
+                        break;
+                    }
+                }
+
                 const result: EffectiveTypeResult = {
                     type: declaredType ?? UnknownType.create(),
                     isIncomplete,
                     includesVariableDecl: includesVariableTypeDecl(typedDecls),
-                    includesIllegalTypeAliasDecl: !typedDecls.every((decl) => isPossibleTypeAliasDeclaration(decl)),
+                    includesIllegalTypeAliasDecl: hasIllegalTypeAliasDecl,
                     includesSpeculativeResult: false,
                     isRecursiveDefinition,
                 };
@@ -23267,7 +23771,7 @@ export function createTypeEvaluator(
     // Determines whether the set of declarations includes a variable declaration
     // that is not part of a typing.pyi or typingExtensions.pyi file.
     function includesVariableTypeDecl(decls: Declaration[]): boolean {
-        return decls.some((decl) => {
+        for (const decl of decls) {
             if (decl.type === DeclarationType.Variable) {
                 // Exempt typing.pyi and typingExtensions.pyi, which use variables to
                 // define some special forms.
@@ -23281,9 +23785,9 @@ export function createTypeEvaluator(
             if (decl.type === DeclarationType.Param) {
                 return true;
             }
+        }
 
-            return false;
-        });
+        return false;
     }
 
     function inferTypeOfSymbolForUsage(symbol: Symbol, usageNode?: NameNode, useLastDecl = false): EffectiveTypeResult {
@@ -23306,11 +23810,19 @@ export function createTypeEvaluator(
 
         // Limit the number of declarations to explore.
         if (decls.length > maxDeclarationsToUseForInference) {
+            let hasIllegalTypeAliasDecl = false;
+            for (const decl of decls) {
+                if (!isPossibleTypeAliasDeclaration(decl)) {
+                    hasIllegalTypeAliasDecl = true;
+                    break;
+                }
+            }
+
             const result: EffectiveTypeResult = {
                 type: UnknownType.create(),
                 isIncomplete: false,
                 includesVariableDecl: false,
-                includesIllegalTypeAliasDecl: !decls.every((decl) => isPossibleTypeAliasDeclaration(decl)),
+                includesIllegalTypeAliasDecl: hasIllegalTypeAliasDecl,
                 includesSpeculativeResult: false,
                 isRecursiveDefinition: false,
             };
@@ -23323,21 +23835,39 @@ export function createTypeEvaluator(
         // will use only the last one, but we'll ignore decls that are in
         // except clauses.
         if (useLastDecl) {
-            decls.forEach((decl, index) => {
-                if (!decl.isInExceptSuite) {
+            for (let index = 0; index < decls.length; index++) {
+                if (!decls[index].isInExceptSuite) {
                     declIndexToConsider = index;
                 }
-            });
+            }
         } else {
             // Handle the case where there are multiple imports — one of them in
             // a try block and one or more in except blocks. In this case, we'll
             // use the one in the try block rather than the excepts.
-            if (decls.length > 1 && decls.every((decl) => decl.type === DeclarationType.Alias)) {
-                const nonExceptDecls = decls.filter(
-                    (decl) => decl.type === DeclarationType.Alias && !decl.isInExceptSuite
-                );
-                if (nonExceptDecls.length === 1) {
-                    declIndexToConsider = decls.findIndex((decl) => decl === nonExceptDecls[0]);
+            if (decls.length > 1) {
+                let allAliasDecls = true;
+                for (const decl of decls) {
+                    if (decl.type !== DeclarationType.Alias) {
+                        allAliasDecls = false;
+                        break;
+                    }
+                }
+
+                if (allAliasDecls) {
+                    const nonExceptDecls: Declaration[] = [];
+                    for (const decl of decls) {
+                        if (decl.type === DeclarationType.Alias && !decl.isInExceptSuite) {
+                            nonExceptDecls.push(decl);
+                        }
+                    }
+                    if (nonExceptDecls.length === 1) {
+                        for (let index = 0; index < decls.length; index++) {
+                            if (decls[index] === nonExceptDecls[0]) {
+                                declIndexToConsider = index;
+                                break;
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -23348,7 +23878,8 @@ export function createTypeEvaluator(
         let includesIllegalTypeAliasDecl = false;
 
         let sawExplicitTypeAlias = false;
-        decls.forEach((decl, index) => {
+        for (let index = 0; index < decls.length; index++) {
+            const decl = decls[index];
             const resolvedDecl =
                 resolveAliasDeclaration(decl, /* resolveLocalNames */ true, {
                     allowExternallyHiddenAccess: AnalyzerNodeInfo.getFileInfo(decl.node).isStubFile,
@@ -23363,7 +23894,7 @@ export function createTypeEvaluator(
             }
 
             if (declIndexToConsider !== undefined && declIndexToConsider !== index) {
-                return;
+                continue;
             }
 
             // If we have already seen an explicit type alias, do not consider
@@ -23371,7 +23902,7 @@ export function createTypeEvaluator(
             // are provided -- normally an error, but it can happen in stdlib stubs
             // if the user sets the pythonPlatform to "All".
             if (sawExplicitTypeAlias) {
-                return;
+                continue;
             }
 
             // If the symbol is explicitly marked as a ClassVar, consider only the
@@ -23382,7 +23913,7 @@ export function createTypeEvaluator(
                 decl.type === DeclarationType.Variable &&
                 decl.isDefinedByMemberAccess
             ) {
-                return;
+                continue;
             }
 
             if (usageNode !== undefined) {
@@ -23394,7 +23925,7 @@ export function createTypeEvaluator(
                     const declScope = ParseTreeUtils.getExecutionScopeNode(decl.node);
                     if (usageScope === declScope) {
                         if (!isFlowPathBetweenNodes(decl.node, usageNode)) {
-                            return;
+                            continue;
                         }
                     }
                 }
@@ -23418,17 +23949,21 @@ export function createTypeEvaluator(
             }
 
             declsToConsider.push(resolvedDecl);
-        });
+        }
 
         // If all of the decls come from augmented assignments, we won't be able to
         // determine its type. At least one declaration must be a simple assignment.
-        if (
-            declsToConsider.every(
-                (decl) =>
-                    isVariableDeclaration(decl) &&
-                    ParseTreeUtils.isNodeContainedWithinNodeType(decl.node, ParseNodeType.AugmentedAssignment)
-            )
-        ) {
+        let allAugmentedAssignments = true;
+        for (const decl of declsToConsider) {
+            if (
+                !isVariableDeclaration(decl) ||
+                !ParseTreeUtils.isNodeContainedWithinNodeType(decl.node, ParseNodeType.AugmentedAssignment)
+            ) {
+                allAugmentedAssignments = false;
+                break;
+            }
+        }
+        if (allAugmentedAssignments) {
             declsToConsider.splice(0);
         }
 
@@ -23461,7 +23996,7 @@ export function createTypeEvaluator(
         let sawPendingEvaluation = false;
         let includesSpeculativeResult = false;
 
-        decls.forEach((decl) => {
+        for (const decl of decls) {
             if (pushSymbolResolution(symbol, decl)) {
                 try {
                     let type = getInferredTypeOfDeclaration(symbol, decl);
@@ -23524,7 +24059,7 @@ export function createTypeEvaluator(
                 // it was already in the process of being evaluated.
                 sawPendingEvaluation = true;
             }
-        });
+        }
 
         // How many times have we already attempted to evaluate this declaration already?
         const cacheEntries = effectiveTypeCache.get(symbol.id);
@@ -23593,7 +24128,8 @@ export function createTypeEvaluator(
                 typedDecls = [typedDecls[typedDecls.length - 1]];
                 exceedsMaxDecls = true;
             } else {
-                const filteredTypedDecls = typedDecls.filter((decl) => {
+                const filteredTypedDecls: Declaration[] = [];
+                for (const decl of typedDecls) {
                     if (decl.type !== DeclarationType.Alias) {
                         // Is the declaration in the same execution scope as the "usageNode" node?
                         const usageScope = ParseTreeUtils.getExecutionScopeNode(usageNode);
@@ -23601,12 +24137,12 @@ export function createTypeEvaluator(
 
                         if (usageScope === declScope) {
                             if (!isFlowPathBetweenNodes(decl.node, usageNode, /* allowSelf */ false)) {
-                                return false;
+                                continue;
                             }
                         }
                     }
-                    return true;
-                });
+                    filteredTypedDecls.push(decl);
+                }
 
                 if (filteredTypedDecls.length === 0) {
                     return { type: UnboundType.create() };
@@ -23664,9 +24200,9 @@ export function createTypeEvaluator(
         if (isFunction(type)) {
             getEffectiveReturnType(type);
         } else if (isOverloaded(type)) {
-            OverloadedType.getOverloads(type).forEach((overload) => {
+            for (const overload of OverloadedType.getOverloads(type)) {
                 getEffectiveReturnType(overload);
-            });
+            }
 
             const impl = OverloadedType.getImplementation(type);
             if (impl && isFunction(impl)) {
@@ -23744,9 +24280,15 @@ export function createTypeEvaluator(
                     // For very complex functions that have no annotated parameter types,
                     // don't attempt to infer the return type because it can be extremely
                     // expensive.
-                    const parametersAreAnnotated =
-                        type.shared.parameters.length <= 1 ||
-                        type.shared.parameters.some((param) => FunctionParam.isTypeDeclared(param));
+                    let parametersAreAnnotated = type.shared.parameters.length <= 1;
+                    if (!parametersAreAnnotated) {
+                        for (const param of type.shared.parameters) {
+                            if (FunctionParam.isTypeDeclared(param)) {
+                                parametersAreAnnotated = true;
+                                break;
+                            }
+                        }
+                    }
 
                     if (parametersAreAnnotated || codeFlowComplexity < maxReturnTypeInferenceCodeFlowComplexity) {
                         // Temporarily disable speculative mode while we
@@ -23846,14 +24388,28 @@ export function createTypeEvaluator(
         // If an arg hasn't been matched to a specific named parameter,
         // it's an unpacked value that corresponds to multiple parameters.
         // That's an edge case that we don't handle here.
-        if (args.some((arg) => !arg.paramName)) {
+        let hasUnmatchedArg = false;
+        for (const arg of args) {
+            if (!arg.paramName) {
+                hasUnmatchedArg = true;
+                break;
+            }
+        }
+        if (hasUnmatchedArg) {
             return undefined;
         }
 
         // Detect recurrence. If a function invokes itself either directly
         // or indirectly, we won't attempt to infer contextual return
         // types any further.
-        if (returnTypeInferenceContextStack.some((context) => context.functionNode === functionNode)) {
+        let hasRecurrence = false;
+        for (const context of returnTypeInferenceContextStack) {
+            if (context.functionNode === functionNode) {
+                hasRecurrence = true;
+                break;
+            }
+        }
+        if (hasRecurrence) {
             return undefined;
         }
 
@@ -23896,13 +24452,20 @@ export function createTypeEvaluator(
                 returnTypeInferenceTypeCache = new Map<number, TypeCacheEntry>();
 
                 let allArgTypesAreUnknown = true;
-                functionNode.d.params.forEach((param, index) => {
+                for (let index = 0; index < functionNode.d.params.length; index++) {
+                    const param = functionNode.d.params[index];
                     if (param.d.name) {
                         let paramType: Type | undefined;
-                        const arg = args.find((arg) => param.d.name!.d.value === arg.paramName);
+                        let matchedArg: (typeof args)[number] | undefined;
+                        for (const arg of args) {
+                            if (param.d.name!.d.value === arg.paramName) {
+                                matchedArg = arg;
+                                break;
+                            }
+                        }
 
-                        if (arg && arg.argument.valueExpression) {
-                            paramType = getTypeOfExpression(arg.argument.valueExpression).type;
+                        if (matchedArg && matchedArg.argument.valueExpression) {
+                            paramType = getTypeOfExpression(matchedArg.argument.valueExpression).type;
                             if (!isUnknown(paramType)) {
                                 allArgTypesAreUnknown = false;
                             }
@@ -23943,19 +24506,32 @@ export function createTypeEvaluator(
                         paramTypes.push(paramType);
                         writeTypeCache(param.d.name, { type: paramType }, EvalFlags.None);
                     }
-                });
+                }
 
                 // Don't bother trying to determine the contextual return
                 // type if none of the argument types are known.
                 if (!allArgTypesAreUnknown) {
                     // See if the return type is already cached. If so, skip the
                     // inference step, which is potentially very expensive.
-                    const cacheEntry = functionTypeResult.functionType.priv.callSiteReturnTypeCache?.find((entry) => {
-                        return (
-                            entry.paramTypes.length === paramTypes.length &&
-                            entry.paramTypes.every((t, i) => isTypeSame(t, paramTypes[i]))
-                        );
-                    });
+                    const cache = functionTypeResult.functionType.priv.callSiteReturnTypeCache;
+                    let cacheEntry: CallSiteInferenceTypeCacheEntry | undefined;
+                    if (cache) {
+                        for (const entry of cache) {
+                            if (entry.paramTypes.length === paramTypes.length) {
+                                let allSame = true;
+                                for (let i = 0; i < entry.paramTypes.length; i++) {
+                                    if (!isTypeSame(entry.paramTypes[i], paramTypes[i])) {
+                                        allSame = false;
+                                        break;
+                                    }
+                                }
+                                if (allSame) {
+                                    cacheEntry = entry;
+                                    break;
+                                }
+                            }
+                        }
+                    }
 
                     if (cacheEntry) {
                         contextualReturnType = cacheEntry.returnType;
@@ -24195,14 +24771,20 @@ export function createTypeEvaluator(
         // Handle special-case type promotions.
         if (destType.priv.includePromotions) {
             const promotionList = typePromotions.get(destType.shared.fullName);
-            if (
-                promotionList &&
-                promotionList.some((srcName) =>
-                    srcType.shared.mro.some((mroClass) => isClass(mroClass) && srcName === mroClass.shared.fullName)
-                )
-            ) {
-                if ((flags & AssignTypeFlags.Invariant) === 0) {
-                    return true;
+            if (promotionList) {
+                let hasPromotion = false;
+                outer: for (const srcName of promotionList) {
+                    for (const mroClass of srcType.shared.mro) {
+                        if (isClass(mroClass) && srcName === mroClass.shared.fullName) {
+                            hasPromotion = true;
+                            break outer;
+                        }
+                    }
+                }
+                if (hasPromotion) {
+                    if ((flags & AssignTypeFlags.Invariant) === 0) {
+                        return true;
+                    }
                 }
             }
         }
@@ -24289,8 +24871,17 @@ export function createTypeEvaluator(
             // Tell the user about the disableBytesTypePromotions if that is involved.
             if (ClassType.isBuiltIn(destType, 'bytes')) {
                 const promotions = typePromotions.get(destType.shared.fullName);
-                if (promotions && promotions.some((name) => name === srcType.shared.fullName)) {
-                    diag?.addMessage(LocAddendum.bytesTypePromotions());
+                if (promotions) {
+                    let hasMatchingPromotion = false;
+                    for (const name of promotions) {
+                        if (name === srcType.shared.fullName) {
+                            hasMatchingPromotion = true;
+                            break;
+                        }
+                    }
+                    if (hasMatchingPromotion) {
+                        diag?.addMessage(LocAddendum.bytesTypePromotions());
+                    }
                 }
             }
         }
@@ -24325,14 +24916,14 @@ export function createTypeEvaluator(
             // as though all type parameters are invariant.
             assignClassToSelfStack.push({ class: destType, assumedVariance });
 
-            ClassType.getSymbolTable(destType).forEach((symbol, name) => {
+            for (const [name, symbol] of ClassType.getSymbolTable(destType)) {
                 if (!isAssignable || symbol.isIgnoredForProtocolMatch()) {
-                    return;
+                    continue;
                 }
 
                 // Constructor methods are exempt from variance calculations.
                 if (name === '__new__' || name === '__init__') {
-                    return;
+                    continue;
                 }
 
                 const memberInfo = lookUpClassMember(srcType, name);
@@ -24395,30 +24986,31 @@ export function createTypeEvaluator(
                         isAssignable = false;
                     }
                 }
-            });
+            }
 
             if (!isAssignable) {
                 return false;
             }
 
             // Now handle generic base classes.
-            destType.shared.baseClasses.forEach((baseClass) => {
+            for (const baseClass of destType.shared.baseClasses) {
                 if (
                     !isAssignable ||
                     !isInstantiableClass(baseClass) ||
                     ClassType.isBuiltIn(baseClass, ['object', 'Protocol', 'Generic']) ||
                     baseClass.shared.typeParams.length === 0
                 ) {
-                    return;
+                    continue;
                 }
 
                 const specializedDestBaseClass = specializeForBaseClass(destType, baseClass);
                 const specializedSrcBaseClass = specializeForBaseClass(srcType, baseClass);
 
                 if (!ignoreBaseClassVariance) {
-                    specializedDestBaseClass.shared.typeParams.forEach((param, index) => {
+                    for (let index = 0; index < specializedDestBaseClass.shared.typeParams.length; index++) {
+                        const param = specializedDestBaseClass.shared.typeParams[index];
                         if (isParamSpec(param) || isTypeVarTuple(param) || param.shared.isSynthesized) {
-                            return;
+                            continue;
                         }
 
                         if (
@@ -24427,33 +25019,33 @@ export function createTypeEvaluator(
                             !specializedDestBaseClass.priv.typeArgs ||
                             index >= specializedDestBaseClass.priv.typeArgs.length
                         ) {
-                            return;
+                            continue;
                         }
 
                         const paramVariance = param.shared.declaredVariance;
                         if (isTypeVar(specializedSrcBaseClass.priv.typeArgs[index])) {
                             if (paramVariance === Variance.Invariant || paramVariance === Variance.Contravariant) {
                                 isAssignable = false;
-                                return;
+                                continue;
                             }
                         }
 
                         if (isTypeVar(specializedDestBaseClass.priv.typeArgs[index])) {
                             if (paramVariance === Variance.Invariant || paramVariance === Variance.Covariant) {
                                 isAssignable = false;
-                                return;
+                                continue;
                             }
                         }
-                    });
+                    }
                 }
 
                 if (!isAssignable) {
-                    return;
+                    continue;
                 }
 
                 // Handle tuples specially since their type arguments are variadic.
                 if (ClassType.isTupleClass(specializedDestBaseClass)) {
-                    return;
+                    continue;
                 }
 
                 if (
@@ -24467,7 +25059,7 @@ export function createTypeEvaluator(
                 ) {
                     isAssignable = false;
                 }
-            });
+            }
 
             return isAssignable;
         } finally {
@@ -24634,9 +25226,13 @@ export function createTypeEvaluator(
         // Are we performing protocol variance validation for this class? If so,
         // treat all of the type parameters as invariant even if they are declared
         // otherwise.
-        const assignClassToSelfInfo = assignClassToSelfStack.find((info) =>
-            ClassType.isSameGenericClass(info.class, destType)
-        );
+        let assignClassToSelfInfo: (typeof assignClassToSelfStack)[number] | undefined;
+        for (const info of assignClassToSelfStack) {
+            if (ClassType.isSameGenericClass(info.class, destType)) {
+                assignClassToSelfInfo = info;
+                break;
+            }
+        }
         const assumedVariance = assignClassToSelfInfo?.assumedVariance;
 
         // If either source or dest type arguments are missing, they are
@@ -24646,8 +25242,20 @@ export function createTypeEvaluator(
         }
 
         if (ClassType.isTupleClass(destType)) {
-            destTypeArgs = destType.priv.tupleTypeArgs?.map((t) => t.type) ?? [];
-            srcTypeArgs = srcType.priv.tupleTypeArgs?.map((t) => t.type);
+            const destTupleArgs: Type[] = [];
+            if (destType.priv.tupleTypeArgs) {
+                for (const t of destType.priv.tupleTypeArgs) {
+                    destTupleArgs.push(t.type);
+                }
+            }
+            destTypeArgs = destTupleArgs;
+            if (srcType.priv.tupleTypeArgs) {
+                const srcTupleArgs: Type[] = [];
+                for (const t of srcType.priv.tupleTypeArgs) {
+                    srcTupleArgs.push(t.type);
+                }
+                srcTypeArgs = srcTupleArgs;
+            }
         } else {
             destTypeArgs = destType.priv.typeArgs;
             srcTypeArgs = srcType.priv.typeArgs;
@@ -24655,7 +25263,9 @@ export function createTypeEvaluator(
 
         let isCompatible = true;
 
-        srcTypeArgs?.forEach((srcTypeArg, srcArgIndex) => {
+        if (srcTypeArgs) {
+            for (let srcArgIndex = 0; srcArgIndex < srcTypeArgs.length; srcArgIndex++) {
+                const srcTypeArg = srcTypeArgs[srcArgIndex];
             // In most cases, the number of type args should match the number
             // of type arguments, but there are a few special cases where this
             // isn't true (e.g. assigning a Tuple[X, Y, Z] to a tuple[W]).
@@ -24734,7 +25344,8 @@ export function createTypeEvaluator(
                     isCompatible = false;
                 }
             }
-        });
+            }
+        }
 
         return isCompatible;
     }
@@ -24865,9 +25476,14 @@ export function createTypeEvaluator(
                 // Add a special case for when the source is a str, which is itself
                 // a recursive type (since it derives from Sequence[str]).
                 if (isClassInstance(srcType) && ClassType.isBuiltIn(srcType, 'str') && isUnion(transformedDestType)) {
-                    return transformedDestType.priv.subtypes.some(
-                        (subtype) => isClassInstance(subtype) && ClassType.isBuiltIn(subtype, ['object', 'str'])
-                    );
+                    let hasMatchingSubtype = false;
+                    for (const subtype of transformedDestType.priv.subtypes) {
+                        if (isClassInstance(subtype) && ClassType.isBuiltIn(subtype, ['object', 'str'])) {
+                            hasMatchingSubtype = true;
+                            break;
+                        }
+                    }
+                    return hasMatchingSubtype;
                 }
                 return true;
             }
@@ -24899,15 +25515,21 @@ export function createTypeEvaluator(
             const destTypeVar = destType;
             if (
                 TypeBase.isInstantiable(destType) === TypeBase.isInstantiable(srcType) &&
-                srcType.props?.condition &&
-                srcType.props.condition.some((cond) => {
-                    return (
+                srcType.props?.condition
+            ) {
+                let hasMatchingCondition = false;
+                for (const cond of srcType.props.condition) {
+                    if (
                         !TypeVarType.hasConstraints(cond.typeVar) &&
                         cond.typeVar.priv.nameWithScope === destTypeVar.priv.nameWithScope
-                    );
-                })
-            ) {
-                return true;
+                    ) {
+                        hasMatchingCondition = true;
+                        break;
+                    }
+                }
+                if (hasMatchingCondition) {
+                    return true;
+                }
             }
 
             if (isUnion(srcType)) {
@@ -25439,7 +26061,7 @@ export function createTypeEvaluator(
                 const filteredOverloads: FunctionType[] = [];
                 const typeVarSignatures: ConstraintSet[] = [];
 
-                overloads.forEach((overload) => {
+                for (const overload of overloads) {
                     const overloadScopeId = getTypeVarScopeId(overload) ?? '';
                     const constraintsClone = constraints?.cloneWithSignature(overloadScopeId);
 
@@ -25450,7 +26072,7 @@ export function createTypeEvaluator(
                             appendArray(typeVarSignatures, constraintsClone.getConstraintSets());
                         }
                     }
-                });
+                }
 
                 if (filteredOverloads.length === 0) {
                     diag?.addMessage(LocAddendum.noOverloadAssignable().format({ type: printType(destType) }));
@@ -25494,25 +26116,31 @@ export function createTypeEvaluator(
             if (isOverloaded(srcType)) {
                 const srcOverloads = OverloadedType.getOverloads(srcType);
                 if (destOverloads.length === srcOverloads.length) {
-                    if (
-                        destOverloads.every((destOverload, index) => {
-                            const srcOverload = srcOverloads[index];
-                            return assignType(
-                                destOverload,
+                    let allMatch = true;
+                    for (let index = 0; index < destOverloads.length; index++) {
+                        const srcOverload = srcOverloads[index];
+                        if (
+                            !assignType(
+                                destOverloads[index],
                                 srcOverload,
                                 /* diag */ undefined,
                                 constraints,
                                 flags,
                                 recursionCount
-                            );
-                        })
-                    ) {
+                            )
+                        ) {
+                            allMatch = false;
+                            break;
+                        }
+                    }
+                    if (allMatch) {
                         return true;
                     }
                 }
             }
 
-            const isAssignable = destOverloads.every((destOverload) => {
+            let isAssignable = true;
+            for (const destOverload of destOverloads) {
                 const result = assignType(
                     destOverload,
                     srcType,
@@ -25521,8 +26149,11 @@ export function createTypeEvaluator(
                     flags,
                     recursionCount
                 );
-                return result;
-            });
+                if (!result) {
+                    isAssignable = false;
+                    break;
+                }
+            }
 
             if (!isAssignable) {
                 const overloads = OverloadedType.getOverloads(destType);
@@ -25592,7 +26223,8 @@ export function createTypeEvaluator(
         const srcTypeArgs = srcAliasInfo.typeArgs;
         const variances = destAliasInfo.shared.computedVariance;
 
-        destAliasInfo.typeArgs.forEach((destTypeArg, index) => {
+        for (let index = 0; index < destAliasInfo.typeArgs.length; index++) {
+            const destTypeArg = destAliasInfo.typeArgs[index];
             const srcTypeArg = index < srcTypeArgs.length ? srcTypeArgs[index] : UnknownType.create();
 
             let adjFlags = flags;
@@ -25607,7 +26239,7 @@ export function createTypeEvaluator(
             if (!assignType(destTypeArg, srcTypeArg, diag, constraints, adjFlags, recursionCount)) {
                 isAssignable = false;
             }
-        });
+        }
 
         return isAssignable;
     }
@@ -25681,11 +26313,17 @@ export function createTypeEvaluator(
             return true;
         }
 
-        if (
-            (flags & AssignTypeFlags.OverloadOverlap) !== 0 &&
-            srcType.priv.subtypes.some((subtype) => isAnyOrUnknown(subtype))
-        ) {
-            return false;
+        if ((flags & AssignTypeFlags.OverloadOverlap) !== 0) {
+            let hasAnyOrUnknownSubtype = false;
+            for (const subtype of srcType.priv.subtypes) {
+                if (isAnyOrUnknown(subtype)) {
+                    hasAnyOrUnknownSubtype = true;
+                    break;
+                }
+            }
+            if (hasAnyOrUnknownSubtype) {
+                return false;
+            }
         }
 
         // Sort the subtypes so we have a deterministic order for unions.
@@ -25712,13 +26350,17 @@ export function createTypeEvaluator(
 
             // First attempt to match all of the non-generic types in the dest
             // to non-generic types in the source.
-            sortTypes(destType.priv.subtypes).forEach((destSubtype) => {
+            for (const destSubtype of sortTypes(destType.priv.subtypes)) {
                 if (requiresSpecialization(destSubtype)) {
                     remainingDestSubtypes.push(destSubtype);
                 } else {
-                    const srcTypeIndex = remainingSrcSubtypes.findIndex((srcSubtype) =>
-                        isTypeSame(srcSubtype, destSubtype, undefined, recursionCount)
-                    );
+                    let srcTypeIndex = -1;
+                    for (let i = 0; i < remainingSrcSubtypes.length; i++) {
+                        if (isTypeSame(remainingSrcSubtypes[i], destSubtype, undefined, recursionCount)) {
+                            srcTypeIndex = i;
+                            break;
+                        }
+                    }
 
                     if (srcTypeIndex >= 0) {
                         remainingSrcSubtypes.splice(srcTypeIndex, 1);
@@ -25727,14 +26369,17 @@ export function createTypeEvaluator(
                         remainingDestSubtypes.push(destSubtype);
                     }
                 }
-            });
+            }
 
             // For all remaining source subtypes, attempt to find a dest subtype
             // whose primary type matches.
-            remainingSrcSubtypes.forEach((srcSubtype) => {
-                const destTypeIndex = remainingDestSubtypes.findIndex((destSubtype) => {
+            for (const srcSubtype of remainingSrcSubtypes) {
+                let destTypeIndex = -1;
+                for (let di = 0; di < remainingDestSubtypes.length; di++) {
+                    const destSubtype = remainingDestSubtypes[di];
                     if (isTypeSame(destSubtype, srcSubtype)) {
-                        return true;
+                        destTypeIndex = di;
+                        break;
                     }
 
                     if (
@@ -25743,7 +26388,8 @@ export function createTypeEvaluator(
                         TypeBase.isInstance(srcSubtype) === TypeBase.isInstance(destSubtype)
                     ) {
                         if (ClassType.isSameGenericClass(srcSubtype, destSubtype)) {
-                            return true;
+                            destTypeIndex = di;
+                            break;
                         }
 
                         // Are they equivalent TypedDicts?
@@ -25758,17 +26404,17 @@ export function createTypeEvaluator(
                                     recursionCount
                                 )
                             ) {
-                                return true;
+                                destTypeIndex = di;
+                                break;
                             }
                         }
                     }
 
                     if (isFunctionOrOverloaded(srcSubtype) && isFunctionOrOverloaded(destSubtype)) {
-                        return true;
+                        destTypeIndex = di;
+                        break;
                     }
-
-                    return false;
-                });
+                }
 
                 if (destTypeIndex >= 0) {
                     if (
@@ -25789,9 +26435,15 @@ export function createTypeEvaluator(
                     }
 
                     remainingDestSubtypes.splice(destTypeIndex, 1);
-                    remainingSrcSubtypes = remainingSrcSubtypes.filter((t) => t !== srcSubtype);
+                    const filteredRemaining: Type[] = [];
+                    for (const t of remainingSrcSubtypes) {
+                        if (t !== srcSubtype) {
+                            filteredRemaining.push(t);
+                        }
+                    }
+                    remainingSrcSubtypes = filteredRemaining;
                 }
-            });
+            }
 
             // If there is are remaining dest subtypes and they're all type variables,
             // attempt to assign the remaining source subtypes to them.
@@ -25800,21 +26452,36 @@ export function createTypeEvaluator(
                     // If we have no src subtypes remaining but not all dest types have been subsumed
                     // by other dest types, then the types are not compatible if we're enforcing invariance.
                     if (remainingSrcSubtypes.length === 0) {
-                        return remainingDestSubtypes.every((destSubtype) =>
-                            isTypeSubsumedByOtherType(
-                                destSubtype,
-                                destType,
-                                /* allowAnyToSubsume */ true,
-                                recursionCount
-                            )
-                        );
+                        let allSubsumed = true;
+                        for (const destSubtype of remainingDestSubtypes) {
+                            if (
+                                !isTypeSubsumedByOtherType(
+                                    destSubtype,
+                                    destType,
+                                    /* allowAnyToSubsume */ true,
+                                    recursionCount
+                                )
+                            ) {
+                                allSubsumed = false;
+                                break;
+                            }
+                        }
+                        return allSubsumed;
                     }
                 }
 
                 const isContra = (flags & AssignTypeFlags.Contravariant) !== 0;
                 const effectiveDestSubtypes = isContra ? remainingSrcSubtypes : remainingDestSubtypes;
 
-                if (effectiveDestSubtypes.length === 0 || effectiveDestSubtypes.some((t) => !isTypeVar(t))) {
+                let hasNonTypeVar = false;
+                for (const t of effectiveDestSubtypes) {
+                    if (!isTypeVar(t)) {
+                        hasNonTypeVar = true;
+                        break;
+                    }
+                }
+
+                if (effectiveDestSubtypes.length === 0 || hasNonTypeVar) {
                     canUseFastPath = false;
 
                     // We can avoid checking the source subtypes that have already been checked.
@@ -25859,9 +26526,9 @@ export function createTypeEvaluator(
                         // If we're populating an expected type, try not to leave
                         // any TypeVars unsolved. Assign the full type to the remaining
                         // dest TypeVars.
-                        remainingDestSubtypes.forEach((destSubtype) => {
+                        for (const destSubtype of remainingDestSubtypes) {
                             assignType(destSubtype, srcType, /* diag */ undefined, constraints, flags, recursionCount);
-                        });
+                        }
                     }
 
                     // If we've assigned all of the source subtypes but one or more dest
@@ -25899,9 +26566,9 @@ export function createTypeEvaluator(
 
         let isIncompatible = false;
 
-        sortedSrcTypes.forEach((subtype) => {
+        for (const subtype of sortedSrcTypes) {
             if (isIncompatible) {
-                return;
+                break;
             }
 
             if (!assignType(destType, subtype, /* diag */ undefined, constraints, flags, recursionCount)) {
@@ -25924,7 +26591,7 @@ export function createTypeEvaluator(
             } else {
                 matchedSomeSubtypes = true;
             }
-        }, /* sortSubtypes */ true);
+        }
 
         if (isIncompatible) {
             // If we're looking for type overlaps and at least one type was matched,
@@ -25956,14 +26623,14 @@ export function createTypeEvaluator(
         constraints: ConstraintTracker
     ) {
         const typeVars = getTypeVarArgsRecursive(destType);
-        typeVars.forEach((typeVar) => {
+        for (const typeVar of typeVars) {
             if (!TypeVarType.isBound(typeVar) && !constraints.getMainConstraintSet().getTypeVar(typeVar)) {
                 // Don't set ParamSpecs or TypeVarTuples.
                 if (!isParamSpec(srcType) && !isTypeVarTuple(srcType)) {
                     constraints.setBounds(typeVar, srcType);
                 }
             }
-        });
+        }
     }
 
     // Determines whether a type is "subsumed by" (i.e. is a proper subtype of) another type.
@@ -26004,12 +26671,20 @@ export function createTypeEvaluator(
         }
 
         // Shortcut the check if either type is a class whose hierarchy contains an unknown type.
-        if (isClass(destType) && destType.shared.mro.some((mro) => isAnyOrUnknown(mro))) {
-            return true;
+        if (isClass(destType)) {
+            for (const mroEntry of destType.shared.mro) {
+                if (isAnyOrUnknown(mroEntry)) {
+                    return true;
+                }
+            }
         }
 
-        if (isClass(srcType) && srcType.shared.mro.some((mro) => isAnyOrUnknown(mro))) {
-            return true;
+        if (isClass(srcType)) {
+            for (const mroEntry of srcType.shared.mro) {
+                if (isAnyOrUnknown(mroEntry)) {
+                    return true;
+                }
+            }
         }
 
         return (
@@ -26372,16 +27047,21 @@ export function createTypeEvaluator(
 
             // Determine which conditions on this type apply to this type variable.
             // There might be more than one of them.
-            const applicableConditions = (getTypeCondition(srcSubtype) ?? []).filter(
-                (constraint) => constraint.typeVar.priv.nameWithScope === destTypeVarName
-            );
+            const applicableConditions: TypeCondition[] = [];
+            const typeConditions = getTypeCondition(srcSubtype) ?? [];
+            for (const constraint of typeConditions) {
+                if (constraint.typeVar.priv.nameWithScope === destTypeVarName) {
+                    applicableConditions.push(constraint);
+                }
+            }
 
             // If there are no applicable conditions, it's not assignable.
             if (applicableConditions.length === 0) {
                 return true;
             }
 
-            return !applicableConditions.some((condition) => {
+            let hasMatchingCondition = false;
+            for (const condition of applicableConditions) {
                 if (condition.typeVar.priv.nameWithScope === TypeVarType.getNameWithScope(destType)) {
                     if (destType.shared.boundType) {
                         assert(
@@ -26389,38 +27069,46 @@ export function createTypeEvaluator(
                             'Expected constraint for bound TypeVar to have index of 0'
                         );
 
-                        return assignType(
-                            destType.shared.boundType,
-                            srcSubtype,
-                            /* diag */ undefined,
-                            /* constraints */ undefined,
-                            AssignTypeFlags.Default,
-                            recursionCount
-                        );
-                    }
-
-                    if (TypeVarType.hasConstraints(destType)) {
+                        if (
+                            assignType(
+                                destType.shared.boundType,
+                                srcSubtype,
+                                /* diag */ undefined,
+                                /* constraints */ undefined,
+                                AssignTypeFlags.Default,
+                                recursionCount
+                            )
+                        ) {
+                            hasMatchingCondition = true;
+                            break;
+                        }
+                    } else if (TypeVarType.hasConstraints(destType)) {
                         assert(
                             condition.constraintIndex < destType.shared.constraints.length,
                             'Constraint for constrained TypeVar is out of bounds'
                         );
 
-                        return assignType(
-                            destType.shared.constraints[condition.constraintIndex],
-                            srcSubtype,
-                            /* diag */ undefined,
-                            /* constraints */ undefined,
-                            AssignTypeFlags.Default,
-                            recursionCount
-                        );
+                        if (
+                            assignType(
+                                destType.shared.constraints[condition.constraintIndex],
+                                srcSubtype,
+                                /* diag */ undefined,
+                                /* constraints */ undefined,
+                                AssignTypeFlags.Default,
+                                recursionCount
+                            )
+                        ) {
+                            hasMatchingCondition = true;
+                            break;
+                        }
+                    } else {
+                        // This is a non-bound and non-constrained type variable with a matching condition.
+                        hasMatchingCondition = true;
+                        break;
                     }
-
-                    // This is a non-bound and non-constrained type variable with a matching condition.
-                    return true;
                 }
-
-                return false;
-            });
+            }
+            return !hasMatchingCondition;
         });
     }
 
@@ -26587,10 +27275,14 @@ export function createTypeEvaluator(
             return;
         }
 
-        let srcLastToPackIndex = srcDetails.params.findIndex((p, i) => {
+        let srcLastToPackIndex = -1;
+        for (let i = 0; i < srcDetails.params.length; i++) {
             assert(destDetails.argsIndex !== undefined);
-            return i >= destDetails.argsIndex && p.kind === ParamKind.Keyword;
-        });
+            if (i >= destDetails.argsIndex && srcDetails.params[i].kind === ParamKind.Keyword) {
+                srcLastToPackIndex = i;
+                break;
+            }
+        }
         if (srcLastToPackIndex < 0) {
             srcLastToPackIndex = srcDetails.params.length;
         }
@@ -26606,7 +27298,7 @@ export function createTypeEvaluator(
         const suffixLength = destFirstNonPositional - destDetails.argsIndex - 1;
         const srcPositionalsToPack = srcDetails.params.slice(destDetails.argsIndex, srcLastToPackIndex - suffixLength);
         const srcTupleTypes: TupleTypeArg[] = [];
-        srcPositionalsToPack.forEach((entry) => {
+        for (const entry of srcPositionalsToPack) {
             if (entry.param.category === ParamCategory.ArgsList) {
                 if (isUnpackedTypeVarTuple(entry.type)) {
                     srcTupleTypes.push({ type: entry.type, isUnbounded: false });
@@ -26618,7 +27310,7 @@ export function createTypeEvaluator(
             } else {
                 srcTupleTypes.push({ type: entry.type, isUnbounded: false, isOptional: !!entry.defaultType });
             }
-        });
+        }
 
         if (srcTupleTypes.length !== 1 || !isTypeVarTuple(srcTupleTypes[0].type)) {
             const srcPositionalsType = makeTupleObject(evaluatorInterface, srcTupleTypes, /* isUnpacked */ true);
@@ -26646,24 +27338,44 @@ export function createTypeEvaluator(
                 ),
             ];
 
-            const argsIndex = srcDetails.params.findIndex((param) => param.param.category === ParamCategory.ArgsList);
+            let argsIndex = -1;
+            for (let i = 0; i < srcDetails.params.length; i++) {
+                if (srcDetails.params[i].param.category === ParamCategory.ArgsList) {
+                    argsIndex = i;
+                    break;
+                }
+            }
             srcDetails.argsIndex = argsIndex >= 0 ? argsIndex : undefined;
 
-            const kwargsIndex = srcDetails.params.findIndex(
-                (param) => param.param.category === ParamCategory.KwargsDict
-            );
+            let kwargsIndex = -1;
+            for (let i = 0; i < srcDetails.params.length; i++) {
+                if (srcDetails.params[i].param.category === ParamCategory.KwargsDict) {
+                    kwargsIndex = i;
+                    break;
+                }
+            }
             srcDetails.kwargsIndex = kwargsIndex >= 0 ? kwargsIndex : undefined;
 
-            const firstKeywordOnlyIndex = srcDetails.params.findIndex((param) => param.kind === ParamKind.Keyword);
+            let firstKeywordOnlyIndex = -1;
+            for (let i = 0; i < srcDetails.params.length; i++) {
+                if (srcDetails.params[i].kind === ParamKind.Keyword) {
+                    firstKeywordOnlyIndex = i;
+                    break;
+                }
+            }
             srcDetails.firstKeywordOnlyIndex = firstKeywordOnlyIndex >= 0 ? firstKeywordOnlyIndex : undefined;
 
-            srcDetails.positionOnlyParamCount = Math.max(
-                0,
-                srcDetails.params.findIndex(
-                    (p) =>
-                        p.kind !== ParamKind.Positional || p.param.category !== ParamCategory.Simple || !!p.defaultType
-                )
-            );
+            let positionOnlyEndIndex = -1;
+            for (let i = 0; i < srcDetails.params.length; i++) {
+                const p = srcDetails.params[i];
+                if (
+                    p.kind !== ParamKind.Positional || p.param.category !== ParamCategory.Simple || !!p.defaultType
+                ) {
+                    positionOnlyEndIndex = i;
+                    break;
+                }
+            }
+            srcDetails.positionOnlyParamCount = Math.max(0, positionOnlyEndIndex);
         }
     }
 
@@ -26826,20 +27538,27 @@ export function createTypeEvaluator(
                 destParam.kind !== ParamKind.Positional &&
                 destParam.kind !== ParamKind.ExpandedArgs &&
                 srcParam.kind === ParamKind.Positional &&
-                srcParamDetails.kwargsIndex === undefined &&
-                !srcParamDetails.params.some(
-                    (p) =>
+                srcParamDetails.kwargsIndex === undefined
+            ) {
+                let hasSrcKeywordParam = false;
+                for (const p of srcParamDetails.params) {
+                    if (
                         p.kind === ParamKind.Keyword &&
                         p.param.category === ParamCategory.Simple &&
                         p.param.name === destParam.param.name
-                )
-            ) {
-                diag?.addMessage(
-                    LocAddendum.namedParamMissingInSource().format({
-                        name: destParam.param.name ?? '',
-                    })
-                );
-                canAssign = false;
+                    ) {
+                        hasSrcKeywordParam = true;
+                        break;
+                    }
+                }
+                if (!hasSrcKeywordParam) {
+                    diag?.addMessage(
+                        LocAddendum.namedParamMissingInSource().format({
+                            name: destParam.param.name ?? '',
+                        })
+                    );
+                    canAssign = false;
+                }
             }
         }
 
@@ -26931,9 +27650,12 @@ export function createTypeEvaluator(
                     continue;
                 }
 
-                const nonDefaultSrcParamCount = srcParamDetails.params.filter(
-                    (p) => !!p.param.name && !p.defaultType && p.param.category === ParamCategory.Simple
-                ).length;
+                let nonDefaultSrcParamCount = 0;
+                for (const p of srcParamDetails.params) {
+                    if (!!p.param.name && !p.defaultType && p.param.category === ParamCategory.Simple) {
+                        nonDefaultSrcParamCount++;
+                    }
+                }
 
                 diag?.createAddendum().addMessage(
                     LocAddendum.functionTooFewParams().format({
@@ -27083,7 +27805,8 @@ export function createTypeEvaluator(
             const destParamMap = new Map<string, VirtualParamDetails>();
 
             if (destParamDetails.firstKeywordOnlyIndex !== undefined) {
-                destParamDetails.params.forEach((param, index) => {
+                for (let index = 0; index < destParamDetails.params.length; index++) {
+                    const param = destParamDetails.params[index];
                     if (index >= destParamDetails.firstKeywordOnlyIndex!) {
                         if (
                             param.param.name &&
@@ -27094,7 +27817,7 @@ export function createTypeEvaluator(
                             destParamMap.set(param.param.name, param);
                         }
                     }
-                });
+                }
             }
 
             // If the dest has fewer positional arguments than the source, the remaining
@@ -27108,9 +27831,10 @@ export function createTypeEvaluator(
             }
 
             if (srcStartOfNamed >= 0) {
-                srcParamDetails.params.forEach((srcParamInfo, index) => {
+                for (let index = 0; index < srcParamDetails.params.length; index++) {
+                    const srcParamInfo = srcParamDetails.params[index];
                     if (index < srcStartOfNamed) {
-                        return;
+                        continue;
                     }
 
                     if (
@@ -27118,7 +27842,7 @@ export function createTypeEvaluator(
                         srcParamInfo.param.category !== ParamCategory.Simple ||
                         srcParamInfo.kind === ParamKind.Positional
                     ) {
-                        return;
+                        continue;
                     }
 
                     const destParamInfo = destParamMap.get(srcParamInfo.param.name);
@@ -27171,7 +27895,7 @@ export function createTypeEvaluator(
                                 }
                             }
                         }
-                        return;
+                        continue;
                     }
 
                     // If we're performing a partial overload match and both the source
@@ -27180,7 +27904,7 @@ export function createTypeEvaluator(
                     if (srcParamInfo.defaultType && destParamInfo.defaultType) {
                         if ((flags & AssignTypeFlags.PartialOverloadOverlap) !== 0) {
                             destParamMap.delete(srcParamInfo.param.name);
-                            return;
+                            continue;
                         }
                     }
 
@@ -27222,11 +27946,11 @@ export function createTypeEvaluator(
                     }
 
                     destParamMap.delete(srcParamInfo.param.name);
-                });
+                }
             }
 
             // See if there are any unmatched named parameters.
-            destParamMap.forEach((destParamInfo, paramName) => {
+            for (const [paramName, destParamInfo] of destParamMap) {
                 if (srcParamDetails.kwargsIndex !== undefined && destParamInfo.param.name) {
                     // Make sure the src kwargs type is compatible.
                     if (
@@ -27249,7 +27973,7 @@ export function createTypeEvaluator(
                     );
                     canAssign = false;
                 }
-            });
+            }
 
             // If both src and dest have a "**kwargs" parameter, make sure their types are compatible.
             if (srcParamDetails.kwargsIndex !== undefined && destParamDetails.kwargsIndex !== undefined) {
@@ -27315,24 +28039,26 @@ export function createTypeEvaluator(
             const effectiveDestParamSpec = isContra ? srcParamSpec : destParamSpec;
 
             if (effectiveDestParamSpec) {
-                const requiredMatchParamCount = effectiveDestType.shared.parameters.filter((p, i) => {
+                let requiredMatchParamCount = 0;
+                for (let i = 0; i < effectiveDestType.shared.parameters.length; i++) {
+                    const p = effectiveDestType.shared.parameters[i];
                     if (!p.name) {
-                        return false;
+                        continue;
                     }
-
                     const paramType = FunctionType.getParamType(effectiveDestType, i);
                     if (p.category === ParamCategory.Simple && isParamSpec(paramType)) {
-                        return false;
+                        continue;
                     }
-                    return true;
-                }).length;
+                    requiredMatchParamCount++;
+                }
                 let matchedParamCount = 0;
                 const remainingParams: FunctionParam[] = [];
 
                 // If there are parameters in the source that are not matched
                 // to parameters in the dest, assume these are concatenated on
                 // to the ParamSpec.
-                effectiveSrcType.shared.parameters.forEach((p, index) => {
+                for (let index = 0; index < effectiveSrcType.shared.parameters.length; index++) {
+                    const p = effectiveSrcType.shared.parameters[index];
                     if (matchedParamCount < requiredMatchParamCount) {
                         if (p.name) {
                             matchedParamCount++;
@@ -27343,14 +28069,14 @@ export function createTypeEvaluator(
                         // that it is not exhausted and can provide additional
                         // parameters.
                         if (p.category !== ParamCategory.ArgsList) {
-                            return;
+                            continue;
                         }
                     }
 
                     if (isPositionOnlySeparator(p) && remainingParams.length === 0) {
                         // Don't bother pushing a position-only separator if it
                         // is the first remaining param.
-                        return;
+                        continue;
                     }
 
                     remainingParams.push(
@@ -27363,7 +28089,7 @@ export function createTypeEvaluator(
                             p.defaultExpr
                         )
                     );
-                });
+                }
 
                 // If there are remaining parameters and the source and dest do not contain
                 // the same ParamSpec, synthesize a function for the remaining parameters.
@@ -27391,9 +28117,9 @@ export function createTypeEvaluator(
                         remainingFunction.priv.constructorTypeVarScopeId =
                             effectiveSrcType.priv.constructorTypeVarScopeId;
                         remainingFunction.shared.methodClass = effectiveSrcType.shared.methodClass;
-                        remainingParams.forEach((param) => {
+                        for (const param of remainingParams) {
                             FunctionType.addParam(remainingFunction, param);
-                        });
+                        }
                         if (effectiveSrcParamSpec) {
                             FunctionType.addParamSpecVariadics(
                                 remainingFunction,
@@ -27616,16 +28342,21 @@ export function createTypeEvaluator(
 
             // For an overload overriding a base method, at least one overload
             // or the implementation must be compatible with the base method.
-            if (
-                overloadsAndImpl.some((overrideOverload) => {
-                    return validateOverrideMethodInternal(
+            let hasCompatibleOverload = false;
+            for (const overrideOverload of overloadsAndImpl) {
+                if (
+                    validateOverrideMethodInternal(
                         baseMethod,
                         overrideOverload,
                         /* diag */ undefined,
                         enforceParamNames
-                    );
-                })
-            ) {
+                    )
+                ) {
+                    hasCompatibleOverload = true;
+                    break;
+                }
+            }
+            if (hasCompatibleOverload) {
                 return true;
             }
 
@@ -27636,19 +28367,26 @@ export function createTypeEvaluator(
         // For a non-overloaded method overriding an overloaded method, the
         // override must match all of the overloads.
         if (isFunction(overrideMethod)) {
-            return OverloadedType.getOverloads(baseMethod).every((overload) => {
+            let allOverloadsMatch = true;
+            for (const overload of OverloadedType.getOverloads(baseMethod)) {
                 // If the override isn't applicable for this base class, skip the check.
                 if (baseClass && !isOverrideMethodApplicable(overload, baseClass)) {
-                    return true;
+                    continue;
                 }
 
-                return validateOverrideMethodInternal(
-                    overload,
-                    overrideMethod,
-                    diag?.createAddendum(),
-                    enforceParamNames
-                );
-            });
+                if (
+                    !validateOverrideMethodInternal(
+                        overload,
+                        overrideMethod,
+                        diag?.createAddendum(),
+                        enforceParamNames
+                    )
+                ) {
+                    allOverloadsMatch = false;
+                    break;
+                }
+            }
+            return allOverloadsMatch;
         }
 
         // For an overloaded method overriding an overloaded method, the overrides
@@ -27661,10 +28399,13 @@ export function createTypeEvaluator(
         for (const overrideOverload of OverloadedType.getOverloads(overrideMethod)) {
             let possibleMatchIndex: number | undefined;
 
-            let matchIndex = baseOverloads.findIndex((baseOverload, index) => {
+            let matchIndex = -1;
+            for (let index = 0; index < baseOverloads.length; index++) {
+                const baseOverload = baseOverloads[index];
+
                 // If the override isn't applicable for this base class, skip the check.
                 if (baseClass && !isOverrideMethodApplicable(baseOverload, baseClass)) {
-                    return false;
+                    continue;
                 }
 
                 const isCompatible = validateOverrideMethodInternal(
@@ -27679,11 +28420,14 @@ export function createTypeEvaluator(
                 // we found at least one match.
                 if (isCompatible && index <= previousMatchIndex && possibleMatchIndex === undefined) {
                     possibleMatchIndex = index;
-                    return false;
+                    continue;
                 }
 
-                return isCompatible;
-            });
+                if (isCompatible) {
+                    matchIndex = index;
+                    break;
+                }
+            }
 
             if (matchIndex < 0 && possibleMatchIndex !== undefined) {
                 matchIndex = possibleMatchIndex;
@@ -27705,12 +28449,16 @@ export function createTypeEvaluator(
             const unmatchedOverloads = baseOverloads.slice(previousMatchIndex + 1);
 
             // See if all of the remaining overrides are nonapplicable.
-            if (
-                !baseClass ||
-                unmatchedOverloads.some((overload) => {
-                    return isOverrideMethodApplicable(overload, baseClass);
-                })
-            ) {
+            let hasApplicableOverload = false;
+            if (baseClass) {
+                for (const overload of unmatchedOverloads) {
+                    if (isOverrideMethodApplicable(overload, baseClass)) {
+                        hasApplicableOverload = true;
+                        break;
+                    }
+                }
+            }
+            if (!baseClass || hasApplicableOverload) {
                 // We didn't find matches for all of the base overloads.
                 diag.addMessage(LocAddendum.overrideOverloadNoMatch());
                 return false;
@@ -28020,15 +28768,27 @@ export function createTypeEvaluator(
             }
 
             // Now check any keyword-only parameters.
-            const baseKwOnlyParams = baseParamDetails.params.filter(
-                (paramInfo) => paramInfo.kind === ParamKind.Keyword && paramInfo.param.category === ParamCategory.Simple
-            );
-            const overrideKwOnlyParams = overrideParamDetails.params.filter(
-                (paramInfo) => paramInfo.kind === ParamKind.Keyword && paramInfo.param.category === ParamCategory.Simple
-            );
+            const baseKwOnlyParams: typeof baseParamDetails.params = [];
+            for (const paramInfo of baseParamDetails.params) {
+                if (paramInfo.kind === ParamKind.Keyword && paramInfo.param.category === ParamCategory.Simple) {
+                    baseKwOnlyParams.push(paramInfo);
+                }
+            }
+            const overrideKwOnlyParams: typeof overrideParamDetails.params = [];
+            for (const paramInfo of overrideParamDetails.params) {
+                if (paramInfo.kind === ParamKind.Keyword && paramInfo.param.category === ParamCategory.Simple) {
+                    overrideKwOnlyParams.push(paramInfo);
+                }
+            }
 
-            baseKwOnlyParams.forEach((paramInfo) => {
-                const overrideParamInfo = overrideKwOnlyParams.find((pi) => paramInfo.param.name === pi.param.name);
+            for (const paramInfo of baseKwOnlyParams) {
+                let overrideParamInfo: (typeof overrideKwOnlyParams)[number] | undefined;
+                for (const pi of overrideKwOnlyParams) {
+                    if (paramInfo.param.name === pi.param.name) {
+                        overrideParamInfo = pi;
+                        break;
+                    }
+                }
 
                 if (!overrideParamInfo && overrideParamDetails.kwargsIndex === undefined) {
                     diag?.addMessage(
@@ -28073,12 +28833,18 @@ export function createTypeEvaluator(
                         }
                     }
                 }
-            });
+            }
 
             // Verify that any keyword-only parameters added by the overload are compatible
             // with the **kwargs in the base.
-            overrideKwOnlyParams.forEach((paramInfo) => {
-                const baseParamInfo = baseKwOnlyParams.find((pi) => paramInfo.param.name === pi.param.name);
+            for (const paramInfo of overrideKwOnlyParams) {
+                let baseParamInfo: (typeof baseKwOnlyParams)[number] | undefined;
+                for (const pi of baseKwOnlyParams) {
+                    if (paramInfo.param.name === pi.param.name) {
+                        baseParamInfo = pi;
+                        break;
+                    }
+                }
 
                 if (!baseParamInfo) {
                     if (baseParamDetails.kwargsIndex === undefined) {
@@ -28114,7 +28880,7 @@ export function createTypeEvaluator(
                         }
                     }
                 }
-            });
+            }
 
             // Verify that if the base method has a **kwargs parameter, the override does too.
             if (baseParamDetails.kwargsIndex !== undefined && overrideParamDetails.kwargsIndex === undefined) {
@@ -28259,11 +29025,21 @@ export function createTypeEvaluator(
 
         if (isTypeVar(srcType) && TypeVarType.hasConstraints(srcType)) {
             // Make sure all the source constraint types map to constraint types in the dest.
-            if (
-                srcType.shared.constraints.every((sourceConstraint) => {
-                    return constraints.some((destConstraint) => assignType(destConstraint, sourceConstraint));
-                })
-            ) {
+            let allConstraintsMatch = true;
+            for (const sourceConstraint of srcType.shared.constraints) {
+                let hasMatchingDest = false;
+                for (const destConstraint of constraints) {
+                    if (assignType(destConstraint, sourceConstraint)) {
+                        hasMatchingDest = true;
+                        break;
+                    }
+                }
+                if (!hasMatchingDest) {
+                    allConstraintsMatch = false;
+                    break;
+                }
+            }
+            if (allConstraintsMatch) {
                 return srcType;
             }
         } else {
@@ -28301,12 +29077,12 @@ export function createTypeEvaluator(
     function getAbstractSymbols(classType: ClassType): AbstractSymbol[] {
         const symbolTable = new Map<string, AbstractSymbol>();
 
-        ClassType.getReverseMro(classType).forEach((mroClass) => {
+        for (const mroClass of ClassType.getReverseMro(classType)) {
             if (isInstantiableClass(mroClass)) {
                 // See if this class is introducing a new abstract symbol that has not been
                 // introduced previously or if it is overriding an abstract symbol with
                 // a non-abstract one.
-                ClassType.getSymbolTable(mroClass).forEach((symbol, symbolName) => {
+                for (const [symbolName, symbol] of ClassType.getSymbolTable(mroClass)) {
                     const abstractSymbolInfo = getAbstractSymbolInfo(mroClass, symbolName);
 
                     if (abstractSymbolInfo) {
@@ -28314,15 +29090,15 @@ export function createTypeEvaluator(
                     } else {
                         symbolTable.delete(symbolName);
                     }
-                });
+                }
             }
-        });
+        }
 
         // Create a final list of symbols that are abstract.
         const symbolList: AbstractSymbol[] = [];
-        symbolTable.forEach((method) => {
+        for (const [, method] of symbolTable) {
             symbolList.push(method);
-        });
+        }
 
         return symbolList;
     }
@@ -28533,7 +29309,12 @@ export function createTypeEvaluator(
     }
 
     function isFinalVariable(symbol: Symbol): boolean {
-        return symbol.getDeclarations().some((decl) => isFinalVariableDeclaration(decl));
+        for (const decl of symbol.getDeclarations()) {
+            if (isFinalVariableDeclaration(decl)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     function isFinalVariableDeclaration(decl: Declaration): boolean {
@@ -28797,9 +29578,9 @@ export function createTypeEvaluator(
             }
 
             const fileInfo = AnalyzerNodeInfo.getFileInfo(node);
-            parseResults.diagnostics.forEach((diag) => {
+            for (const diag of parseResults.diagnostics) {
                 fileInfo.diagnosticSink.addDiagnosticWithTextRange('error', diag.message, node);
-            });
+            }
 
             parseResults.parseTree.parent = node;
 
@@ -28966,4 +29747,12 @@ export function createTypeEvaluator(
     const codeFlowEngine = getCodeFlowEngine(evaluatorInterface, speculativeTypeTracker);
 
     return evaluatorInterface;
+}
+
+function _joinStringNodeValues(strings: readonly { d: { value: string } }[]): string {
+    let result = '';
+    for (const s of strings) {
+        result += s.d.value;
+    }
+    return result;
 }

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -320,6 +320,7 @@ import {
     getTypeVarScopeIds,
     getUnknownForTypeVar,
     getUnknownTypeForCallable,
+    hasTypeVarScopeId,
     InferenceContext,
     invertVariance,
     isDescriptorInstance,
@@ -9827,7 +9828,7 @@ export function createTypeEvaluator(
             );
         }
 
-        let expandedArgTypes: (Type | undefined)[][] | undefined = [argList.map((arg) => undefined)];
+        let expandedArgTypes: (Type | undefined)[][] | undefined = [new Array<Type | undefined>(argList.length)];
 
         while (true) {
             const callResult = validateOverloadsWithExpandedTypes(
@@ -10986,7 +10987,7 @@ export function createTypeEvaluator(
                 // spec? We need to handle these two cases differently.
                 const paramSpecScopeId = varArgListParamType.priv.scopeId;
 
-                if (getTypeVarScopeIds(overload).some((id) => id === paramSpecScopeId)) {
+                if (hasTypeVarScopeId(overload, paramSpecScopeId)) {
                     paramSpecArgList = [];
                     paramSpecTarget = TypeVarType.cloneForParamSpecAccess(varArgListParamType, /* access */ undefined);
                 } else {
@@ -10996,7 +10997,7 @@ export function createTypeEvaluator(
                 }
             }
         } else if (paramSpec) {
-            if (getTypeVarScopeIds(overload).some((id) => id === paramSpec.priv.scopeId)) {
+            if (hasTypeVarScopeId(overload, paramSpec.priv.scopeId)) {
                 hasParamSpecArgsKwargs = true;
                 paramSpecArgList = [];
                 paramSpecTarget = paramSpec;
@@ -11873,10 +11874,14 @@ export function createTypeEvaluator(
                 !isTypeVarTupleFullyMatched
             ) {
                 const paramType = paramDetails.params[paramDetails.argsIndex].type;
-                const variadicArgs = validateArgTypeParams.filter((argParam) => argParam.mapsToVarArgList);
 
                 if (isUnpacked(paramType) && (!isTypeVarTuple(paramType) || !paramType.priv.isInUnion)) {
-                    const tupleTypeArgs: TupleTypeArg[] = variadicArgs.map((argParam) => {
+                    const tupleTypeArgs: TupleTypeArg[] = [];
+                    for (let vai = 0; vai < validateArgTypeParams.length; vai++) {
+                        const argParam = validateArgTypeParams[vai];
+                        if (!argParam.mapsToVarArgList) {
+                            continue;
+                        }
                         const argType = getTypeOfArg(argParam.argument, /* inferenceContext */ undefined).type;
 
                         const containsTypeVarTuple =
@@ -11902,11 +11907,11 @@ export function createTypeEvaluator(
                             reportedArgError = true;
                         }
 
-                        return {
+                        tupleTypeArgs.push({
                             type: argType,
                             isUnbounded: argParam.argument.argCategory === ArgCategory.UnpackedList,
-                        };
-                    });
+                        });
+                    }
 
                     let specializedTuple: Type | undefined;
                     if (tupleTypeArgs.length === 1 && !tupleTypeArgs[0].isUnbounded) {
@@ -11937,10 +11942,14 @@ export function createTypeEvaluator(
                         mapsToVarArgList: true,
                     };
 
-                    validateArgTypeParams = [
-                        ...validateArgTypeParams.filter((argParam) => !argParam.mapsToVarArgList),
-                        combinedArg,
-                    ];
+                    const nonVariadicParams: ValidateArgTypeParams[] = [];
+                    for (let vpi = 0; vpi < validateArgTypeParams.length; vpi++) {
+                        if (!validateArgTypeParams[vpi].mapsToVarArgList) {
+                            nonVariadicParams.push(validateArgTypeParams[vpi]);
+                        }
+                    }
+                    nonVariadicParams.push(combinedArg);
+                    validateArgTypeParams = nonVariadicParams;
                 }
             }
         }
@@ -12245,12 +12254,7 @@ export function createTypeEvaluator(
                             continue;
                         }
 
-                        const argResult = validateArgType(
-                            argParam,
-                            constraints,
-                            typeResultForValidation,
-                            opts
-                        );
+                        const argResult = validateArgType(argParam, constraints, typeResultForValidation, opts);
 
                         if (argResult.isTypeIncomplete) {
                             isTypeIncomplete = true;
@@ -12279,12 +12283,7 @@ export function createTypeEvaluator(
 
         for (let argParamIndex = 0; argParamIndex < argParams.length; argParamIndex++) {
             const argParam = argParams[argParamIndex];
-            const argResult = validateArgType(
-                argParam,
-                constraints,
-                typeResultForValidation,
-                secondPassOptions
-            );
+            const argResult = validateArgType(argParam, constraints, typeResultForValidation, secondPassOptions);
 
             argResults.push(argResult);
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -4290,7 +4290,11 @@ export function createTypeEvaluator(
 
                     // Expand the list of constrained subtypes, filtering out any that are
                     // disallowed by the conditionFilter.
-                    for (let constraintIndex = 0; constraintIndex < subtype.shared.constraints.length; constraintIndex++) {
+                    for (
+                        let constraintIndex = 0;
+                        constraintIndex < subtype.shared.constraints.length;
+                        constraintIndex++
+                    ) {
                         let constraintType = subtype.shared.constraints[constraintIndex];
                         if (conditionFilter) {
                             const typeVarName = TypeVarType.getNameWithScope(subtype);
@@ -4816,9 +4820,9 @@ export function createTypeEvaluator(
             }
 
             case ParseNodeType.Tuple: {
-                node.d.items.forEach((expr) => {
+                for (const expr of node.d.items) {
                     verifyDeleteExpression(expr);
-                });
+                }
                 break;
             }
 
@@ -9722,12 +9726,7 @@ export function createTypeEvaluator(
         for (const match of matches) {
             returnTypes.push(match.returnType);
         }
-        if (
-            areTypesSame(
-                returnTypes,
-                { treatAnySameAsUnknown: true }
-            )
-        ) {
+        if (areTypesSame(returnTypes, { treatAnySameAsUnknown: true })) {
             return [matches[0]];
         }
 
@@ -9992,9 +9991,11 @@ export function createTypeEvaluator(
                             types.push(arg.typeResult.type);
                         } else if (arg.valueExpression) {
                             const valueExpressionNode = arg.valueExpression;
-                            types.push(useSpeculativeMode(valueExpressionNode, () => {
-                                return getTypeOfExpression(valueExpressionNode).type;
-                            }));
+                            types.push(
+                                useSpeculativeMode(valueExpressionNode, () => {
+                                    return getTypeOfExpression(valueExpressionNode).type;
+                                })
+                            );
                         } else {
                             types.push(AnyType.create());
                         }
@@ -14175,7 +14176,7 @@ export function createTypeEvaluator(
                 if (callResult.argumentErrors) {
                     magicMethodSupported = false;
                 } else if (callResult.overloadsUsedForCall) {
-                    callResult.overloadsUsedForCall.forEach((overload) => {
+                    for (const overload of callResult.overloadsUsedForCall) {
                         overloadsUsedForCall.push(overload);
 
                         // If one of the overloads is deprecated, note the message.
@@ -14186,7 +14187,7 @@ export function createTypeEvaluator(
                                 methodName,
                             };
                         }
-                    });
+                    }
                 }
 
                 if (callResult.isTypeIncomplete) {
@@ -14499,11 +14500,15 @@ export function createTypeEvaluator(
         // Strip any literal values and TypeForm types.
         const keyTypes: Type[] = [];
         for (const t of keyTypeResults) {
-            keyTypes.push(stripTypeForm(convertSpecialFormToRuntimeValue(stripLiteralValue(t.type), flags, !hasExpectedType)));
+            keyTypes.push(
+                stripTypeForm(convertSpecialFormToRuntimeValue(stripLiteralValue(t.type), flags, !hasExpectedType))
+            );
         }
         const valueTypes: Type[] = [];
         for (const t of valueTypeResults) {
-            valueTypes.push(stripTypeForm(convertSpecialFormToRuntimeValue(stripLiteralValue(t.type), flags, !hasExpectedType)));
+            valueTypes.push(
+                stripTypeForm(convertSpecialFormToRuntimeValue(stripLiteralValue(t.type), flags, !hasExpectedType))
+            );
         }
 
         if (keyTypes.length > 0) {
@@ -16840,7 +16845,8 @@ export function createTypeEvaluator(
             if (!typeArgs) {
                 tupleTypeArgTypes.push({ type: UnknownType.create(), isUnbounded: true });
             } else {
-                typeArgs.forEach((typeArg, index) => {
+                for (let index = 0; index < typeArgs.length; index++) {
+                    const typeArg = typeArgs[index];
                     if (index === 1 && isEllipsisType(typeArgTypes[index])) {
                         if (tupleTypeArgTypes.length === 1 && !tupleTypeArgTypes[0].isUnbounded) {
                             tupleTypeArgTypes[0] = { type: tupleTypeArgTypes[0].type, isUnbounded: true };
@@ -16850,7 +16856,7 @@ export function createTypeEvaluator(
                     } else {
                         tupleTypeArgTypes.push({ type: typeArgTypes[index], isUnbounded: false });
                     }
-                });
+                }
             }
 
             returnType = specializeTupleClass(classType, tupleTypeArgTypes, typeArgs !== undefined);
@@ -17889,7 +17895,7 @@ export function createTypeEvaluator(
 
             // Keep a list of unique type parameters that are used in the
             // base class arguments.
-            let typeParams: TypeVarType[] = [];
+            const typeParams: TypeVarType[] = [];
 
             if (node.d.typeParams) {
                 const rawTypeParams = evaluateTypeParamList(node.d.typeParams);
@@ -18488,12 +18494,14 @@ export function createTypeEvaluator(
                                         typeVar.shared.isSynthesized = true;
                                         typeVar.priv.scopeId = ParseTreeUtils.getScopeIdForNode(initDeclNode);
                                         typeVar.shared.boundType = UnknownType.create();
-                                        typeParamsResult.push(TypeVarType.cloneForScopeId(
-                                            typeVar,
-                                            ParseTreeUtils.getScopeIdForNode(node),
-                                            node.d.name.d.value,
-                                            TypeVarScopeType.Class
-                                        ));
+                                        typeParamsResult.push(
+                                            TypeVarType.cloneForScopeId(
+                                                typeVar,
+                                                ParseTreeUtils.getScopeIdForNode(node),
+                                                node.d.name.d.value,
+                                                TypeVarScopeType.Class
+                                            )
+                                        );
                                     }
                                     classType.shared.typeParams = typeParamsResult;
                                 }
@@ -18514,10 +18522,7 @@ export function createTypeEvaluator(
                         break;
                     }
                 }
-                if (
-                    hasCustomClassGetItem ||
-                    classType.shared.fields.has('__class_getitem__')
-                ) {
+                if (hasCustomClassGetItem || classType.shared.fields.has('__class_getitem__')) {
                     classType.shared.flags |= ClassTypeFlags.HasCustomClassGetItem;
                 }
             }
@@ -19651,10 +19656,7 @@ export function createTypeEvaluator(
                                 break;
                             }
                         }
-                        if (
-                            isPrivateName(param.d.name.d.value) &&
-                            !hasSlashParam
-                        ) {
+                        if (isPrivateName(param.d.name.d.value) && !hasSlashParam) {
                             isImplicitPositionOnlyParam = true;
 
                             // If the parameter name indicates an implicit position-only parameter
@@ -19666,10 +19668,7 @@ export function createTypeEvaluator(
                                     break;
                                 }
                             }
-                            if (
-                                !paramsArePositionOnly &&
-                                allParamsSimple
-                            ) {
+                            if (!paramsArePositionOnly && allParamsSimple) {
                                 addDiagnostic(
                                     DiagnosticRule.reportGeneralTypeIssues,
                                     LocMessage.positionOnlyAfterNon(),
@@ -22730,10 +22729,10 @@ export function createTypeEvaluator(
                             );
                             if (lookupResults) {
                                 for (const decl of lookupResults.symbol.getDeclarations()) {
-                                if (decl.type === DeclarationType.Variable) {
-                                    return decl;
+                                    if (decl.type === DeclarationType.Variable) {
+                                        return decl;
+                                    }
                                 }
-                            }
                             }
                         }
                     }
@@ -25266,84 +25265,84 @@ export function createTypeEvaluator(
         if (srcTypeArgs) {
             for (let srcArgIndex = 0; srcArgIndex < srcTypeArgs.length; srcArgIndex++) {
                 const srcTypeArg = srcTypeArgs[srcArgIndex];
-            // In most cases, the number of type args should match the number
-            // of type arguments, but there are a few special cases where this
-            // isn't true (e.g. assigning a Tuple[X, Y, Z] to a tuple[W]).
-            const destArgIndex = srcArgIndex >= destTypeArgs.length ? destTypeArgs.length - 1 : srcArgIndex;
-            const destTypeArg = destArgIndex >= 0 ? destTypeArgs[destArgIndex] : UnknownType.create();
-            const destTypeParam = destArgIndex < destTypeParams.length ? destTypeParams[destArgIndex] : undefined;
-            const assignmentDiag = new DiagnosticAddendum();
-            const variance =
-                assumedVariance ?? (destTypeParam ? TypeVarType.getVariance(destTypeParam) : Variance.Covariant);
-            let effectiveFlags: AssignTypeFlags;
-            let errorSource: () => ParameterizedString<{ name: string; sourceType: string; destType: string }>;
-            let includeDiagAddendum = true;
+                // In most cases, the number of type args should match the number
+                // of type arguments, but there are a few special cases where this
+                // isn't true (e.g. assigning a Tuple[X, Y, Z] to a tuple[W]).
+                const destArgIndex = srcArgIndex >= destTypeArgs.length ? destTypeArgs.length - 1 : srcArgIndex;
+                const destTypeArg = destArgIndex >= 0 ? destTypeArgs[destArgIndex] : UnknownType.create();
+                const destTypeParam = destArgIndex < destTypeParams.length ? destTypeParams[destArgIndex] : undefined;
+                const assignmentDiag = new DiagnosticAddendum();
+                const variance =
+                    assumedVariance ?? (destTypeParam ? TypeVarType.getVariance(destTypeParam) : Variance.Covariant);
+                let effectiveFlags: AssignTypeFlags;
+                let errorSource: () => ParameterizedString<{ name: string; sourceType: string; destType: string }>;
+                let includeDiagAddendum = true;
 
-            if (variance === Variance.Covariant) {
-                effectiveFlags = flags | AssignTypeFlags.RetainLiteralsForTypeVar;
-                errorSource = LocAddendum.typeVarIsCovariant;
-            } else if (variance === Variance.Contravariant) {
-                effectiveFlags = flags | AssignTypeFlags.Contravariant | AssignTypeFlags.RetainLiteralsForTypeVar;
-                errorSource = LocAddendum.typeVarIsContravariant;
-            } else {
-                effectiveFlags = flags | AssignTypeFlags.Invariant | AssignTypeFlags.RetainLiteralsForTypeVar;
-                errorSource = LocAddendum.typeVarIsInvariant;
+                if (variance === Variance.Covariant) {
+                    effectiveFlags = flags | AssignTypeFlags.RetainLiteralsForTypeVar;
+                    errorSource = LocAddendum.typeVarIsCovariant;
+                } else if (variance === Variance.Contravariant) {
+                    effectiveFlags = flags | AssignTypeFlags.Contravariant | AssignTypeFlags.RetainLiteralsForTypeVar;
+                    errorSource = LocAddendum.typeVarIsContravariant;
+                } else {
+                    effectiveFlags = flags | AssignTypeFlags.Invariant | AssignTypeFlags.RetainLiteralsForTypeVar;
+                    errorSource = LocAddendum.typeVarIsInvariant;
 
-                // Omit the diagnostic addendum for the invariant case because it's obvious
-                // why two types are not the same.
-                includeDiagAddendum = false;
-            }
-
-            // Special-case TypeForm to retain literals when solving TypeVars.
-            if (ClassType.isBuiltIn(destType, 'TypeForm')) {
-                effectiveFlags |= AssignTypeFlags.RetainLiteralsForTypeVar;
-            }
-
-            if (
-                !assignType(
-                    variance === Variance.Contravariant ? srcTypeArg : destTypeArg,
-                    variance === Variance.Contravariant ? destTypeArg : srcTypeArg,
-                    assignmentDiag,
-                    constraints,
-                    effectiveFlags,
-                    recursionCount
-                )
-            ) {
-                // Don't report errors with type variables in "pseudo-random"
-                // classes since these type variables are not real.
-                if (!ClassType.isPseudoGenericClass(destType)) {
-                    if (diag) {
-                        if (destTypeParam) {
-                            const childDiag = diag.createAddendum();
-
-                            childDiag.addMessage(
-                                errorSource().format({
-                                    name: TypeVarType.getReadableName(destTypeParam),
-                                    ...printSrcDestTypes(srcTypeArg, destTypeArg),
-                                })
-                            );
-
-                            if (includeDiagAddendum) {
-                                childDiag.addAddendum(assignmentDiag);
-                            }
-
-                            if (isCompatible && ClassType.isSameGenericClass(destType, srcType)) {
-                                // Add additional notes to help the user if this is a common type mismatch.
-                                if (ClassType.isBuiltIn(destType, 'dict') && srcArgIndex === 1) {
-                                    childDiag.addMessage(LocAddendum.invariantSuggestionDict());
-                                } else if (ClassType.isBuiltIn(destType, 'list')) {
-                                    childDiag.addMessage(LocAddendum.invariantSuggestionList());
-                                } else if (ClassType.isBuiltIn(destType, 'set')) {
-                                    childDiag.addMessage(LocAddendum.invariantSuggestionSet());
-                                }
-                            }
-                        } else {
-                            diag.addAddendum(assignmentDiag);
-                        }
-                    }
-                    isCompatible = false;
+                    // Omit the diagnostic addendum for the invariant case because it's obvious
+                    // why two types are not the same.
+                    includeDiagAddendum = false;
                 }
-            }
+
+                // Special-case TypeForm to retain literals when solving TypeVars.
+                if (ClassType.isBuiltIn(destType, 'TypeForm')) {
+                    effectiveFlags |= AssignTypeFlags.RetainLiteralsForTypeVar;
+                }
+
+                if (
+                    !assignType(
+                        variance === Variance.Contravariant ? srcTypeArg : destTypeArg,
+                        variance === Variance.Contravariant ? destTypeArg : srcTypeArg,
+                        assignmentDiag,
+                        constraints,
+                        effectiveFlags,
+                        recursionCount
+                    )
+                ) {
+                    // Don't report errors with type variables in "pseudo-random"
+                    // classes since these type variables are not real.
+                    if (!ClassType.isPseudoGenericClass(destType)) {
+                        if (diag) {
+                            if (destTypeParam) {
+                                const childDiag = diag.createAddendum();
+
+                                childDiag.addMessage(
+                                    errorSource().format({
+                                        name: TypeVarType.getReadableName(destTypeParam),
+                                        ...printSrcDestTypes(srcTypeArg, destTypeArg),
+                                    })
+                                );
+
+                                if (includeDiagAddendum) {
+                                    childDiag.addAddendum(assignmentDiag);
+                                }
+
+                                if (isCompatible && ClassType.isSameGenericClass(destType, srcType)) {
+                                    // Add additional notes to help the user if this is a common type mismatch.
+                                    if (ClassType.isBuiltIn(destType, 'dict') && srcArgIndex === 1) {
+                                        childDiag.addMessage(LocAddendum.invariantSuggestionDict());
+                                    } else if (ClassType.isBuiltIn(destType, 'list')) {
+                                        childDiag.addMessage(LocAddendum.invariantSuggestionList());
+                                    } else if (ClassType.isBuiltIn(destType, 'set')) {
+                                        childDiag.addMessage(LocAddendum.invariantSuggestionSet());
+                                    }
+                                }
+                            } else {
+                                diag.addAddendum(assignmentDiag);
+                            }
+                        }
+                        isCompatible = false;
+                    }
+                }
             }
         }
 
@@ -25513,10 +25512,7 @@ export function createTypeEvaluator(
             // If the source is a conditional type associated with a bound TypeVar
             // and the bound TypeVar matches the condition, the types are compatible.
             const destTypeVar = destType;
-            if (
-                TypeBase.isInstantiable(destType) === TypeBase.isInstantiable(srcType) &&
-                srcType.props?.condition
-            ) {
+            if (TypeBase.isInstantiable(destType) === TypeBase.isInstantiable(srcType) && srcType.props?.condition) {
                 let hasMatchingCondition = false;
                 for (const cond of srcType.props.condition) {
                     if (
@@ -27368,9 +27364,7 @@ export function createTypeEvaluator(
             let positionOnlyEndIndex = -1;
             for (let i = 0; i < srcDetails.params.length; i++) {
                 const p = srcDetails.params[i];
-                if (
-                    p.kind !== ParamKind.Positional || p.param.category !== ParamCategory.Simple || !!p.defaultType
-                ) {
+                if (p.kind !== ParamKind.Positional || p.param.category !== ParamCategory.Simple || !!p.defaultType) {
                     positionOnlyEndIndex = i;
                     break;
                 }
@@ -28375,12 +28369,7 @@ export function createTypeEvaluator(
                 }
 
                 if (
-                    !validateOverrideMethodInternal(
-                        overload,
-                        overrideMethod,
-                        diag?.createAddendum(),
-                        enforceParamNames
-                    )
+                    !validateOverrideMethodInternal(overload, overrideMethod, diag?.createAddendum(), enforceParamNames)
                 ) {
                     allOverloadsMatch = false;
                     break;

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -8723,7 +8723,8 @@ export function createTypeEvaluator(
                 AnalyzerNodeInfo.getFileInfo(node).isTypingStubFile;
 
             if (!isCyclicalTypeVarCall) {
-                argList.forEach((arg) => {
+                for (let ali = 0; ali < argList.length; ali++) {
+                    const arg = argList[ali];
                     if (
                         arg.valueExpression &&
                         arg.valueExpression.nodeType !== ParseNodeType.StringList &&
@@ -8731,7 +8732,7 @@ export function createTypeEvaluator(
                     ) {
                         getTypeOfExpression(arg.valueExpression);
                     }
-                });
+                }
             }
         }
 
@@ -9486,7 +9487,8 @@ export function createTypeEvaluator(
                     let dedupedMatchResults: Type[] = [];
                     let dedupedResultsIncludeAny = false;
 
-                    possibleMatchResults.forEach((result) => {
+                    for (let pri = 0; pri < possibleMatchResults.length; pri++) {
+                        const result = possibleMatchResults[pri];
                         let isSubtypeSubsumed = false;
 
                         for (let dedupedIndex = 0; dedupedIndex < dedupedMatchResults.length; dedupedIndex++) {
@@ -9515,7 +9517,7 @@ export function createTypeEvaluator(
                         if (!isSubtypeSubsumed) {
                             dedupedMatchResults.push(result.returnType);
                         }
-                    });
+                    }
 
                     dedupedMatchResults = dedupedMatchResults.filter((t) => !isNever(t));
                     const combinedTypes = combineTypes(dedupedMatchResults);
@@ -9651,13 +9653,14 @@ export function createTypeEvaluator(
         typeResult: TypeResult<OverloadedType>,
         argList: Arg[]
     ): FunctionType | undefined {
-        let overloadIndex = 0;
         const matches: MatchArgsToParamsResult[] = [];
         const speculativeNode = getSpeculativeNodeForCall(errorNode);
 
         useSignatureTracker(errorNode, () => {
             // Create a list of potential overload matches based on arguments.
-            OverloadedType.getOverloads(typeResult.type).forEach((overload) => {
+            const overloads = OverloadedType.getOverloads(typeResult.type);
+            for (let overloadIndex = 0; overloadIndex < overloads.length; overloadIndex++) {
+                const overload = overloads[overloadIndex];
                 useSpeculativeMode(speculativeNode, () => {
                     const matchResults = matchArgsToParams(
                         errorNode,
@@ -9669,30 +9672,29 @@ export function createTypeEvaluator(
                     if (!matchResults.argumentErrors) {
                         matches.push(matchResults);
                     }
-
-                    overloadIndex++;
                 });
-            });
+            }
         });
 
         let winningOverloadIndex: number | undefined;
 
-        matches.forEach((match, matchIndex) => {
-            if (winningOverloadIndex === undefined) {
-                useSpeculativeMode(speculativeNode, () => {
-                    const callResult = validateArgTypes(
-                        errorNode,
-                        match,
-                        new ConstraintTracker(),
-                        /* skipUnknownArgCheck */ true
-                    );
-
-                    if (callResult && !callResult.argumentErrors) {
-                        winningOverloadIndex = matchIndex;
-                    }
-                });
+        for (let matchIndex = 0; matchIndex < matches.length; matchIndex++) {
+            if (winningOverloadIndex !== undefined) {
+                break;
             }
-        });
+            useSpeculativeMode(speculativeNode, () => {
+                const callResult = validateArgTypes(
+                    errorNode,
+                    matches[matchIndex],
+                    new ConstraintTracker(),
+                    /* skipUnknownArgCheck */ true
+                );
+
+                if (callResult && !callResult.argumentErrors) {
+                    winningOverloadIndex = matchIndex;
+                }
+            });
+        }
 
         return winningOverloadIndex === undefined ? undefined : matches[winningOverloadIndex].overload;
     }
@@ -9717,8 +9719,9 @@ export function createTypeEvaluator(
         // speculatively because we don't want to record any types in the type
         // cache or record any diagnostics at this stage.
         useSpeculativeMode(speculativeNode, () => {
-            let overloadIndex = 0;
-            OverloadedType.getOverloads(type).forEach((overload) => {
+            const overloads = OverloadedType.getOverloads(type);
+            for (let overloadIndex = 0; overloadIndex < overloads.length; overloadIndex++) {
+                const overload = overloads[overloadIndex];
                 // Consider only the functions that have the @overload decorator,
                 // not the final function that omits the overload. This is the
                 // intended behavior according to PEP 484.
@@ -9732,9 +9735,7 @@ export function createTypeEvaluator(
                 if (!matchResults.argumentErrors) {
                     filteredMatchResults.push(matchResults);
                 }
-
-                overloadIndex++;
-            });
+            }
         });
 
         // If there are no possible arg/param matches among the overloads,
@@ -10090,11 +10091,12 @@ export function createTypeEvaluator(
     ): CallResult {
         function touchArgTypes() {
             if (!isCallTypeIncomplete) {
-                argList.forEach((arg) => {
+                for (let tai = 0; tai < argList.length; tai++) {
+                    const arg = argList[tai];
                     if (arg.valueExpression && !isSpeculativeModeInUse(arg.valueExpression)) {
                         getTypeOfArg(arg, /* inferenceContext */ undefined);
                     }
-                });
+                }
             }
         }
 
@@ -11008,8 +11010,16 @@ export function createTypeEvaluator(
         // the keyword arguments may target one or more parameters that are positional.
         // In this case, we will limit the number of positional parameters so the
         // *args doesn't consume them all.
-        if (argList.some((arg) => arg.argCategory === ArgCategory.UnpackedList)) {
-            argList.forEach((arg) => {
+        let hasUnpackedListArg = false;
+        for (let ali = 0; ali < argList.length; ali++) {
+            if (argList[ali].argCategory === ArgCategory.UnpackedList) {
+                hasUnpackedListArg = true;
+                break;
+            }
+        }
+        if (hasUnpackedListArg) {
+            for (let ali = 0; ali < argList.length; ali++) {
+                const arg = argList[ali];
                 if (arg.name) {
                     const keywordParamIndex = paramDetails.params.findIndex((paramInfo) => {
                         assert(paramInfo, 'paramInfo entry is undefined fork kwargs check');
@@ -11028,7 +11038,7 @@ export function createTypeEvaluator(
                         }
                     }
                 }
-            });
+            }
         }
 
         // If we didn't see any special cases, then all parameters are positional.
@@ -11045,7 +11055,7 @@ export function createTypeEvaluator(
             }
         }
 
-        const foundUnpackedListArg = argList.find((arg) => arg.argCategory === ArgCategory.UnpackedList) !== undefined;
+        const foundUnpackedListArg = hasUnpackedListArg;
 
         // Map the positional args to parameters.
         let paramIndex = 0;

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -4354,12 +4354,20 @@ export function createTypeEvaluator(
 
                     if (transformedType) {
                         // Apply the type condition if it's associated with a constrained TypeVar.
-                        const typeCondition = getTypeCondition(subtype)?.filter((condition) =>
-                            TypeVarType.hasConstraints(condition.typeVar)
-                        );
-
-                        if (typeCondition && typeCondition.length > 0) {
-                            transformedType = addConditionToType(transformedType, typeCondition);
+                        const rawConditions = getTypeCondition(subtype);
+                        if (rawConditions) {
+                            let filteredConditions: TypeCondition[] | undefined;
+                            for (let ci = 0; ci < rawConditions.length; ci++) {
+                                if (TypeVarType.hasConstraints(rawConditions[ci].typeVar)) {
+                                    if (!filteredConditions) {
+                                        filteredConditions = [];
+                                    }
+                                    filteredConditions.push(rawConditions[ci]);
+                                }
+                            }
+                            if (filteredConditions) {
+                                transformedType = addConditionToType(transformedType, filteredConditions);
+                            }
                         }
 
                         // This code path can often produce many duplicate subtypes. We can
@@ -8622,15 +8630,17 @@ export function createTypeEvaluator(
             );
         }
 
-        const argList = ParseTreeUtils.getArgsByRuntimeOrder(node).map((arg) => {
-            const functionArg: Arg = {
+        const runtimeArgs = ParseTreeUtils.getArgsByRuntimeOrder(node);
+        const argList: Arg[] = new Array(runtimeArgs.length);
+        for (let i = 0; i < runtimeArgs.length; i++) {
+            const arg = runtimeArgs[i];
+            argList[i] = {
                 valueExpression: arg.d.valueExpr,
                 argCategory: arg.d.argCategory,
                 node: arg,
                 name: arg.d.name,
             };
-            return functionArg;
-        });
+        }
 
         let typeResult: TypeResult = { type: UnknownType.create() };
 
@@ -9374,7 +9384,15 @@ export function createTypeEvaluator(
         for (let expandedTypesIndex = 0; expandedTypesIndex < expandedArgTypes.length; expandedTypesIndex++) {
             let matchedOverload: FunctionType | undefined;
             const argTypeOverride = expandedArgTypes[expandedTypesIndex];
-            const hasArgTypeOverride = argTypeOverride.some((a) => a !== undefined);
+
+            let hasArgTypeOverride = false;
+            for (let ai = 0; ai < argTypeOverride.length; ai++) {
+                if (argTypeOverride[ai] !== undefined) {
+                    hasArgTypeOverride = true;
+                    break;
+                }
+            }
+
             let possibleMatchResults: MatchedOverloadInfo[] = [];
             let possibleMatchInvolvesIncompleteUnknown = false;
             isDefinitiveMatchFound = false;
@@ -9384,15 +9402,20 @@ export function createTypeEvaluator(
 
                 let matchResults = argParamMatches[overloadIndex];
                 if (hasArgTypeOverride) {
-                    matchResults = { ...argParamMatches[overloadIndex] };
-                    matchResults.argParams = matchResults.argParams.map((argParam, argIndex) => {
-                        if (!argTypeOverride[argIndex]) {
-                            return argParam;
+                    const srcArgParams = argParamMatches[overloadIndex].argParams;
+                    const newArgParams = new Array(srcArgParams.length);
+                    for (let argIndex = 0; argIndex < srcArgParams.length; argIndex++) {
+                        const override = argTypeOverride[argIndex];
+                        if (!override) {
+                            newArgParams[argIndex] = srcArgParams[argIndex];
+                        } else {
+                            const argParamCopy = { ...srcArgParams[argIndex] };
+                            argParamCopy.argType = override;
+                            newArgParams[argIndex] = argParamCopy;
                         }
-                        const argParamCopy = { ...argParam };
-                        argParamCopy.argType = argTypeOverride[argIndex];
-                        return argParamCopy;
-                    });
+                    }
+                    matchResults = { ...argParamMatches[overloadIndex] };
+                    matchResults.argParams = newArgParams;
                 }
 
                 // Clone the constraints so we don't modify the original.
@@ -9918,13 +9941,14 @@ export function createTypeEvaluator(
         // Expand entry indexToExpand.
         const newExpandedArgTypes: (Type | undefined)[][] = [];
 
-        expandedArgTypes.forEach((preExpandedTypes) => {
-            expandedTypes.forEach((subtype) => {
-                const expandedTypes = [...preExpandedTypes];
-                expandedTypes[indexToExpand] = subtype;
-                newExpandedArgTypes.push(expandedTypes);
-            });
-        });
+        for (let i = 0; i < expandedArgTypes.length; i++) {
+            const preExpandedTypes = expandedArgTypes[i];
+            for (let j = 0; j < expandedTypes.length; j++) {
+                const copy = preExpandedTypes.slice();
+                copy[indexToExpand] = expandedTypes[j];
+                newExpandedArgTypes.push(copy);
+            }
+        }
 
         return newExpandedArgTypes;
     }
@@ -10092,7 +10116,8 @@ export function createTypeEvaluator(
                     inferenceContext
                 );
 
-                return { ...dummyCallResult, returnType: expandedCallType };
+                dummyCallResult.returnType = expandedCallType;
+                return dummyCallResult;
             }
 
             case TypeCategory.Function: {
@@ -12179,28 +12204,52 @@ export function createTypeEvaluator(
         // We'll do two phases. The first one establishes constraints for type
         // variables. The second perform type validation using the solved
         // types. We can skip the first pass if there are no type vars to solve.
-        const typeVarCount = matchResults.argParams.filter((arg) => arg.requiresTypeVarMatching).length;
+        const argParams = matchResults.argParams;
+        let typeVarCount = 0;
+        for (let k = 0; k < argParams.length; k++) {
+            if (argParams[k].requiresTypeVarMatching) {
+                typeVarCount++;
+            }
+        }
+
+        // Hoist the typeResult object outside the loop — it's the same for every arg.
+        const typeResultForValidation: TypeResult<FunctionType> = {
+            type,
+            isIncomplete: matchResults.isTypeIncomplete,
+        };
+
         if (typeVarCount > 0) {
             // Do up to two passes.
             let passCount = Math.min(typeVarCount, 2);
 
+            // Pre-build the first-pass options (skipReportError + isArgFirstPass vary by pass).
+            const firstPassOptions: ValidateArgTypeOptions = {
+                skipUnknownArgCheck,
+                isArgFirstPass: true,
+                conditionFilter: typeCondition,
+                skipReportError: true,
+            };
+            const laterPassOptions: ValidateArgTypeOptions = {
+                skipUnknownArgCheck,
+                conditionFilter: typeCondition,
+                skipReportError: true,
+            };
+
             for (let i = 0; i < passCount; i++) {
                 useSpeculativeMode(speculativeNode, () => {
-                    matchResults.argParams.forEach((argParam) => {
+                    const opts = passCount > 1 && i === 0 ? firstPassOptions : laterPassOptions;
+
+                    for (let j = 0; j < argParams.length; j++) {
+                        const argParam = argParams[j];
                         if (!argParam.requiresTypeVarMatching) {
-                            return;
+                            continue;
                         }
 
                         const argResult = validateArgType(
                             argParam,
                             constraints,
-                            { type, isIncomplete: matchResults.isTypeIncomplete },
-                            {
-                                skipUnknownArgCheck,
-                                isArgFirstPass: passCount > 1 && i === 0,
-                                conditionFilter: typeCondition,
-                                skipReportError: true,
-                            }
+                            typeResultForValidation,
+                            opts
                         );
 
                         if (argResult.isTypeIncomplete) {
@@ -12212,7 +12261,7 @@ export function createTypeEvaluator(
                         if (i === 0 && passCount < 2 && argResult.skippedBareTypeVarExpectedType) {
                             passCount++;
                         }
-                    });
+                    }
                 });
             }
         }
@@ -12223,15 +12272,18 @@ export function createTypeEvaluator(
         let condition: TypeCondition[] = [];
         const argResults: ArgResult[] = [];
 
-        matchResults.argParams.forEach((argParam, argParamIndex) => {
+        const secondPassOptions: ValidateArgTypeOptions = {
+            skipUnknownArgCheck,
+            conditionFilter: typeCondition,
+        };
+
+        for (let argParamIndex = 0; argParamIndex < argParams.length; argParamIndex++) {
+            const argParam = argParams[argParamIndex];
             const argResult = validateArgType(
                 argParam,
                 constraints,
-                { type, isIncomplete: matchResults.isTypeIncomplete },
-                {
-                    skipUnknownArgCheck,
-                    conditionFilter: typeCondition,
-                }
+                typeResultForValidation,
+                secondPassOptions
             );
 
             argResults.push(argResult);
@@ -12242,7 +12294,7 @@ export function createTypeEvaluator(
                 // Add the inverse index so earlier parameters represent larger errors.
                 // This will help the heuristics in the overload error paths to pick the
                 // most likely intended overload if none of them match.
-                argumentMatchScore += 1 + (matchResults.argParams.length - argParamIndex);
+                argumentMatchScore += 1 + (argParams.length - argParamIndex);
             }
 
             if (argResult.isTypeIncomplete) {
@@ -12288,7 +12340,7 @@ export function createTypeEvaluator(
                     }
                 }
             }
-        });
+        }
 
         let paramSpecConstraints: (ConstraintTracker | undefined)[] = [];
 
@@ -12414,17 +12466,31 @@ export function createTypeEvaluator(
                 let typeVarsInReturnType = getTypeVarArgsRecursive(returnType);
 
                 // Remove any type variables that appear in the function's input parameters.
-                functionType.shared.parameters.forEach((param, index) => {
+                const params = functionType.shared.parameters;
+                for (let pi = 0; pi < params.length; pi++) {
+                    const param = params[pi];
                     if (FunctionParam.isTypeDeclared(param)) {
                         const typeVarsInInputParam = getTypeVarArgsRecursive(
-                            FunctionType.getParamType(functionType, index)
+                            FunctionType.getParamType(functionType, pi)
                         );
-                        typeVarsInReturnType = typeVarsInReturnType.filter(
-                            (returnTypeVar) =>
-                                !typeVarsInInputParam.some((inputTypeVar) => isTypeSame(returnTypeVar, inputTypeVar))
-                        );
+
+                        const filtered: TypeVarType[] = [];
+                        for (let ri = 0; ri < typeVarsInReturnType.length; ri++) {
+                            const returnTypeVar = typeVarsInReturnType[ri];
+                            let found = false;
+                            for (let ii = 0; ii < typeVarsInInputParam.length; ii++) {
+                                if (isTypeSame(returnTypeVar, typeVarsInInputParam[ii])) {
+                                    found = true;
+                                    break;
+                                }
+                            }
+                            if (!found) {
+                                filtered.push(returnTypeVar);
+                            }
+                        }
+                        typeVarsInReturnType = filtered;
                     }
-                });
+                }
 
                 return typeVarsInReturnType;
             }
@@ -12448,9 +12514,21 @@ export function createTypeEvaluator(
         }
 
         // What type variables are referenced in the callable return type? Do not include any live type variables.
-        const typeParams = getTypeVarArgsRecursive(returnType).filter(
-            (t) => !liveTypeVarScopes.some((scopeId) => t.priv.scopeId === scopeId)
-        );
+        const allTypeVars = getTypeVarArgsRecursive(returnType);
+        const typeParams: TypeVarType[] = [];
+        for (let ti = 0; ti < allTypeVars.length; ti++) {
+            const t = allTypeVars[ti];
+            let isLive = false;
+            for (let si = 0; si < liveTypeVarScopes.length; si++) {
+                if (t.priv.scopeId === liveTypeVarScopes[si]) {
+                    isLive = true;
+                    break;
+                }
+            }
+            if (!isLive) {
+                typeParams.push(t);
+            }
+        }
 
         // If there are no unsolved type variables, we're done. If there are
         // unsolved type variables, rescope them to the callable.
@@ -12466,7 +12544,9 @@ export function createTypeEvaluator(
         const newScopeId = ParseTreeUtils.getScopeIdForNode(callNode);
         const solution = new ConstraintSolution();
 
-        const newTypeParams = typeParams.map((typeVar) => {
+        const newTypeParams: TypeVarType[] = new Array(typeParams.length);
+        for (let nti = 0; nti < typeParams.length; nti++) {
+            const typeVar = typeParams[nti];
             const newTypeParam = TypeVarType.cloneForScopeId(
                 typeVar,
                 newScopeId,
@@ -12474,8 +12554,8 @@ export function createTypeEvaluator(
                 TypeVarScopeType.Function
             );
             solution.setType(typeVar, newTypeParam);
-            return newTypeParam;
-        });
+            newTypeParams[nti] = newTypeParam;
+        }
 
         return applySolvedTypeVars(
             FunctionType.cloneWithNewTypeVarScopeId(

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -8092,7 +8092,6 @@ export function createTypeEvaluator(
         doForEachSubtype(transformedType, (subtype) => {
             if (subtype.category === TypeCategory.Function) {
                 for (let index = 0; index < subtype.shared.parameters.length; index++) {
-                    const param = subtype.shared.parameters[index];
                     const paramType = FunctionType.getParamType(subtype, index);
                     updateUsageVarianceForType(paramType, invertVariance(varianceContext));
                 }
@@ -29071,7 +29070,7 @@ export function createTypeEvaluator(
                 // See if this class is introducing a new abstract symbol that has not been
                 // introduced previously or if it is overriding an abstract symbol with
                 // a non-abstract one.
-                for (const [symbolName, symbol] of ClassType.getSymbolTable(mroClass)) {
+                for (const symbolName of ClassType.getSymbolTable(mroClass).keys()) {
                     const abstractSymbolInfo = getAbstractSymbolInfo(mroClass, symbolName);
 
                     if (abstractSymbolInfo) {

--- a/packages/pyright-internal/src/analyzer/typeEvaluatorWithTracker.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorWithTracker.ts
@@ -36,9 +36,9 @@ export function createTypeEvaluatorWithTracker(
                             s.add(printer?.printFileOrModuleName(args[0]));
                         } else {
                             // Print all parameters.
-                            args.forEach((a) => {
+                            for (const a of args) {
                                 s.add(printer?.print(a));
-                            });
+                            }
                         }
                         return timingStats.typeEvaluationTime.timeOperation(func, ...args);
                     },
@@ -59,13 +59,13 @@ export function createTypeEvaluatorWithTracker(
 
     // Track these apis external usages when logging is on. otherwise, it should be noop.
     const keys = Object.keys(evaluator);
-    keys.forEach((k) => {
+    for (const k of keys) {
         const entry = (evaluator as any)[k];
         if (typeof entry === 'function' && entry.name) {
             // Only wrap functions that aren't wrapped already.
             (evaluator as any)[k] = wrapWithLogger(entry);
         }
-    });
+    }
 
     return evaluator;
 }

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -2769,7 +2769,7 @@ export function enumerateLiteralsForType(evaluator: TypeEvaluator, type: ClassTy
         // Enumerate all of the values in this enumeration.
         const enumList: ClassType[] = [];
         const fields = ClassType.getSymbolTable(type);
-        fields.forEach((symbol, name) => {
+        for (const [name, symbol] of fields) {
             if (!symbol.isIgnoredForProtocolMatch()) {
                 let symbolType = evaluator.getEffectiveTypeOfSymbol(symbol);
                 symbolType = transformTypeForEnumMember(evaluator, type, name) ?? symbolType;
@@ -2782,7 +2782,7 @@ export function enumerateLiteralsForType(evaluator: TypeEvaluator, type: ClassTy
                     enumList.push(symbolType);
                 }
             }
-        });
+        }
 
         return enumList;
     }

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -108,6 +108,8 @@ export interface TypeNarrowingResult {
 
 export type TypeNarrowingCallback = (type: Type) => TypeNarrowingResult | undefined;
 
+const _supportedContainerNames = ['list', 'set', 'frozenset', 'deque', 'tuple', 'dict', 'defaultdict', 'OrderedDict'];
+
 // Given a reference expression and a test expression, returns a callback that
 // can be used to narrow the type described by the reference expression.
 // If the specified flow node is not associated with the test expression,
@@ -1228,7 +1230,8 @@ export function getIsInstanceClassTypes(
     // Create a helper function that returns a list of class types or
     // undefined if any of the types are not valid.
     const addClassTypesToList = (types: Type[]) => {
-        types.forEach((subtype) => {
+        for (let i = 0; i < types.length; i++) {
+            let subtype = types[i];
             if (isClass(subtype)) {
                 subtype = specializeWithUnknownTypeArgs(subtype, evaluator.getTupleClassType());
 
@@ -1260,7 +1263,7 @@ export function getIsInstanceClassTypes(
             } else {
                 foundNonClassType = true;
             }
-        });
+        }
     };
 
     const addClassTypesRecursive = (type: Type, recursionCount = 0) => {
@@ -1270,9 +1273,9 @@ export function getIsInstanceClassTypes(
 
         if (isClass(type) && TypeBase.isInstance(type) && isTupleClass(type)) {
             if (type.priv.tupleTypeArgs) {
-                type.priv.tupleTypeArgs.forEach((tupleEntry) => {
+                for (const tupleEntry of type.priv.tupleTypeArgs) {
                     addClassTypesRecursive(tupleEntry.type, recursionCount + 1);
-                });
+                }
             }
         } else {
             doForEachSubtype(type, (subtype) => {
@@ -1346,7 +1349,11 @@ function narrowTypeForInstanceOrSubclassInternal(
 
             // Handle metaclass instances specially.
             if (isMetaclassInstance(subtype) && !isTypeInstance) {
-                adjFilterTypes = filterTypes.map((filterType) => convertToInstantiable(filterType));
+                const converted: Type[] = new Array(filterTypes.length);
+                for (let i = 0; i < filterTypes.length; i++) {
+                    converted[i] = convertToInstantiable(filterTypes[i]);
+                }
+                adjFilterTypes = converted;
             } else {
                 adjSubtype = convertToInstance(subtype);
 
@@ -1766,7 +1773,11 @@ function narrowTypeForInstance(
             }
         }
 
-        return filteredTypes.map((t) => convertToInstance(t));
+        const result: Type[] = new Array(filteredTypes.length);
+        for (let i = 0; i < filteredTypes.length; i++) {
+            result[i] = convertToInstance(filteredTypes[i]);
+        }
+        return result;
     };
 
     const isFilterTypeCallbackProtocol = (filterType: Type) => {
@@ -1888,9 +1899,11 @@ function narrowTypeForInstance(
                 // If this is a positive test and the effective type is Any or
                 // Unknown, we can assume that the type matches one of the
                 // specified types.
-                anyOrUnknownSubstitutions.push(
-                    combineTypes(filterTypes.map((classType) => convertToInstance(classType)))
-                );
+                const instanceTypes: Type[] = new Array(filterTypes.length);
+                for (let i = 0; i < filterTypes.length; i++) {
+                    instanceTypes[i] = convertToInstance(filterTypes[i]);
+                }
+                anyOrUnknownSubstitutions.push(combineTypes(instanceTypes));
 
                 anyOrUnknown.push(subtype);
                 return undefined;
@@ -2078,7 +2091,7 @@ function narrowTypeForTupleLength(
 function expandUnboundedTupleElement(tupleType: ClassType, elementsToAdd: number, keepUnbounded: boolean) {
     const tupleTypeArgs: TupleTypeArg[] = [];
 
-    tupleType.priv.tupleTypeArgs!.forEach((typeArg) => {
+    for (const typeArg of tupleType.priv.tupleTypeArgs!) {
         if (!typeArg.isUnbounded) {
             tupleTypeArgs.push(typeArg);
         } else {
@@ -2090,7 +2103,7 @@ function expandUnboundedTupleElement(tupleType: ClassType, elementsToAdd: number
                 tupleTypeArgs.push(typeArg);
             }
         }
-    });
+    }
 
     return specializeTupleClass(tupleType, tupleTypeArgs);
 }
@@ -2128,7 +2141,7 @@ function narrowTypeForContainerType(
     // Determine which tuple types can be eliminated. Only "None" and
     // literal types can be handled here.
     const typesToEliminate: Type[] = [];
-    containerType.priv.tupleTypeArgs.forEach((tupleEntry) => {
+    for (const tupleEntry of containerType.priv.tupleTypeArgs) {
         if (!tupleEntry.isUnbounded) {
             if (isNoneInstance(tupleEntry.type)) {
                 typesToEliminate.push(tupleEntry.type);
@@ -2136,7 +2149,7 @@ function narrowTypeForContainerType(
                 typesToEliminate.push(tupleEntry.type);
             }
         }
-    });
+    }
 
     if (typesToEliminate.length === 0) {
         return referenceType;
@@ -2149,14 +2162,27 @@ function narrowTypeForContainerType(
             // (for bool or enum), we can eliminate all others in a negative test.
             const allLiteralTypes = enumerateLiteralsForType(evaluator, referenceSubtype);
             if (allLiteralTypes && allLiteralTypes.length > 0) {
-                return combineTypes(
-                    allLiteralTypes.filter((type) => !typesToEliminate.some((t) => isTypeSame(t, type)))
-                );
+                const surviving: Type[] = [];
+                for (const type of allLiteralTypes) {
+                    let shouldEliminate = false;
+                    for (const t of typesToEliminate) {
+                        if (isTypeSame(t, type)) {
+                            shouldEliminate = true;
+                            break;
+                        }
+                    }
+                    if (!shouldEliminate) {
+                        surviving.push(type);
+                    }
+                }
+                return combineTypes(surviving);
             }
         }
 
-        if (typesToEliminate.some((t) => isTypeSame(t, referenceSubtype))) {
-            return undefined;
+        for (const t of typesToEliminate) {
+            if (isTypeSame(t, referenceSubtype)) {
+                return undefined;
+            }
         }
 
         return referenceSubtype;
@@ -2165,8 +2191,7 @@ function narrowTypeForContainerType(
 
 export function getElementTypeForContainerNarrowing(containerType: Type) {
     // We support contains narrowing only for certain built-in types that have been specialized.
-    const supportedContainers = ['list', 'set', 'frozenset', 'deque', 'tuple', 'dict', 'defaultdict', 'OrderedDict'];
-    if (!isClassInstance(containerType) || !ClassType.isBuiltIn(containerType, supportedContainers)) {
+    if (!isClassInstance(containerType) || !ClassType.isBuiltIn(containerType, _supportedContainerNames)) {
         return undefined;
     }
 
@@ -2176,7 +2201,11 @@ export function getElementTypeForContainerNarrowing(containerType: Type) {
 
     let elementType = containerType.priv.typeArgs[0];
     if (isTupleClass(containerType) && containerType.priv.tupleTypeArgs) {
-        elementType = combineTypes(containerType.priv.tupleTypeArgs.map((t) => t.type));
+        const tupleTypes: Type[] = new Array(containerType.priv.tupleTypeArgs.length);
+        for (let i = 0; i < containerType.priv.tupleTypeArgs.length; i++) {
+            tupleTypes[i] = containerType.priv.tupleTypeArgs[i].type;
+        }
+        elementType = combineTypes(tupleTypes);
     }
 
     return elementType;

--- a/packages/pyright-internal/src/analyzer/typePrinter.ts
+++ b/packages/pyright-internal/src/analyzer/typePrinter.ts
@@ -250,7 +250,8 @@ function printTypeInternal(
                             aliasInfo.typeArgs.some((typeArg) => !isUnknown(typeArg))
                         ) {
                             argumentStrings = [];
-                            aliasInfo.typeArgs.forEach((typeArg, index) => {
+                            for (let index = 0; index < aliasInfo.typeArgs.length; index++) {
+                                const typeArg = aliasInfo.typeArgs[index];
                                 // Which type parameter does this map to?
                                 const typeParam =
                                     index < typeParams.length ? typeParams[index] : typeParams[typeParams.length - 1];
@@ -263,7 +264,7 @@ function printTypeInternal(
                                     typeArg.priv.tupleTypeArgs &&
                                     typeArg.priv.tupleTypeArgs.every((typeArg) => !typeArg.isUnbounded)
                                 ) {
-                                    typeArg.priv.tupleTypeArgs.forEach((tupleTypeArg) => {
+                                    for (const tupleTypeArg of typeArg.priv.tupleTypeArgs) {
                                         argumentStrings!.push(
                                             printTypeInternal(
                                                 tupleTypeArg.type,
@@ -274,7 +275,7 @@ function printTypeInternal(
                                                 recursionCount
                                             )
                                         );
-                                    });
+                                    }
                                 } else {
                                     argumentStrings!.push(
                                         printTypeInternal(
@@ -287,7 +288,7 @@ function printTypeInternal(
                                         )
                                     );
                                 }
-                            });
+                            }
                         }
                     } else {
                         if (
@@ -295,7 +296,7 @@ function printTypeInternal(
                             typeParams.some((typeParam) => !isUnknown(typeParam))
                         ) {
                             argumentStrings = [];
-                            typeParams.forEach((typeParam) => {
+                            for (const typeParam of typeParams) {
                                 argumentStrings!.push(
                                     printTypeInternal(
                                         typeParam,
@@ -306,7 +307,7 @@ function printTypeInternal(
                                         recursionCount
                                     )
                                 );
-                            });
+                            }
                         }
                     }
 
@@ -726,7 +727,9 @@ function printUnionType(
                         recursionCount
                     )
                 );
-                indicesCoveredByTypeAlias.forEach((index) => subtypeHandledSet.add(index));
+                for (const index of indicesCoveredByTypeAlias) {
+                    subtypeHandledSet.add(index);
+                }
             }
         }
     }
@@ -794,17 +797,23 @@ function printUnionType(
     });
 
     const dedupedSubtypeStrings: string[] = [];
-    subtypeStrings.forEach((s) => dedupedSubtypeStrings.push(s));
+    for (const s of subtypeStrings) {
+        dedupedSubtypeStrings.push(s);
+    }
 
     if (literalObjectStrings.size > 0) {
         const literalStrings: string[] = [];
-        literalObjectStrings.forEach((s) => literalStrings.push(s));
+        for (const s of literalObjectStrings) {
+            literalStrings.push(s);
+        }
         dedupedSubtypeStrings.push(`Literal[${literalStrings.join(', ')}]`);
     }
 
     if (literalClassStrings.size > 0) {
         const literalStrings: string[] = [];
-        literalClassStrings.forEach((s) => literalStrings.push(s));
+        for (const s of literalClassStrings) {
+            literalStrings.push(s);
+        }
         dedupedSubtypeStrings.push(`type[Literal[${literalStrings.join(', ')}]]`);
     }
 
@@ -865,7 +874,8 @@ function printFunctionType(
         if (isPositionalParamsOnly) {
             const paramTypes: string[] = [];
 
-            typeWithoutParamSpec.shared.parameters.forEach((param, index) => {
+            for (let index = 0; index < typeWithoutParamSpec.shared.parameters.length; index++) {
+                const param = typeWithoutParamSpec.shared.parameters[index];
                 if (param.name) {
                     const paramType = FunctionType.getParamType(typeWithoutParamSpec, index);
                     if (recursionTypes.length < maxTypeRecursionCount) {
@@ -883,7 +893,7 @@ function printFunctionType(
                         paramTypes.push('Any');
                     }
                 }
-            });
+            }
 
             if (paramSpec) {
                 if (paramTypes.length > 0) {
@@ -973,7 +983,8 @@ function printObjectTypeForClassInternal(
                 const typeArgStrings: string[] = [];
                 let isAllUnknown = true;
 
-                typeArgs.forEach((typeArg, index) => {
+                for (let index = 0; index < typeArgs.length; index++) {
+                    const typeArg = typeArgs[index];
                     const typeParam = index < typeParams.length ? typeParams[index] : undefined;
                     if (
                         typeParam &&
@@ -1040,7 +1051,7 @@ function printObjectTypeForClassInternal(
                             typeArgStrings.push(typeArgTypeText);
                         }
                     }
-                });
+                }
 
                 if (type.priv.isUnpacked) {
                     objName = printUnpack(objName, printTypeFlags);
@@ -1115,7 +1126,8 @@ function printFunctionPartsInternal(
         type = FunctionType.cloneRemoveParamSpecArgsKwargs(type);
     }
 
-    type.shared.parameters.forEach((param, index) => {
+    for (let index = 0; index < type.shared.parameters.length; index++) {
+        const param = type.shared.parameters[index];
         const paramType = FunctionType.getParamType(type, index);
         const defaultType = FunctionType.getParamDefaultType(type, index);
 
@@ -1131,7 +1143,7 @@ function printFunctionPartsInternal(
                 ClassType.isBuiltIn(specializedParamType, 'tuple') &&
                 specializedParamType.priv.tupleTypeArgs
             ) {
-                specializedParamType.priv.tupleTypeArgs.forEach((paramType) => {
+                for (const paramType of specializedParamType.priv.tupleTypeArgs) {
                     const paramString = printTypeInternal(
                         paramType.type,
                         printTypeFlags,
@@ -1141,8 +1153,8 @@ function printFunctionPartsInternal(
                         recursionCount
                     );
                     paramTypeStrings.push(paramString);
-                });
-                return;
+                }
+                continue;
             }
         }
 
@@ -1152,7 +1164,7 @@ function printFunctionPartsInternal(
             printTypeFlags & PrintTypeFlags.ExpandTypedDictArgs &&
             paramType.category === TypeCategory.Class
         ) {
-            paramType.shared.typedDictEntries!.knownItems.forEach((v, k) => {
+            for (const [k, v] of paramType.shared.typedDictEntries!.knownItems) {
                 const valueTypeString = printTypeInternal(
                     v.valueType,
                     printTypeFlags,
@@ -1162,7 +1174,7 @@ function printFunctionPartsInternal(
                     recursionCount
                 );
                 paramTypeStrings.push(`${k}: ${valueTypeString}`);
-            });
+            }
 
             const extraItemsType = paramType.shared.typedDictEntries?.extraItems?.valueType;
             if (extraItemsType && !isNever(extraItemsType)) {
@@ -1177,7 +1189,7 @@ function printFunctionPartsInternal(
                 paramTypeStrings.push(`**kwargs: ${valueTypeString}`);
             }
 
-            return;
+            continue;
         }
 
         let paramString = '';
@@ -1261,7 +1273,7 @@ function printFunctionPartsInternal(
             if (sawDefinedName) {
                 paramString += '/';
             } else {
-                return;
+                continue;
             }
         }
 
@@ -1281,12 +1293,12 @@ function printFunctionPartsInternal(
             if (param.category === ParamCategory.ArgsList) {
                 paramString = '...';
             } else if (param.category === ParamCategory.KwargsDict) {
-                return;
+                continue;
             }
         }
 
         paramTypeStrings.push(paramString);
-    });
+    }
 
     if (paramSpec) {
         if (printTypeFlags & PrintTypeFlags.PythonSyntax) {
@@ -1396,9 +1408,9 @@ class UniqueNameMap {
                     recursionTypes.push(type);
 
                     try {
-                        aliasInfo.typeArgs.forEach((typeArg) => {
+                        for (const typeArg of aliasInfo.typeArgs) {
                             this.build(typeArg, recursionTypes, recursionCount);
-                        });
+                        }
                     } finally {
                         recursionTypes.pop();
                     }
@@ -1413,10 +1425,10 @@ class UniqueNameMap {
 
             switch (type.category) {
                 case TypeCategory.Function: {
-                    type.shared.parameters.forEach((_, index) => {
+                    for (let index = 0; index < type.shared.parameters.length; index++) {
                         const paramType = FunctionType.getParamType(type, index);
                         this.build(paramType, recursionTypes, recursionCount);
-                    });
+                    }
 
                     const returnType = this._returnTypeCallback(type);
                     this.build(returnType, recursionTypes, recursionCount);
@@ -1424,9 +1436,9 @@ class UniqueNameMap {
                 }
 
                 case TypeCategory.Overloaded: {
-                    OverloadedType.getOverloads(type).forEach((overload) => {
+                    for (const overload of OverloadedType.getOverloads(type)) {
                         this.build(overload, recursionTypes, recursionCount);
-                    });
+                    }
                     break;
                 }
 
@@ -1447,13 +1459,13 @@ class UniqueNameMap {
 
                     if (!ClassType.isPseudoGenericClass(type)) {
                         if (type.priv.tupleTypeArgs) {
-                            type.priv.tupleTypeArgs.forEach((typeArg) => {
+                            for (const typeArg of type.priv.tupleTypeArgs) {
                                 this.build(typeArg.type, recursionTypes, recursionCount);
-                            });
+                            }
                         } else if (type.priv.typeArgs) {
-                            type.priv.typeArgs.forEach((typeArg) => {
+                            for (const typeArg of type.priv.typeArgs) {
                                 this.build(typeArg, recursionTypes, recursionCount);
-                            });
+                            }
                         }
                     }
                     break;
@@ -1464,9 +1476,11 @@ class UniqueNameMap {
                         this.build(subtype, recursionTypes, recursionCount);
                     });
 
-                    type.priv.typeAliasSources?.forEach((typeAliasSource) => {
-                        this.build(typeAliasSource, recursionTypes, recursionCount);
-                    });
+                    if (type.priv.typeAliasSources) {
+                        for (const typeAliasSource of type.priv.typeAliasSources) {
+                            this.build(typeAliasSource, recursionTypes, recursionCount);
+                        }
+                    }
                     break;
                 }
             }

--- a/packages/pyright-internal/src/analyzer/typeStubWriter.ts
+++ b/packages/pyright-internal/src/analyzer/typeStubWriter.ts
@@ -521,7 +521,7 @@ export class TypeStubWriter extends ParseTreeWalker {
         const currentScope = getScopeForNode(node);
         if (currentScope) {
             // Record the input for later.
-            node.d.list.forEach((imp) => {
+            for (const imp of node.d.list) {
                 const moduleName = this._printModuleName(imp.d.module);
                 if (!this._trackedImportAs.has(moduleName)) {
                     const symbolName = imp.d.alias
@@ -539,7 +539,7 @@ export class TypeStubWriter extends ParseTreeWalker {
                         this._trackedImportAs.set(moduleName, trackedImportAs);
                     }
                 }
-            });
+            }
         }
 
         return false;
@@ -560,7 +560,7 @@ export class TypeStubWriter extends ParseTreeWalker {
                 this._trackedImportFrom.set(moduleName, trackedImportFrom);
             }
 
-            node.d.imports.forEach((imp) => {
+            for (const imp of node.d.imports) {
                 const symbolName = imp.d.alias ? imp.d.alias.d.value : imp.d.name.d.value;
                 const symbolInfo = currentScope.lookUpSymbolRecursive(symbolName);
                 if (symbolInfo) {
@@ -571,7 +571,7 @@ export class TypeStubWriter extends ParseTreeWalker {
                         false
                     );
                 }
-            });
+            }
         }
 
         return false;
@@ -615,9 +615,9 @@ export class TypeStubWriter extends ParseTreeWalker {
     }
 
     private _emitDecorators(decorators: DecoratorNode[]) {
-        decorators.forEach((decorator) => {
+        for (const decorator of decorators) {
             this._emitLine('@' + this._printExpression(decorator.d.expr));
-        });
+        }
     }
 
     private _printHeaderDocString() {
@@ -731,7 +731,7 @@ export class TypeStubWriter extends ParseTreeWalker {
         let lineEmitted = false;
 
         // Emit the "import" statements.
-        this._trackedImportAs.forEach((imp) => {
+        for (const imp of this._trackedImportAs.values()) {
             if (this._accessedImportedSymbols.has(imp.alias || imp.importName)) {
                 imp.isAccessed = true;
             }
@@ -744,15 +744,15 @@ export class TypeStubWriter extends ParseTreeWalker {
                 importStr += this._lineEnd;
                 lineEmitted = true;
             }
-        });
+        }
 
         // Emit the "import from" statements.
-        this._trackedImportFrom.forEach((imp) => {
-            imp.symbols.forEach((s) => {
+        for (const imp of this._trackedImportFrom.values()) {
+            for (const s of imp.symbols) {
                 if (this._accessedImportedSymbols.has(s.alias || s.name)) {
                     s.isAccessed = true;
                 }
-            });
+            }
 
             if (imp.isWildcardImport) {
                 importStr += `from ${imp.importName} import *` + this._lineEnd;
@@ -789,7 +789,7 @@ export class TypeStubWriter extends ParseTreeWalker {
                 importStr += this._lineEnd;
                 lineEmitted = true;
             }
-        });
+        }
 
         if (lineEmitted) {
             importStr += this._lineEnd;

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -239,6 +239,10 @@ export interface AddConditionOptions {
 // large enough that we should never hit it in legitimate circumstances.
 const maxTupleTypeArgRecursionDepth = 10;
 
+// Shared empty options object to avoid allocating a new {} on every call
+// from the ~25 call sites that use the default.
+const _defaultApplyTypeVarOptions: ApplyTypeVarOptions = {};
+
 // Tracks whether a function signature has been seen before within
 // an expression. For example, in the expression "foo(foo, foo)", the
 // signature for "foo" will be seen three times at three different
@@ -1590,7 +1594,7 @@ export function makeTypeVarsFree(type: Type, scopeIds: TypeVarScopeId[]): Type {
 
 // Specializes a (potentially generic) type by substituting
 // type variables from a type var map.
-export function applySolvedTypeVars(type: Type, solution: ConstraintSolution, options: ApplyTypeVarOptions = {}): Type {
+export function applySolvedTypeVars(type: Type, solution: ConstraintSolution, options: ApplyTypeVarOptions = _defaultApplyTypeVarOptions): Type {
     // Use a shortcut if constraints is empty and no transform is necessary.
     if (solution.isEmpty() && !options.replaceUnsolved) {
         return type;

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -242,6 +242,21 @@ const maxTupleTypeArgRecursionDepth = 10;
 // Shared empty options object to avoid allocating a new {} on every call
 // from the ~25 call sites that use the default.
 const _defaultApplyTypeVarOptions: ApplyTypeVarOptions = {};
+const _ignoreTypeFlagsOptions: TypeSameOptions = { ignoreTypeFlags: true };
+
+// Special built-in classes that require type arguments even though typeParams is empty.
+const _specialBuiltInClassNames = new Set([
+    'Tuple',
+    'Callable',
+    'Generic',
+    'Type',
+    'Optional',
+    'Union',
+    'Literal',
+    'Annotated',
+    'TypeGuard',
+    'TypeIs',
+]);
 
 // Tracks whether a function signature has been seen before within
 // an expression. For example, in the expression "foo(foo, foo)", the
@@ -1594,7 +1609,11 @@ export function makeTypeVarsFree(type: Type, scopeIds: TypeVarScopeId[]): Type {
 
 // Specializes a (potentially generic) type by substituting
 // type variables from a type var map.
-export function applySolvedTypeVars(type: Type, solution: ConstraintSolution, options: ApplyTypeVarOptions = _defaultApplyTypeVarOptions): Type {
+export function applySolvedTypeVars(
+    type: Type,
+    solution: ConstraintSolution,
+    options: ApplyTypeVarOptions = _defaultApplyTypeVarOptions
+): Type {
     // Use a shortcut if constraints is empty and no transform is necessary.
     if (solution.isEmpty() && !options.replaceUnsolved) {
         return type;
@@ -2055,7 +2074,14 @@ export function addTypeVarsToListIfUnique(list1: TypeVarType[], list2: TypeVarTy
             continue;
         }
 
-        if (!list1.find((type1) => isTypeSame(type1, type2))) {
+        let found = false;
+        for (let i = 0; i < list1.length; i++) {
+            if (isTypeSame(list1[i], type2)) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
             list1.push(type2);
         }
     }
@@ -2226,7 +2252,14 @@ export function specializeForBaseClass(srcType: ClassType, baseClass: ClassType)
 }
 
 export function derivesFromStdlibClass(classType: ClassType, className: string) {
-    return classType.shared.mro.some((mroClass) => isClass(mroClass) && ClassType.isBuiltIn(mroClass, className));
+    const mro = classType.shared.mro;
+    for (let i = 0; i < mro.length; i++) {
+        const mroClass = mro[i];
+        if (isClass(mroClass) && ClassType.isBuiltIn(mroClass, className)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 // If ignoreUnknown is true, an unknown base class is ignored when
@@ -2322,17 +2355,31 @@ export function getGeneratorYieldType(declaredReturnType: Type, isAsync: boolean
 }
 
 export function isInstantiableMetaclass(type: Type): boolean {
-    return (
-        isInstantiableClass(type) &&
-        type.shared.mro.some((mroClass) => isClass(mroClass) && ClassType.isBuiltIn(mroClass, 'type'))
-    );
+    if (!isInstantiableClass(type)) {
+        return false;
+    }
+    const mro = type.shared.mro;
+    for (let i = 0; i < mro.length; i++) {
+        const mroClass = mro[i];
+        if (isClass(mroClass) && ClassType.isBuiltIn(mroClass, 'type')) {
+            return true;
+        }
+    }
+    return false;
 }
 
 export function isMetaclassInstance(type: Type): boolean {
-    return (
-        isClassInstance(type) &&
-        type.shared.mro.some((mroClass) => isClass(mroClass) && ClassType.isBuiltIn(mroClass, 'type'))
-    );
+    if (!isClassInstance(type)) {
+        return false;
+    }
+    const mro = type.shared.mro;
+    for (let i = 0; i < mro.length; i++) {
+        const mroClass = mro[i];
+        if (isClass(mroClass) && ClassType.isBuiltIn(mroClass, 'type')) {
+            return true;
+        }
+    }
+    return false;
 }
 
 export function isEffectivelyInstantiable(type: Type, options?: IsInstantiableOptions, recursionCount = 0): boolean {
@@ -2922,20 +2969,7 @@ export function requiresTypeArgs(classType: ClassType) {
     // There are a few built-in special classes that require
     // type arguments even though typeParams is empty.
     if (ClassType.isSpecialBuiltIn(classType)) {
-        const specialClasses = [
-            'Tuple',
-            'Callable',
-            'Generic',
-            'Type',
-            'Optional',
-            'Union',
-            'Literal',
-            'Annotated',
-            'TypeGuard',
-            'TypeIs',
-        ];
-
-        if (specialClasses.some((t) => t === (classType.priv.aliasName || classType.shared.name))) {
+        if (_specialBuiltInClassNames.has(classType.priv.aliasName || classType.shared.name)) {
             return true;
         }
     }
@@ -3591,24 +3625,30 @@ export class TypeVarTransformer {
 
         if (isFunction(type)) {
             // Prevent recursion.
-            if (this._pendingFunctionTransformations.some((t) => t === type)) {
-                return type;
+            const pending = this._pendingFunctionTransformations;
+            for (let i = 0; i < pending.length; i++) {
+                if (pending[i] === type) {
+                    return type;
+                }
             }
 
-            this._pendingFunctionTransformations.push(type);
+            pending.push(type);
             const result = this.transformTypeVarsInFunctionType(type, recursionCount);
-            this._pendingFunctionTransformations.pop();
+            pending.pop();
 
             return result;
         }
 
         if (isOverloaded(type)) {
             // Prevent recursion.
-            if (this._pendingFunctionTransformations.some((t) => t === type)) {
-                return type;
+            const pending = this._pendingFunctionTransformations;
+            for (let i = 0; i < pending.length; i++) {
+                if (pending[i] === type) {
+                    return type;
+                }
             }
 
-            this._pendingFunctionTransformations.push(type);
+            pending.push(type);
 
             let requiresUpdate = false;
 
@@ -4465,8 +4505,10 @@ class ApplySolvedTypeVarsTransformer extends TypeVarTransformer {
 
         const exemptTypeVars = this._options.replaceUnsolved?.unsolvedExemptTypeVars;
         if (exemptTypeVars) {
-            if (exemptTypeVars.some((t) => isTypeSame(t, typeVar, { ignoreTypeFlags: true }))) {
-                return false;
+            for (let i = 0; i < exemptTypeVars.length; i++) {
+                if (isTypeSame(exemptTypeVars[i], typeVar, _ignoreTypeFlagsOptions)) {
+                    return false;
+                }
             }
         }
 
@@ -4497,8 +4539,12 @@ class UnificationTypeTransformer extends TypeVarTransformer {
     }
 
     private _isTypeVarLive(typeVar: TypeVarType) {
-        return this._liveTypeVarScopes.some(
-            (scopeId) => typeVar.priv.scopeId === scopeId || typeVar.priv.freeTypeVar?.priv.scopeId === scopeId
-        );
+        const scopes = this._liveTypeVarScopes;
+        for (let i = 0; i < scopes.length; i++) {
+            if (typeVar.priv.scopeId === scopes[i] || typeVar.priv.freeTypeVar?.priv.scopeId === scopes[i]) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -276,11 +276,11 @@ export class UniqueSignatureTracker {
     }
 
     addTrackedSignatures(signatures: SignatureWithOffsets[]) {
-        signatures.forEach((s) => {
-            s.expressionOffsets.forEach((offset) => {
+        for (const s of signatures) {
+            for (const offset of s.expressionOffsets) {
                 this.addSignature(s.type, offset);
-            });
-        });
+            }
+        }
     }
 
     findSignature(signature: FunctionType | OverloadedType): SignatureWithOffsets | undefined {
@@ -1699,14 +1699,14 @@ export function getProtocolSymbolsRecursive(
         return;
     }
 
-    classType.shared.baseClasses.forEach((baseClass) => {
+    for (const baseClass of classType.shared.baseClasses) {
         if (isClass(baseClass) && (baseClass.shared.flags & classFlags) !== 0) {
             getProtocolSymbolsRecursive(baseClass, symbolMap, classFlags, recursionCount + 1);
         }
-    });
+    }
 
     if ((classType.shared.flags & classFlags) !== 0) {
-        ClassType.getSymbolTable(classType).forEach((symbol, name) => {
+        for (const [name, symbol] of ClassType.getSymbolTable(classType)) {
             if (!symbol.isIgnoredForProtocolMatch()) {
                 symbolMap.set(name, {
                     symbol,
@@ -1721,7 +1721,7 @@ export function getProtocolSymbolsRecursive(
                     skippedUndeclaredType: false,
                 });
             }
-        });
+        }
     }
 }
 
@@ -1741,19 +1741,19 @@ export function getContainerDepth(type: Type, recursionCount = 0) {
     let maxChildDepth = 0;
 
     if (type.priv.tupleTypeArgs) {
-        type.priv.tupleTypeArgs.forEach((typeArgInfo) => {
+        for (const typeArgInfo of type.priv.tupleTypeArgs) {
             doForEachSubtype(typeArgInfo.type, (subtype) => {
                 const childDepth = getContainerDepth(subtype, recursionCount);
                 maxChildDepth = Math.max(childDepth, maxChildDepth);
             });
-        });
+        }
     } else if (type.priv.typeArgs) {
-        type.priv.typeArgs.forEach((typeArg) => {
+        for (const typeArg of type.priv.typeArgs) {
             doForEachSubtype(typeArg, (subtype) => {
                 const childDepth = getContainerDepth(subtype, recursionCount);
                 maxChildDepth = Math.max(childDepth, maxChildDepth);
             });
-        });
+        }
     } else {
         return 0;
     }
@@ -2051,11 +2051,11 @@ export function getClassFieldsRecursive(classType: ClassType): Map<string, Class
     const memberMap = new Map<string, ClassMember>();
 
     // Evaluate the types of members from the end of the MRO to the beginning.
-    ClassType.getReverseMro(classType).forEach((mroClass) => {
+    for (const mroClass of ClassType.getReverseMro(classType)) {
         const specializedMroClass = partiallySpecializeType(mroClass, classType, /* typeClassType */ undefined);
 
         if (isClass(specializedMroClass)) {
-            ClassType.getSymbolTable(specializedMroClass).forEach((symbol, name) => {
+            for (const [name, symbol] of ClassType.getSymbolTable(specializedMroClass)) {
                 if (!symbol.isIgnoredForProtocolMatch() && symbol.hasTypedDeclarations()) {
                     memberMap.set(name, {
                         classType: specializedMroClass,
@@ -2070,13 +2070,13 @@ export function getClassFieldsRecursive(classType: ClassType): Map<string, Class
                         skippedUndeclaredType: false,
                     });
                 }
-            });
+            }
         } else {
             // If this ancestor class is unknown, throw away all symbols
             // found so far because they could be overridden by the unknown class.
             memberMap.clear();
         }
-    });
+    }
 
     return memberMap;
 }
@@ -2118,17 +2118,17 @@ export function getTypeVarArgsRecursive(type: Type, recursionCount = 0): TypeVar
         const combinedList: TypeVarType[] = [];
 
         if (aliasInfo.typeArgs) {
-            aliasInfo?.typeArgs.forEach((typeArg) => {
+            for (const typeArg of aliasInfo.typeArgs) {
                 addTypeVarsToListIfUnique(combinedList, getTypeVarArgsRecursive(typeArg, recursionCount));
-            });
+            }
 
             return combinedList;
         }
 
         if (aliasInfo.shared.typeParams) {
-            aliasInfo.shared.typeParams.forEach((typeParam) => {
+            for (const typeParam of aliasInfo.shared.typeParams) {
                 addTypeVarsToListIfUnique(combinedList, [typeParam]);
-            });
+            }
 
             return combinedList;
         }
@@ -2157,9 +2157,9 @@ export function getTypeVarArgsRecursive(type: Type, recursionCount = 0): TypeVar
         const combinedList: TypeVarType[] = [];
         const typeArgs = type.priv.tupleTypeArgs ? type.priv.tupleTypeArgs.map((e) => e.type) : type.priv.typeArgs;
         if (typeArgs) {
-            typeArgs.forEach((typeArg) => {
+            for (const typeArg of typeArgs) {
                 addTypeVarsToListIfUnique(combinedList, getTypeVarArgsRecursive(typeArg, recursionCount));
-            });
+            }
         }
 
         return combinedList;
@@ -2241,11 +2241,12 @@ export function buildSolution(typeParams: TypeVarType[], typeArgs: Type[] | unde
         return solution;
     }
 
-    typeParams.forEach((typeParam, index) => {
+    for (let index = 0; index < typeParams.length; index++) {
+        const typeParam = typeParams[index];
         if (index < typeArgs.length) {
             solution.setType(typeParam, typeArgs[index]);
         }
-    });
+    }
 
     return solution;
 }
@@ -2553,11 +2554,11 @@ export function convertToInstantiable(type: Type, includeSubclasses = true): Typ
 }
 
 export function getMembersForClass(classType: ClassType, symbolTable: SymbolTable, includeInstanceVars: boolean) {
-    classType.shared.mro.forEach((mroClass) => {
+    for (const mroClass of classType.shared.mro) {
         if (isInstantiableClass(mroClass)) {
             // Add any new member variables from this class.
             const isClassTypedDict = ClassType.isTypedDictClass(mroClass);
-            ClassType.getSymbolTable(mroClass).forEach((symbol, name) => {
+            for (const [name, symbol] of ClassType.getSymbolTable(mroClass)) {
                 if (symbol.isClassMember() || (includeInstanceVars && symbol.isInstanceMember())) {
                     if (!isClassTypedDict || !isTypedDictMemberAccessedThroughIndex(symbol)) {
                         if (!symbol.isInitVar()) {
@@ -2573,9 +2574,9 @@ export function getMembersForClass(classType: ClassType, symbolTable: SymbolTabl
                         }
                     }
                 }
-            });
+            }
         }
-    });
+    }
 
     // Add members of the metaclass as well.
     if (!includeInstanceVars) {
@@ -2583,7 +2584,7 @@ export function getMembersForClass(classType: ClassType, symbolTable: SymbolTabl
         if (metaclass && isInstantiableClass(metaclass)) {
             for (const mroClass of metaclass.shared.mro) {
                 if (isInstantiableClass(mroClass)) {
-                    ClassType.getSymbolTable(mroClass).forEach((symbol, name) => {
+                    for (const [name, symbol] of ClassType.getSymbolTable(mroClass)) {
                         const existingSymbol = symbolTable.get(name);
 
                         if (!existingSymbol) {
@@ -2593,7 +2594,7 @@ export function getMembersForClass(classType: ClassType, symbolTable: SymbolTabl
                             // has an annotation for the symbol, use the parent type instead.
                             symbolTable.set(name, symbol);
                         }
-                    });
+                    }
                 } else {
                     break;
                 }
@@ -2607,14 +2608,14 @@ export function getMembersForModule(moduleType: ModuleType, symbolTable: SymbolT
     // same name defined within the module, they will overwrite the
     // loader fields.
     if (moduleType.priv.loaderFields) {
-        moduleType.priv.loaderFields.forEach((symbol, name) => {
+        for (const [name, symbol] of moduleType.priv.loaderFields) {
             symbolTable.set(name, symbol);
-        });
+        }
     }
 
-    moduleType.priv.fields.forEach((symbol, name) => {
+    for (const [name, symbol] of moduleType.priv.fields) {
         symbolTable.set(name, symbol);
-    });
+    }
 }
 
 // Determines if the type contains an Any recursively.
@@ -2819,9 +2820,10 @@ export function combineSameSizedTuples(type: Type, tupleType: Type | undefined):
             if (tupleClass && isClass(tupleClass) && tupleClass.priv.tupleTypeArgs) {
                 if (tupleEntries) {
                     if (tupleEntries.length === tupleClass.priv.tupleTypeArgs.length) {
-                        tupleClass.priv.tupleTypeArgs.forEach((entry, index) => {
+                        for (let index = 0; index < tupleClass.priv.tupleTypeArgs.length; index++) {
+                            const entry = tupleClass.priv.tupleTypeArgs[index];
                             tupleEntries![index].push(entry.type);
-                        });
+                        }
                     } else {
                         isValid = false;
                     }
@@ -2853,12 +2855,12 @@ export function combineSameSizedTuples(type: Type, tupleType: Type | undefined):
 export function combineTupleTypeArgs(typeArgs: TupleTypeArg[]): Type {
     const typesToCombine: Type[] = [];
 
-    typeArgs.forEach((t) => {
+    for (const t of typeArgs) {
         if (isTypeVar(t.type)) {
             if (isUnpackedTypeVarTuple(t.type)) {
                 // Treat the unpacked TypeVarTuple as a union.
                 typesToCombine.push(TypeVarType.cloneForUnpacked(t.type, /* isInUnion */ true));
-                return;
+                continue;
             }
 
             if (isUnpackedTypeVar(t.type)) {
@@ -2870,12 +2872,12 @@ export function combineTupleTypeArgs(typeArgs: TupleTypeArg[]): Type {
                 ) {
                     typesToCombine.push(combineTupleTypeArgs(t.type.shared.boundType.priv.tupleTypeArgs));
                 }
-                return;
+                continue;
             }
         }
 
         typesToCombine.push(t.type);
-    });
+    }
 
     return combineTypes(typesToCombine);
 }
@@ -3247,7 +3249,7 @@ export function computeMroLinearization(classType: ClassType): boolean {
     // Construct the list of class lists that need to be merged.
     const classListsToMerge: Type[][] = [];
 
-    filteredBaseClasses.forEach((baseClass) => {
+    for (const baseClass of filteredBaseClasses) {
         if (isInstantiableClass(baseClass)) {
             const solution = buildSolutionFromSpecializedClass(baseClass);
             classListsToMerge.push(
@@ -3258,7 +3260,7 @@ export function computeMroLinearization(classType: ClassType): boolean {
         } else {
             classListsToMerge.push([baseClass]);
         }
-    });
+    }
 
     classListsToMerge.push(
         filteredBaseClasses.map((baseClass) => {
@@ -3396,9 +3398,9 @@ function addDeclaringModuleNamesForType(type: Type, moduleList: string[], recurs
 
         case TypeCategory.Overloaded: {
             const overloads = OverloadedType.getOverloads(type);
-            overloads.forEach((overload) => {
+            for (const overload of overloads) {
                 addDeclaringModuleNamesForType(overload, moduleList, recursionCount);
-            });
+            }
             const impl = OverloadedType.getImplementation(type);
             if (impl) {
                 addDeclaringModuleNamesForType(impl, moduleList, recursionCount);
@@ -3447,7 +3449,8 @@ export function convertTypeToParamSpecValue(type: Type): FunctionType {
 
         newFunction.shared.deprecatedMessage = type.shared.deprecatedMessage;
 
-        type.shared.parameters.forEach((param, index) => {
+        for (let index = 0; index < type.shared.parameters.length; index++) {
+            const param = type.shared.parameters[index];
             FunctionType.addParam(
                 newFunction,
                 FunctionParam.create(
@@ -3459,7 +3462,7 @@ export function convertTypeToParamSpecValue(type: Type): FunctionType {
                     param.defaultExpr
                 )
             );
-        });
+        }
 
         newFunction.shared.typeVarScopeId = type.shared.typeVarScopeId;
         newFunction.priv.constructorTypeVarScopeId = type.priv.constructorTypeVarScopeId;
@@ -3671,7 +3674,7 @@ export class TypeVarTransformer {
             const overloads = OverloadedType.getOverloads(type);
             const newOverloads: FunctionType[] = [];
 
-            overloads.forEach((entry) => {
+            for (const entry of overloads) {
                 const replacementType = this.transformTypeVarsInFunctionType(entry, recursionCount);
 
                 if (isFunction(replacementType)) {
@@ -3683,7 +3686,7 @@ export class TypeVarTransformer {
                 if (replacementType !== entry) {
                     requiresUpdate = true;
                 }
-            });
+            }
 
             const impl = OverloadedType.getImplementation(type);
             let newImpl: Type | undefined = impl;
@@ -3778,7 +3781,7 @@ export class TypeVarTransformer {
             if (classType.priv.tupleTypeArgs) {
                 newTupleTypeArgs = [];
 
-                classType.priv.tupleTypeArgs.forEach((oldTypeArgType) => {
+                for (const oldTypeArgType of classType.priv.tupleTypeArgs) {
                     const newTypeArgType = this.apply(oldTypeArgType.type, recursionCount);
 
                     if (newTypeArgType !== oldTypeArgType.type) {
@@ -3811,7 +3814,7 @@ export class TypeVarTransformer {
                             });
                         }
                     }
-                });
+                }
             } else if (typeParams.length > 0) {
                 newTupleTypeArgs = this.transformTupleTypeVar(typeParams[0], recursionCount);
                 if (newTupleTypeArgs) {
@@ -3998,12 +4001,13 @@ export class TypeVarTransformer {
             let insertKeywordOnlySeparator = false;
             let swallowPositionOnlySeparator = false;
 
-            specializedParams.parameterTypes.forEach((paramType, index) => {
+            for (let index = 0; index < specializedParams.parameterTypes.length; index++) {
+                const paramType = specializedParams.parameterTypes[index];
                 if (index === variadicParamIndex) {
                     let sawUnboundedEntry = false;
 
                     // Unpack the tuple into individual parameters.
-                    variadicTypesToUnpack!.forEach((unpackedType) => {
+                    for (const unpackedType of variadicTypesToUnpack!) {
                         FunctionType.addParam(
                             newFunctionType,
                             FunctionParam.create(
@@ -4019,7 +4023,7 @@ export class TypeVarTransformer {
                         if (unpackedType.isUnbounded) {
                             sawUnboundedEntry = true;
                         }
-                    });
+                    }
 
                     if (sawUnboundedEntry) {
                         swallowPositionOnlySeparator = true;
@@ -4058,7 +4062,7 @@ export class TypeVarTransformer {
                         );
                     }
                 }
-            });
+            }
 
             newFunctionType.shared.declaredReturnType = specializedParams.returnType;
 
@@ -4127,7 +4131,7 @@ class UniqueFunctionSignatureTransformer extends TypeVarTransformer {
 
                 // Create new type variables with the same scope but with
                 // different (unique) names.
-                sourceType.shared.typeParams.forEach((typeParam) => {
+                for (const typeParam of sourceType.shared.typeParams) {
                     if (typeParam.priv.scopeType === TypeVarScopeType.Function) {
                         const replacement: Type = TypeVarType.cloneForNewName(
                             typeParam,
@@ -4136,7 +4140,7 @@ class UniqueFunctionSignatureTransformer extends TypeVarTransformer {
 
                         solution.setType(typeParam, replacement);
                     }
-                });
+                }
 
                 updatedSourceType = applySolvedTypeVars(sourceType, solution);
                 assert(isFunctionOrOverloaded(updatedSourceType));

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -473,16 +473,17 @@ export function mapSignatures(
     const newSignatures: FunctionType[] = [];
     let changeMade = false;
 
-    OverloadedType.getOverloads(type).forEach((overload, index) => {
-        const newOverload = callback(overload);
-        if (newOverload !== overload) {
+    const overloads = OverloadedType.getOverloads(type);
+    for (let i = 0; i < overloads.length; i++) {
+        const newOverload = callback(overloads[i]);
+        if (newOverload !== overloads[i]) {
             changeMade = true;
         }
 
         if (newOverload) {
             newSignatures.push(newOverload);
         }
-    });
+    }
 
     if (newSignatures.length === 0) {
         return undefined;
@@ -579,9 +580,7 @@ export function cleanIncompleteUnknown(type: Type, recursionCount = 0): Type {
 
 // Sorts types into a deterministic order.
 export function sortTypes(types: Type[]): Type[] {
-    return types.slice(0).sort((a, b) => {
-        return compareTypes(a, b);
-    });
+    return types.slice(0).sort(compareTypes);
 }
 
 function compareTypes(a: Type, b: Type, recursionCount = 0): number {
@@ -768,6 +767,11 @@ function compareTypes(a: Type, b: Type, recursionCount = 0): number {
     return 1;
 }
 
+// Reusable single-element array to avoid per-call [type] allocations
+// in doForEachSubtype for non-union types. Contents are overwritten
+// on each call, so callers must not retain a reference.
+const _singletonSubtypeArray: Type[] = [undefined as unknown as Type];
+
 export function doForEachSubtype(
     type: Type,
     callback: (type: Type, index: number, allSubtypes: Type[]) => void,
@@ -775,19 +779,25 @@ export function doForEachSubtype(
 ): void {
     if (isUnion(type)) {
         const subtypes = sortSubtypes ? sortTypes(type.priv.subtypes) : type.priv.subtypes;
-        subtypes.forEach((subtype, index) => {
-            callback(subtype, index, subtypes);
-        });
+        for (let i = 0; i < subtypes.length; i++) {
+            callback(subtypes[i], i, subtypes);
+        }
     } else {
-        callback(type, 0, [type]);
+        // Reuse a single-element array to avoid per-call allocation.
+        _singletonSubtypeArray[0] = type;
+        callback(type, 0, _singletonSubtypeArray);
     }
 }
 
 export function someSubtypes(type: Type, callback: (type: Type) => boolean): boolean {
     if (isUnion(type)) {
-        return type.priv.subtypes.some((subtype) => {
-            return callback(subtype);
-        });
+        const subtypes = type.priv.subtypes;
+        for (let i = 0; i < subtypes.length; i++) {
+            if (callback(subtypes[i])) {
+                return true;
+            }
+        }
+        return false;
     } else {
         return callback(type);
     }
@@ -795,9 +805,13 @@ export function someSubtypes(type: Type, callback: (type: Type) => boolean): boo
 
 export function allSubtypes(type: Type, callback: (type: Type) => boolean): boolean {
     if (isUnion(type)) {
-        return type.priv.subtypes.every((subtype) => {
-            callback(subtype);
-        });
+        const subtypes = type.priv.subtypes;
+        for (let i = 0; i < subtypes.length; i++) {
+            if (!callback(subtypes[i])) {
+                return false;
+            }
+        }
+        return true;
     } else {
         return callback(type);
     }
@@ -810,9 +824,10 @@ export function doForEachSignature(
     if (isFunction(type)) {
         callback(type, 0);
     } else {
-        OverloadedType.getOverloads(type).forEach((overload, index) => {
-            callback(overload, index);
-        });
+        const overloads = OverloadedType.getOverloads(type);
+        for (let i = 0; i < overloads.length; i++) {
+            callback(overloads[i], i);
+        }
     }
 }
 

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1134,6 +1134,21 @@ export function getTypeVarScopeIds(type: Type): TypeVarScopeId[] {
     return scopeIds;
 }
 
+// Checks whether the type has a specific scope ID without allocating an array.
+// This is an optimized alternative to `getTypeVarScopeIds(type).some(id => id === targetId)`.
+export function hasTypeVarScopeId(type: Type, targetId: TypeVarScopeId | undefined): boolean {
+    if (targetId === undefined) {
+        return false;
+    }
+    if (getTypeVarScopeId(type) === targetId) {
+        return true;
+    }
+    if (isFunction(type) && type.priv.constructorTypeVarScopeId === targetId) {
+        return true;
+    }
+    return false;
+}
+
 // Specializes the class with "Unknown" type args (or the equivalent for ParamSpecs
 // or TypeVarTuples).
 export function specializeWithUnknownTypeArgs(type: ClassType, tupleClassType?: ClassType): ClassType {

--- a/packages/pyright-internal/src/analyzer/typeWalker.ts
+++ b/packages/pyright-internal/src/analyzer/typeWalker.ts
@@ -173,7 +173,15 @@ export class TypeWalker {
 
     visitClass(type: ClassType): void {
         if (!ClassType.isPseudoGenericClass(type)) {
-            const typeArgs = type.priv.tupleTypeArgs?.map((t) => t.type) || type.priv.typeArgs;
+            let typeArgs: Type[] | undefined;
+            if (type.priv.tupleTypeArgs) {
+                typeArgs = [];
+                for (const t of type.priv.tupleTypeArgs) {
+                    typeArgs.push(t.type);
+                }
+            } else {
+                typeArgs = type.priv.typeArgs;
+            }
             if (typeArgs) {
                 for (const argType of typeArgs) {
                     this.walk(argType);

--- a/packages/pyright-internal/src/analyzer/typedDicts.ts
+++ b/packages/pyright-internal/src/analyzer/typedDicts.ts
@@ -103,7 +103,11 @@ export function createTypedDictType(
                 argList[0].valueExpression || errorNode
             );
         } else {
-            className = nameArg.valueExpression.d.strings.map((s) => s.d.value).join('');
+            let joined = '';
+            for (const s of nameArg.valueExpression.d.strings) {
+                joined += s.d.value;
+            }
+            className = joined;
         }
     }
 
@@ -997,7 +1001,10 @@ function getTypedDictFieldsFromDictSyntax(
             continue;
         }
 
-        const entryName = entry.d.keyExpr.d.strings.map((s) => s.d.value).join('');
+        let entryName = '';
+        for (const s of entry.d.keyExpr.d.strings) {
+            entryName += s.d.value;
+        }
         if (!entryName) {
             evaluator.addDiagnostic(
                 DiagnosticRule.reportGeneralTypeIssues,

--- a/packages/pyright-internal/src/analyzer/typedDicts.ts
+++ b/packages/pyright-internal/src/analyzer/typedDicts.ts
@@ -367,7 +367,7 @@ export function synthesizeTypedDictClassMethods(
         FunctionType.addKeywordOnlyParamSeparator(initOverride2);
     }
 
-    entries.knownItems.forEach((entry, name) => {
+    for (const [name, entry] of entries.knownItems) {
         FunctionType.addParam(
             initOverride1,
             FunctionParam.create(
@@ -393,7 +393,7 @@ export function synthesizeTypedDictClassMethods(
         if (!entry.isReadOnly) {
             allEntriesAreReadOnly = false;
         }
-    });
+    }
 
     if (entries.extraItems && !isNever(entries.extraItems.valueType)) {
         FunctionType.addParam(
@@ -605,7 +605,7 @@ export function synthesizeTypedDictClassMethods(
             const tuplesToCombine: Type[] = [];
             const tupleClass = evaluator.getBuiltInType(node, 'tuple');
 
-            entries.knownItems.forEach((entry, name) => {
+            for (const [name, entry] of entries.knownItems) {
                 if (!entry.isReadOnly) {
                     // For writable entries, add a tuple entry.
                     if (tupleClass && isInstantiableClass(tupleClass) && strClass && isInstantiableClass(strClass)) {
@@ -632,7 +632,7 @@ export function synthesizeTypedDictClassMethods(
                         )
                     );
                 }
-            });
+            }
 
             const iterableClass = evaluator.getTypingType(node, 'Iterable');
             if (iterableClass && isInstantiableClass(iterableClass)) {
@@ -663,7 +663,7 @@ export function synthesizeTypedDictClassMethods(
         const popOverloads: FunctionType[] = [];
         const setDefaultOverloads: FunctionType[] = [];
 
-        entries.knownItems.forEach((entry, name) => {
+        for (const [name, entry] of entries.knownItems) {
             const nameLiteralType = ClassType.cloneAsInstance(ClassType.cloneWithLiteral(strClass, name));
 
             getOverloads.push(
@@ -688,7 +688,7 @@ export function synthesizeTypedDictClassMethods(
             if (!entry.isReadOnly) {
                 setDefaultOverloads.push(createSetDefaultMethod(nameLiteralType, entry.valueType));
             }
-        });
+        }
 
         const strType = ClassType.cloneAsInstance(strClass);
 
@@ -786,12 +786,14 @@ export function synthesizeTypedDictClassMethods(
             // If we know that there can be no more items, we can provide
             // a more accurate key type consisting of all known keys.
             if (entries.extraItems && isNever(entries.extraItems.valueType)) {
-                keyValueType = combineTypes(
-                    Array.from(entries.knownItems.keys()).map((key) => ClassType.cloneWithLiteral(strType, key))
-                );
+                const keyTypes: Type[] = [];
+                for (const key of entries.knownItems.keys()) {
+                    keyTypes.push(ClassType.cloneWithLiteral(strType, key));
+                }
+                keyValueType = combineTypes(keyTypes);
             }
 
-            ['items', 'keys', 'values'].forEach((methodName) => {
+            for (const methodName of ['items', 'keys', 'values']) {
                 const method = FunctionType.createSynthesizedInstance(methodName);
                 FunctionType.addParam(method, selfParam);
 
@@ -808,7 +810,7 @@ export function synthesizeTypedDictClassMethods(
 
                     symbolTable.set(methodName, Symbol.createWithType(SymbolFlags.ClassMember, method));
                 }
-            });
+            }
         }
     }
 }
@@ -843,7 +845,7 @@ export function getTypedDictMembersForClass(
 
     // Create a specialized copy of the entries so the caller can mutate them.
     const entries = new Map<string, TypedDictEntry>();
-    classType.shared.typedDictEntries!.knownItems.forEach((value, key) => {
+    for (const [key, value] of classType.shared.typedDictEntries!.knownItems) {
         const tdEntry = { ...value };
         tdEntry.valueType = applySolvedTypeVars(tdEntry.valueType, solution);
 
@@ -860,15 +862,15 @@ export function getTypedDictMembersForClass(
         }
 
         entries.set(key, tdEntry);
-    });
+    }
 
     // Apply narrowed types on top of existing entries if present.
     if (allowNarrowed && classType.priv.typedDictNarrowedEntries) {
-        classType.priv.typedDictNarrowedEntries.forEach((value, key) => {
+        for (const [key, value] of classType.priv.typedDictNarrowedEntries) {
             const tdEntry = { ...value };
             tdEntry.valueType = applySolvedTypeVars(tdEntry.valueType, solution);
             entries.set(key, tdEntry);
-        });
+        }
     }
 
     let extraItems = classType.shared.typedDictEntries?.extraItems;
@@ -896,9 +898,9 @@ export function getTypedDictMappingEquivalent(evaluator: TypeEvaluator, classTyp
     const entries = getTypedDictMembersForClass(evaluator, classType);
     const typesToCombine: Type[] = [];
 
-    entries.knownItems.forEach((entry) => {
+    for (const [, entry] of entries.knownItems) {
         typesToCombine.push(entry.valueType);
-    });
+    }
 
     if (entries.extraItems) {
         typesToCombine.push(entries.extraItems.valueType);
@@ -939,7 +941,7 @@ export function getTypedDictDictEquivalent(
     let dictValueType = entries.extraItems.valueType;
 
     let isEquivalentToDict = true;
-    entries.knownItems.forEach((entry) => {
+    for (const [, entry] of entries.knownItems) {
         if (entry.isReadOnly || entry.isRequired) {
             isEquivalentToDict = false;
         }
@@ -958,7 +960,7 @@ export function getTypedDictDictEquivalent(
         ) {
             isEquivalentToDict = false;
         }
-    });
+    }
 
     if (!isEquivalentToDict) {
         return undefined;
@@ -976,14 +978,14 @@ function getTypedDictFieldsFromDictSyntax(
     const entrySet = new Set<string>();
     const fileInfo = AnalyzerNodeInfo.getFileInfo(entryDict);
 
-    entryDict.d.items.forEach((entry) => {
+    for (const entry of entryDict.d.items) {
         if (entry.nodeType !== ParseNodeType.DictionaryKeyEntry) {
             evaluator.addDiagnostic(
                 DiagnosticRule.reportGeneralTypeIssues,
                 LocMessage.typedDictSecondArgDictEntry(),
                 entry
             );
-            return;
+            continue;
         }
 
         if (entry.d.keyExpr.nodeType !== ParseNodeType.StringList) {
@@ -992,7 +994,7 @@ function getTypedDictFieldsFromDictSyntax(
                 LocMessage.typedDictEntryName(),
                 entry.d.keyExpr
             );
-            return;
+            continue;
         }
 
         const entryName = entry.d.keyExpr.d.strings.map((s) => s.d.value).join('');
@@ -1002,7 +1004,7 @@ function getTypedDictFieldsFromDictSyntax(
                 LocMessage.typedDictEmptyName(),
                 entry.d.keyExpr
             );
-            return;
+            continue;
         }
 
         if (entrySet.has(entryName)) {
@@ -1011,7 +1013,7 @@ function getTypedDictFieldsFromDictSyntax(
                 LocMessage.typedDictEntryUnique(),
                 entry.d.keyExpr
             );
-            return;
+            continue;
         }
 
         // Record names in a set to detect duplicates.
@@ -1032,7 +1034,7 @@ function getTypedDictFieldsFromDictSyntax(
         newSymbol.addDeclaration(declaration);
 
         classFields.set(entryName, newSymbol);
-    });
+    }
 
     // Set the type in the type cache for the dict node so it doesn't
     // get evaluated again.
@@ -1051,7 +1053,7 @@ function getTypedDictMembersForClassRecursive(
     }
     recursionCount++;
 
-    classType.shared.baseClasses.forEach((baseClassType) => {
+    for (const baseClassType of classType.shared.baseClasses) {
         if (isInstantiableClass(baseClassType) && ClassType.isTypedDictClass(baseClassType)) {
             const specializedBaseClassType = partiallySpecializeType(
                 baseClassType,
@@ -1064,7 +1066,7 @@ function getTypedDictMembersForClassRecursive(
             // in these cases because they will be reported within that class.
             getTypedDictMembersForClassRecursive(evaluator, specializedBaseClassType, entries, recursionCount);
         }
-    });
+    }
 
     const solution = buildSolutionFromSpecializedClass(classType);
 
@@ -1090,7 +1092,7 @@ function getTypedDictMembersForClassRecursive(
     }
 
     // Add any new typed dict entries from this class.
-    ClassType.getSymbolTable(classType).forEach((symbol, name) => {
+    for (const [name, symbol] of ClassType.getSymbolTable(classType)) {
         if (!symbol.isIgnoredForProtocolMatch()) {
             // Only variables (not functions, classes, etc.) are considered.
             const lastDecl = getLastTypedDeclarationForSymbol(symbol);
@@ -1122,7 +1124,7 @@ function getTypedDictMembersForClassRecursive(
                 entries.knownItems.set(name, tdEntry);
             }
         }
-    });
+    }
 }
 
 export function getEffectiveExtraItemsEntryType(evaluator: TypeEvaluator, classType: ClassType): TypedDictEntry {
@@ -1165,11 +1167,11 @@ export function assignTypedDictToTypedDict(
     const srcEntries = getTypedDictMembersForClass(evaluator, srcType, /* allowNarrowed */ true);
     const extraSrcEntries = srcEntries.extraItems ?? getEffectiveExtraItemsEntryType(evaluator, srcType);
 
-    destEntries.knownItems.forEach((destEntry, name) => {
+    for (const [name, destEntry] of destEntries.knownItems) {
         // If we've already determined that the types are inconsistent and
         // the caller isn't interested in detailed diagnostics, skip the remainder.
         if (!typesAreConsistent && !diag) {
-            return;
+            continue;
         }
 
         const srcEntry = srcEntries.knownItems.get(name);
@@ -1240,7 +1242,7 @@ export function assignTypedDictToTypedDict(
                 typesAreConsistent = false;
             }
         }
-    });
+    }
 
     // If the types are not consistent and the caller isn't interested
     // in detailed diagnostics, don't do additional work.
@@ -1253,10 +1255,10 @@ export function assignTypedDictToTypedDict(
     if (ClassType.isTypedDictEffectivelyClosed(destType)) {
         const extraDestEntries = destEntries.extraItems ?? getEffectiveExtraItemsEntryType(evaluator, destType);
 
-        srcEntries.knownItems.forEach((srcEntry, name) => {
+        for (const [name, srcEntry] of srcEntries.knownItems) {
             // Have we already checked this item in the loop above?
             if (destEntries.knownItems.has(name)) {
-                return;
+                continue;
             }
 
             if (!destEntries.extraItems) {
@@ -1308,7 +1310,7 @@ export function assignTypedDictToTypedDict(
                     typesAreConsistent = false;
                 }
             }
-        });
+        }
 
         const subDiag = diag?.createAddendum();
         if (
@@ -1376,7 +1378,8 @@ export function assignToTypedDict(
 
     const tdEntries = getTypedDictMembersForClass(evaluator, genericClassType);
 
-    keyTypes.forEach((keyTypeResult, index) => {
+    for (let index = 0; index < keyTypes.length; index++) {
+        const keyTypeResult = keyTypes[index];
         const keyType = keyTypeResult.type;
         if (!isClassInstance(keyType) || !ClassType.isBuiltIn(keyType, 'str') || !isLiteralType(keyType)) {
             isMatch = false;
@@ -1460,14 +1463,14 @@ export function assignToTypedDict(
                 symbolEntry.isProvided = true;
             }
         }
-    });
+    }
 
     if (!isMatch) {
         return undefined;
     }
 
     // See if any required keys are missing.
-    tdEntries.knownItems.forEach((entry, name) => {
+    for (const [name, entry] of tdEntries.knownItems) {
         if (entry.isRequired && !entry.isProvided) {
             if (diagAddendum) {
                 diagAddendum.addMessage(
@@ -1479,7 +1482,7 @@ export function assignToTypedDict(
             }
             isMatch = false;
         }
-    });
+    }
 
     if (!isMatch) {
         return undefined;
@@ -1645,9 +1648,9 @@ export function narrowForKeyAssignment(classType: ClassType, key: string) {
 }
 
 function isRequiredTypedDictVariable(evaluator: TypeEvaluator, symbol: Symbol) {
-    return symbol.getDeclarations().some((decl) => {
+    for (const decl of symbol.getDeclarations()) {
         if (decl.type !== DeclarationType.Variable || !decl.typeAnnotationNode) {
-            return false;
+            continue;
         }
 
         const annotatedType = evaluator.getTypeOfExpressionExpectingType(decl.typeAnnotationNode, {
@@ -1656,14 +1659,17 @@ function isRequiredTypedDictVariable(evaluator: TypeEvaluator, symbol: Symbol) {
             allowReadOnly: true,
         });
 
-        return !!annotatedType.isRequired;
-    });
+        if (annotatedType.isRequired) {
+            return true;
+        }
+    }
+    return false;
 }
 
 function isNotRequiredTypedDictVariable(evaluator: TypeEvaluator, symbol: Symbol) {
-    return symbol.getDeclarations().some((decl) => {
+    for (const decl of symbol.getDeclarations()) {
         if (decl.type !== DeclarationType.Variable || !decl.typeAnnotationNode) {
-            return false;
+            continue;
         }
 
         const annotatedType = evaluator.getTypeOfExpressionExpectingType(decl.typeAnnotationNode, {
@@ -1672,14 +1678,17 @@ function isNotRequiredTypedDictVariable(evaluator: TypeEvaluator, symbol: Symbol
             allowReadOnly: true,
         });
 
-        return !!annotatedType.isNotRequired;
-    });
+        if (annotatedType.isNotRequired) {
+            return true;
+        }
+    }
+    return false;
 }
 
 function isReadOnlyTypedDictVariable(evaluator: TypeEvaluator, symbol: Symbol) {
-    return symbol.getDeclarations().some((decl) => {
+    for (const decl of symbol.getDeclarations()) {
         if (decl.type !== DeclarationType.Variable || !decl.typeAnnotationNode) {
-            return false;
+            continue;
         }
 
         const annotatedType = evaluator.getTypeOfExpressionExpectingType(decl.typeAnnotationNode, {
@@ -1688,6 +1697,9 @@ function isReadOnlyTypedDictVariable(evaluator: TypeEvaluator, symbol: Symbol) {
             allowReadOnly: true,
         });
 
-        return !!annotatedType.isReadOnly;
-    });
+        if (annotatedType.isReadOnly) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -131,6 +131,8 @@ export interface TypeSameOptions {
 }
 
 const _defaultTypeSameOptions: TypeSameOptions = {};
+const _honorTypeFormOptions: TypeSameOptions = { honorTypeForm: true };
+const _honorTypeFormPseudoGenericOptions: TypeSameOptions = { ignorePseudoGeneric: true, honorTypeForm: true };
 
 export interface TypeAliasSharedInfo {
     name: string;
@@ -3831,7 +3833,7 @@ export function combineTypes(subtypes: Type[], options?: CombineTypesOptions): T
 
     // Expand all union types.
     let expandedTypes: Type[] | undefined;
-    const typeAliasSources = new Set<UnionType>();
+    let typeAliasSources: Set<UnionType> | undefined;
 
     for (let i = 0; i < subtypes.length; i++) {
         const subtype = subtypes[i];
@@ -3842,10 +3844,10 @@ export function combineTypes(subtypes: Type[], options?: CombineTypesOptions): T
             expandedTypes = expandedTypes.concat(subtype.priv.subtypes);
 
             if (subtype.props?.typeAliasInfo) {
-                typeAliasSources.add(subtype);
+                (typeAliasSources ??= new Set<UnionType>()).add(subtype);
             } else if (subtype.priv.typeAliasSources) {
                 subtype.priv.typeAliasSources.forEach((subtype) => {
-                    typeAliasSources.add(subtype);
+                    (typeAliasSources ??= new Set<UnionType>()).add(subtype);
                 });
             }
         } else if (expandedTypes) {
@@ -3867,7 +3869,7 @@ export function combineTypes(subtypes: Type[], options?: CombineTypesOptions): T
     }
 
     const newUnionType = UnionType.create();
-    if (typeAliasSources.size > 0) {
+    if (typeAliasSources && typeAliasSources.size > 0) {
         newUnionType.priv.typeAliasSources = typeAliasSources;
     }
 
@@ -3991,7 +3993,7 @@ function _addTypeIfUnique(unionType: UnionType, typeToAdd: UnionableType, elideR
         const type = unionType.priv.subtypes[i];
 
         // Does this type already exist in the types array?
-        if (isTypeSame(type, typeToAdd, { honorTypeForm: true })) {
+        if (isTypeSame(type, typeToAdd, _honorTypeFormOptions)) {
             return;
         }
 
@@ -4002,7 +4004,7 @@ function _addTypeIfUnique(unionType: UnionType, typeToAdd: UnionableType, elideR
         // we can hit recursive cases (where a pseudo-generic class is
         // parameterized with its own class) ad infinitum.
         if (isPseudoGeneric) {
-            if (isTypeSame(type, typeToAdd, { ignorePseudoGeneric: true, honorTypeForm: true })) {
+            if (isTypeSame(type, typeToAdd, _honorTypeFormPseudoGenericOptions)) {
                 unionType.priv.subtypes[i] = ClassType.specialize(
                     typeToAdd,
                     typeToAdd.shared.typeParams.map(() => UnknownType.create())

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -7,7 +7,6 @@
  * Representation of types used during type analysis within Python.
  */
 
-import { partition } from '../common/collectionUtils';
 import { assert } from '../common/debug';
 import { Uri } from '../common/uri/uri';
 import { ArgumentNode, ExpressionNode, NameNode, ParamCategory, TypeAnnotationNode } from '../parser/parseNodes';
@@ -3742,18 +3741,43 @@ export interface CombineTypesOptions {
 // are combined into a UnionType. NeverTypes are filtered out.
 // If no types remain in the end, a NeverType is returned.
 export function combineTypes(subtypes: Type[], options?: CombineTypesOptions): Type {
-    let neverTypes: NeverType[];
-
-    // Filter out any Never or NoReturn types.
-    [neverTypes, subtypes] = partition<Type, NeverType>(subtypes, isNever);
-
-    if (subtypes.length === 0) {
-        if (neverTypes.length > 0) {
-            // Prefer NoReturn over Never. This approach preserves type alias
-            // information if present.
-            return neverTypes.find((t) => t.priv.isNoReturn) ?? neverTypes[0];
+    // Fast path: check if any Never types exist before allocating partition arrays.
+    let hasNever = false;
+    for (let i = 0; i < subtypes.length; i++) {
+        if (isNever(subtypes[i])) {
+            hasNever = true;
+            break;
         }
+    }
 
+    if (hasNever) {
+        // Slow path: separate Never types from non-Never. Only allocates when needed.
+        const neverTypes: NeverType[] = [];
+        const filtered: Type[] = [];
+        for (let i = 0; i < subtypes.length; i++) {
+            if (isNever(subtypes[i])) {
+                neverTypes.push(subtypes[i] as NeverType);
+            } else {
+                filtered.push(subtypes[i]);
+            }
+        }
+        subtypes = filtered;
+
+        if (subtypes.length === 0) {
+            if (neverTypes.length > 0) {
+                // Prefer NoReturn over Never. This approach preserves type alias
+                // information if present.
+                for (let i = 0; i < neverTypes.length; i++) {
+                    if (neverTypes[i].priv.isNoReturn) {
+                        return neverTypes[i];
+                    }
+                }
+                return neverTypes[0];
+            }
+
+            return NeverType.createNever();
+        }
+    } else if (subtypes.length === 0) {
         return NeverType.createNever();
     }
 
@@ -3799,24 +3823,10 @@ export function combineTypes(subtypes: Type[], options?: CombineTypesOptions): T
 
     expandedTypes = expandedTypes ?? subtypes;
 
-    // Sort all of the literal and empty types to the end.
-    expandedTypes = expandedTypes.sort((type1, type2) => {
-        if (isClass(type1) && type1.priv.literalValue !== undefined) {
-            return 1;
-        }
-
-        if (isClass(type2) && type2.priv.literalValue !== undefined) {
-            return -1;
-        }
-
-        if (isClassInstance(type1) && type1.priv.isEmptyContainer) {
-            return 1;
-        } else if (isClassInstance(type2) && type2.priv.isEmptyContainer) {
-            return -1;
-        }
-
-        return 0;
-    });
+    // Partition: move literal and empty-container types to end (O(n) vs O(n log n) sort).
+    // We need non-literal types first so _addTypeIfUnique can properly elide
+    // redundant literals.
+    _partitionLiteralsToEnd(expandedTypes);
 
     // If removing all NoReturn types results in no remaining types,
     // convert it to an unknown.
@@ -3830,18 +3840,20 @@ export function combineTypes(subtypes: Type[], options?: CombineTypesOptions): T
     }
 
     let hitMaxSubtypeCount = false;
+    const maxSubtypeCount = options?.maxSubtypeCount;
+    const elideRedundantLiterals = !options?.skipElideRedundantLiterals;
 
-    expandedTypes.forEach((subtype, index) => {
-        if (index === 0) {
-            UnionType.addType(newUnionType, subtype as UnionableType);
+    for (let i = 0; i < expandedTypes.length; i++) {
+        if (i === 0) {
+            UnionType.addType(newUnionType, expandedTypes[i] as UnionableType);
         } else {
-            if (options?.maxSubtypeCount === undefined || newUnionType.priv.subtypes.length < options.maxSubtypeCount) {
-                _addTypeIfUnique(newUnionType, subtype as UnionableType, !options?.skipElideRedundantLiterals);
+            if (maxSubtypeCount === undefined || newUnionType.priv.subtypes.length < maxSubtypeCount) {
+                _addTypeIfUnique(newUnionType, expandedTypes[i] as UnionableType, elideRedundantLiterals);
             } else {
                 hitMaxSubtypeCount = true;
             }
         }
-    });
+    }
 
     if (hitMaxSubtypeCount) {
         return AnyType.create();
@@ -3853,6 +3865,46 @@ export function combineTypes(subtypes: Type[], options?: CombineTypesOptions): T
     }
 
     return newUnionType;
+}
+
+// In-place partition: move non-literal/non-empty types to front,
+// literals and empty containers to end. Preserves relative order
+// within each group (stable partition).
+function _partitionLiteralsToEnd(types: Type[]): void {
+    // Count non-trailing types to decide if partitioning is needed.
+    let hasTrailing = false;
+    for (let i = 0; i < types.length; i++) {
+        const t = types[i];
+        if ((isClass(t) && t.priv.literalValue !== undefined) || (isClassInstance(t) && t.priv.isEmptyContainer)) {
+            hasTrailing = true;
+            break;
+        }
+    }
+
+    if (!hasTrailing) {
+        return;
+    }
+
+    // Stable partition: collect non-trailing first, then trailing.
+    const front: Type[] = [];
+    const back: Type[] = [];
+    for (let i = 0; i < types.length; i++) {
+        const t = types[i];
+        if ((isClass(t) && t.priv.literalValue !== undefined) || (isClassInstance(t) && t.priv.isEmptyContainer)) {
+            back.push(t);
+        } else {
+            front.push(t);
+        }
+    }
+
+    // Write back in-place.
+    let idx = 0;
+    for (let i = 0; i < front.length; i++) {
+        types[idx++] = front[i];
+    }
+    for (let i = 0; i < back.length; i++) {
+        types[idx++] = back[i];
+    }
 }
 
 // Determines whether the dest type is the same as the source type with

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -130,6 +130,8 @@ export interface TypeSameOptions {
     treatAnySameAsUnknown?: boolean;
 }
 
+const _defaultTypeSameOptions: TypeSameOptions = {};
+
 export interface TypeAliasSharedInfo {
     name: string;
     fullName: string;
@@ -3181,7 +3183,13 @@ export function isAnyOrUnknown(type: Type): type is AnyType | UnknownType {
     }
 
     if (isUnion(type)) {
-        return type.priv.subtypes.find((subtype) => !isAnyOrUnknown(subtype)) === undefined;
+        const subtypes = type.priv.subtypes;
+        for (let i = 0; i < subtypes.length; i++) {
+            if (!isAnyOrUnknown(subtypes[i])) {
+                return false;
+            }
+        }
+        return true;
     }
 
     return false;
@@ -3201,7 +3209,13 @@ export function isPossiblyUnbound(type: Type): boolean {
     }
 
     if (isUnion(type)) {
-        return type.priv.subtypes.find((subtype) => isPossiblyUnbound(subtype)) !== undefined;
+        const subtypes = type.priv.subtypes;
+        for (let i = 0; i < subtypes.length; i++) {
+            if (isPossiblyUnbound(subtypes[i])) {
+                return true;
+            }
+        }
+        return false;
     }
 
     return false;
@@ -3313,7 +3327,12 @@ export function getTypeAliasInfo(type: Type) {
 // Determines whether two types are the same. If ignorePseudoGeneric is true,
 // type arguments for "pseudo-generic" classes (non-generic classes whose init
 // methods are not annotated and are therefore treated as generic) are ignored.
-export function isTypeSame(type1: Type, type2: Type, options: TypeSameOptions = {}, recursionCount = 0): boolean {
+export function isTypeSame(
+    type1: Type,
+    type2: Type,
+    options: TypeSameOptions = _defaultTypeSameOptions,
+    recursionCount = 0
+): boolean {
     if (type1 === type2) {
         return true;
     }
@@ -3359,6 +3378,9 @@ export function isTypeSame(type1: Type, type2: Type, options: TypeSameOptions = 
         }
     }
 
+    // Pre-compute options with ignoreTypeFlags forced to false (used in many branches).
+    const typeArgOptions = options.ignoreTypeFlags ? { ...options, ignoreTypeFlags: false } : options;
+
     switch (type1.category) {
         case TypeCategory.Class: {
             const classType2 = type2 as ClassType;
@@ -3386,7 +3408,7 @@ export function isTypeSame(type1: Type, type2: Type, options: TypeSameOptions = 
                             !isTypeSame(
                                 type1TupleTypeArgs[i].type,
                                 type2TupleTypeArgs[i].type,
-                                { ...options, ignoreTypeFlags: false },
+                                typeArgOptions,
                                 recursionCount
                             )
                         ) {
@@ -3407,7 +3429,7 @@ export function isTypeSame(type1: Type, type2: Type, options: TypeSameOptions = 
                         const typeArg1 = i < type1TypeArgs.length ? type1TypeArgs[i] : UnknownType.create();
                         const typeArg2 = i < type2TypeArgs.length ? type2TypeArgs[i] : UnknownType.create();
 
-                        if (!isTypeSame(typeArg1, typeArg2, { ...options, ignoreTypeFlags: false }, recursionCount)) {
+                        if (!isTypeSame(typeArg1, typeArg2, typeArgOptions, recursionCount)) {
                             return false;
                         }
                     }
@@ -3485,7 +3507,7 @@ export function isTypeSame(type1: Type, type2: Type, options: TypeSameOptions = 
 
                 const param1Type = FunctionType.getParamType(type1, i);
                 const param2Type = FunctionType.getParamType(functionType2, i);
-                if (!isTypeSame(param1Type, param2Type, { ...options, ignoreTypeFlags: false }, recursionCount)) {
+                if (!isTypeSame(param1Type, param2Type, typeArgOptions, recursionCount)) {
                     return false;
                 }
             }
@@ -3511,7 +3533,7 @@ export function isTypeSame(type1: Type, type2: Type, options: TypeSameOptions = 
                 if (
                     !return1Type ||
                     !return2Type ||
-                    !isTypeSame(return1Type, return2Type, { ...options, ignoreTypeFlags: false }, recursionCount)
+                    !isTypeSame(return1Type, return2Type, typeArgOptions, recursionCount)
                 ) {
                     return false;
                 }
@@ -3581,7 +3603,7 @@ export function isTypeSame(type1: Type, type2: Type, options: TypeSameOptions = 
                     const typeArg1 = i < type1TypeArgs.length ? type1TypeArgs[i] : AnyType.create();
                     const typeArg2 = i < type2TypeArgs.length ? type2TypeArgs[i] : AnyType.create();
 
-                    if (!isTypeSame(typeArg1, typeArg2, { ...options, ignoreTypeFlags: false }, recursionCount)) {
+                    if (!isTypeSame(typeArg1, typeArg2, typeArgOptions, recursionCount)) {
                         return false;
                     }
                 }
@@ -3617,10 +3639,7 @@ export function isTypeSame(type1: Type, type2: Type, options: TypeSameOptions = 
             const boundType1 = type1.shared.boundType;
             const boundType2 = type2TypeVar.shared.boundType;
             if (boundType1) {
-                if (
-                    !boundType2 ||
-                    !isTypeSame(boundType1, boundType2, { ...options, ignoreTypeFlags: false }, recursionCount)
-                ) {
+                if (!boundType2 || !isTypeSame(boundType1, boundType2, typeArgOptions, recursionCount)) {
                     return false;
                 }
             } else {
@@ -3636,14 +3655,7 @@ export function isTypeSame(type1: Type, type2: Type, options: TypeSameOptions = 
             }
 
             for (let i = 0; i < constraints1.length; i++) {
-                if (
-                    !isTypeSame(
-                        constraints1[i],
-                        constraints2[i],
-                        { ...options, ignoreTypeFlags: false },
-                        recursionCount
-                    )
-                ) {
+                if (!isTypeSame(constraints1[i], constraints2[i], typeArgOptions, recursionCount)) {
                     return false;
                 }
             }
@@ -3701,8 +3713,24 @@ export function removeUnbound(type: Type): Type {
 
 export function removeFromUnion(type: Type, removeFilter: (type: Type) => boolean) {
     if (isUnion(type)) {
-        const remainingTypes = type.priv.subtypes.filter((t) => !removeFilter(t));
-        if (remainingTypes.length < type.priv.subtypes.length) {
+        const subtypes = type.priv.subtypes;
+
+        // Fast check: see if any subtypes need removal before allocating.
+        let hasRemoval = false;
+        for (let i = 0; i < subtypes.length; i++) {
+            if (removeFilter(subtypes[i])) {
+                hasRemoval = true;
+                break;
+            }
+        }
+
+        if (hasRemoval) {
+            const remainingTypes: Type[] = [];
+            for (let i = 0; i < subtypes.length; i++) {
+                if (!removeFilter(subtypes[i])) {
+                    remainingTypes.push(subtypes[i]);
+                }
+            }
             const newType = combineTypes(remainingTypes);
 
             if (isUnion(newType)) {
@@ -3718,9 +3746,13 @@ export function removeFromUnion(type: Type, removeFilter: (type: Type) => boolea
 
 export function findSubtype(type: Type, filter: (type: UnionableType | NeverType) => boolean) {
     if (isUnion(type)) {
-        return type.priv.subtypes.find((subtype) => {
-            return filter(subtype);
-        });
+        const subtypes = type.priv.subtypes;
+        for (let i = 0; i < subtypes.length; i++) {
+            if (filter(subtypes[i])) {
+                return subtypes[i];
+            }
+        }
+        return undefined;
     }
 
     return filter(type) ? type : undefined;

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -133,6 +133,8 @@ export interface TypeSameOptions {
 const _defaultTypeSameOptions: TypeSameOptions = {};
 const _honorTypeFormOptions: TypeSameOptions = { honorTypeForm: true };
 const _honorTypeFormPseudoGenericOptions: TypeSameOptions = { ignorePseudoGeneric: true, honorTypeForm: true };
+const _ignoreConditionsOptions: TypeSameOptions = { ignoreConditions: true };
+const _skipElideRedundantLiteralsOptions: CombineTypesOptions = { skipElideRedundantLiterals: true };
 
 export interface TypeAliasSharedInfo {
     name: string;
@@ -2681,7 +2683,7 @@ export namespace UnionType {
     export function containsType(
         unionType: UnionType,
         subtype: Type,
-        options: TypeSameOptions = {},
+        options: TypeSameOptions = _defaultTypeSameOptions,
         exclusionSet?: Set<number>,
         recursionCount = 0
     ): boolean {
@@ -2702,20 +2704,19 @@ export namespace UnionType {
             }
         }
 
-        const foundIndex = unionType.priv.subtypes.findIndex((t, i) => {
+        const subtypes = unionType.priv.subtypes;
+        for (let i = 0; i < subtypes.length; i++) {
             if (exclusionSet?.has(i)) {
-                return false;
+                continue;
             }
 
-            return isTypeSame(t, subtype, options, recursionCount);
-        });
-
-        if (foundIndex < 0) {
-            return false;
+            if (isTypeSame(subtypes[i], subtype, options, recursionCount)) {
+                exclusionSet?.add(i);
+                return true;
+            }
         }
 
-        exclusionSet?.add(foundIndex);
-        return true;
+        return false;
     }
 
     export function addTypeAliasSource(unionType: UnionType, typeAliasSource: Type) {
@@ -3941,7 +3942,7 @@ export function isSameWithoutLiteralValue(destType: Type, srcType: Type): boolea
     if (isClassInstance(srcType) && srcType.priv.literalValue !== undefined) {
         // Strip the literal.
         srcType = ClassType.cloneWithLiteral(srcType, /* value */ undefined);
-        return isTypeSame(destType, srcType, { ignoreConditions: true });
+        return isTypeSame(destType, srcType, _ignoreConditionsOptions);
     }
 
     return false;

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -3867,43 +3867,25 @@ export function combineTypes(subtypes: Type[], options?: CombineTypesOptions): T
     return newUnionType;
 }
 
-// In-place partition: move non-literal/non-empty types to front,
+// In-place stable partition: move non-literal/non-empty types to front,
 // literals and empty containers to end. Preserves relative order
-// within each group (stable partition).
+// within each group. Uses O(1) extra space.
 function _partitionLiteralsToEnd(types: Type[]): void {
-    // Count non-trailing types to decide if partitioning is needed.
-    let hasTrailing = false;
+    let writePos = 0;
+
     for (let i = 0; i < types.length; i++) {
         const t = types[i];
-        if ((isClass(t) && t.priv.literalValue !== undefined) || (isClassInstance(t) && t.priv.isEmptyContainer)) {
-            hasTrailing = true;
-            break;
+        if (!((isClass(t) && t.priv.literalValue !== undefined) || (isClassInstance(t) && t.priv.isEmptyContainer))) {
+            // This is a "front" item — shift it to writePos.
+            if (i !== writePos) {
+                const frontItem = types[i];
+                for (let j = i; j > writePos; j--) {
+                    types[j] = types[j - 1];
+                }
+                types[writePos] = frontItem;
+            }
+            writePos++;
         }
-    }
-
-    if (!hasTrailing) {
-        return;
-    }
-
-    // Stable partition: collect non-trailing first, then trailing.
-    const front: Type[] = [];
-    const back: Type[] = [];
-    for (let i = 0; i < types.length; i++) {
-        const t = types[i];
-        if ((isClass(t) && t.priv.literalValue !== undefined) || (isClassInstance(t) && t.priv.isEmptyContainer)) {
-            back.push(t);
-        } else {
-            front.push(t);
-        }
-    }
-
-    // Write back in-place.
-    let idx = 0;
-    for (let i = 0; i < front.length; i++) {
-        types[idx++] = front[i];
-    }
-    for (let i = 0; i < back.length; i++) {
-        types[idx++] = back[i];
     }
 }
 

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -1952,7 +1952,7 @@ export namespace FunctionType {
         // Update the specialized parameter types as well.
         const specializedTypes = newFunction.priv.specializedTypes;
         if (specializedTypes) {
-            paramSpecValue.shared.parameters.forEach((_, index) => {
+            for (let index = 0; index < paramSpecValue.shared.parameters.length; index++) {
                 specializedTypes.parameterTypes.push(FunctionType.getParamType(paramSpecValue, index));
 
                 if (specializedTypes.parameterDefaultTypes) {
@@ -1960,7 +1960,7 @@ export namespace FunctionType {
                         FunctionType.getParamDefaultType(paramSpecValue, index)
                     );
                 }
-            });
+            }
         }
 
         newFunction.priv.constructorTypeVarScopeId = paramSpecValue.priv.constructorTypeVarScopeId;
@@ -2138,9 +2138,9 @@ export namespace FunctionType {
     }
 
     export function addDefaultParams(type: FunctionType, useUnknown = false) {
-        getDefaultParams(useUnknown).forEach((param) => {
+        for (const param of getDefaultParams(useUnknown)) {
             FunctionType.addParam(type, param);
-        });
+        }
     }
 
     export function getDefaultParams(useUnknown = false): FunctionParam[] {
@@ -2373,9 +2373,9 @@ export namespace OverloadedType {
             },
         };
 
-        overloads.forEach((overload) => {
+        for (const overload of overloads) {
             OverloadedType.addOverload(newType, overload);
-        });
+        }
 
         if (implementation && isFunction(implementation)) {
             implementation.priv.overloaded = newType;
@@ -2517,11 +2517,11 @@ export namespace TypeCondition {
 
         // Deduplicate the lists.
         const combined = Array.from(conditions1);
-        conditions2.forEach((c1) => {
+        for (const c1 of conditions2) {
             if (!combined.some((c2) => _compare(c1, c2) === 0)) {
                 combined.push(c1);
             }
-        });
+        }
 
         // Always keep the conditions sorted for easier comparison.
         return combined.sort(_compare);
@@ -2730,9 +2730,9 @@ export namespace UnionType {
                     unionType.priv.typeAliasSources = new Set<UnionType>();
                 }
 
-                sourcesToAdd.forEach((source) => {
+                for (const source of sourcesToAdd) {
                     unionType.priv.typeAliasSources!.add(source);
-                });
+                }
             }
         }
     }
@@ -3847,9 +3847,9 @@ export function combineTypes(subtypes: Type[], options?: CombineTypesOptions): T
             if (subtype.props?.typeAliasInfo) {
                 (typeAliasSources ??= new Set<UnionType>()).add(subtype);
             } else if (subtype.priv.typeAliasSources) {
-                subtype.priv.typeAliasSources.forEach((subtype) => {
-                    (typeAliasSources ??= new Set<UnionType>()).add(subtype);
-                });
+                for (const subtype2 of subtype.priv.typeAliasSources) {
+                    (typeAliasSources ??= new Set<UnionType>()).add(subtype2);
+                }
             }
         } else if (expandedTypes) {
             expandedTypes.push(subtype);

--- a/packages/pyright-internal/src/analyzer/types.ts
+++ b/packages/pyright-internal/src/analyzer/types.ts
@@ -134,7 +134,6 @@ const _defaultTypeSameOptions: TypeSameOptions = {};
 const _honorTypeFormOptions: TypeSameOptions = { honorTypeForm: true };
 const _honorTypeFormPseudoGenericOptions: TypeSameOptions = { ignorePseudoGeneric: true, honorTypeForm: true };
 const _ignoreConditionsOptions: TypeSameOptions = { ignoreConditions: true };
-const _skipElideRedundantLiteralsOptions: CombineTypesOptions = { skipElideRedundantLiterals: true };
 
 export interface TypeAliasSharedInfo {
     name: string;

--- a/packages/pyright-internal/src/common/cancellationUtils.ts
+++ b/packages/pyright-internal/src/common/cancellationUtils.ts
@@ -116,7 +116,9 @@ export function setupCombinedTokensFor(source: AbstractCancellationTokenSource, 
 
     disposables.push(
         onCancellationRequested(source.token, () => {
-            disposables.forEach((d) => d.dispose());
+            for (const d of disposables) {
+                d.dispose();
+            }
         })
     );
 }

--- a/packages/pyright-internal/src/common/collectionUtils.ts
+++ b/packages/pyright-internal/src/common/collectionUtils.ts
@@ -385,11 +385,11 @@ export function addIfUnique<T>(arr: T[], t: T, equalityComparer: EqualityCompare
 
 export function getMapValues<K, V>(m: Map<K, V>, predicate: (k: K, v: V) => boolean): V[] {
     const values: V[] = [];
-    m.forEach((v, k) => {
+    for (const [k, v] of m) {
         if (predicate(k, v)) {
             values.push(v);
         }
-    });
+    }
 
     return values;
 }

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -1162,7 +1162,8 @@ export class ConfigOptions {
             } else {
                 this.include = [];
                 const filesList = configObj.include as string[];
-                filesList.forEach((fileSpec, index) => {
+                for (let index = 0; index < filesList.length; index++) {
+                    const fileSpec = filesList[index];
                     if (typeof fileSpec !== 'string') {
                         console.error(`Index ${index} of "include" array should be a string.`);
                     } else if (isAbsolute(fileSpec)) {
@@ -1170,7 +1171,7 @@ export class ConfigOptions {
                     } else {
                         this.include.push(getFileSpec(configDirUri, fileSpec));
                     }
-                });
+                }
             }
         }
 
@@ -1182,7 +1183,8 @@ export class ConfigOptions {
             } else {
                 this.exclude = [];
                 const filesList = configObj.exclude as string[];
-                filesList.forEach((fileSpec, index) => {
+                for (let index = 0; index < filesList.length; index++) {
+                    const fileSpec = filesList[index];
                     if (typeof fileSpec !== 'string') {
                         console.error(`Index ${index} of "exclude" array should be a string.`);
                     } else if (isAbsolute(fileSpec)) {
@@ -1190,7 +1192,7 @@ export class ConfigOptions {
                     } else {
                         this.exclude.push(getFileSpec(configDirUri, fileSpec));
                     }
-                });
+                }
             }
         }
 
@@ -1202,7 +1204,8 @@ export class ConfigOptions {
             } else {
                 this.ignore = [];
                 const filesList = configObj.ignore as string[];
-                filesList.forEach((fileSpec, index) => {
+                for (let index = 0; index < filesList.length; index++) {
+                    const fileSpec = filesList[index];
                     if (typeof fileSpec !== 'string') {
                         console.error(`Index ${index} of "ignore" array should be a string.`);
                     } else {
@@ -1212,7 +1215,7 @@ export class ConfigOptions {
                         // paths when the conf file is used with a language server.
                         this.ignore.push(getFileSpec(configDirUri, fileSpec));
                     }
-                });
+                }
             }
         }
 
@@ -1224,7 +1227,8 @@ export class ConfigOptions {
             } else {
                 this.strict = [];
                 const filesList = configObj.strict as string[];
-                filesList.forEach((fileSpec, index) => {
+                for (let index = 0; index < filesList.length; index++) {
+                    const fileSpec = filesList[index];
                     if (typeof fileSpec !== 'string') {
                         console.error(`Index ${index} of "strict" array should be a string.`);
                     } else if (isAbsolute(fileSpec)) {
@@ -1232,7 +1236,7 @@ export class ConfigOptions {
                     } else {
                         this.strict.push(getFileSpec(configDirUri, fileSpec));
                     }
-                });
+                }
             }
         }
 
@@ -1262,24 +1266,24 @@ export class ConfigOptions {
 
         // Apply overrides from the config file for the boolean rules.
         const configRuleSet = { ...this.diagnosticRuleSet };
-        getBooleanDiagnosticRules(/* includeNonOverridable */ true).forEach((ruleName) => {
+        for (const ruleName of getBooleanDiagnosticRules(/* includeNonOverridable */ true)) {
             unusedConfigKeys.delete(ruleName);
             (configRuleSet as any)[ruleName] = this._convertBoolean(
                 configObj[ruleName],
                 ruleName,
                 configRuleSet[ruleName] as boolean
             );
-        });
+        }
 
         // Apply overrides from the config file for the diagnostic level rules.
-        getDiagLevelDiagnosticRules().forEach((ruleName) => {
+        for (const ruleName of getDiagLevelDiagnosticRules()) {
             unusedConfigKeys.delete(ruleName);
             (configRuleSet as any)[ruleName] = this._convertDiagnosticLevel(
                 configObj[ruleName],
                 ruleName,
                 configRuleSet[ruleName] as DiagnosticLevel
             );
-        });
+        }
         this.diagnosticRuleSet = { ...configRuleSet };
 
         // Read the "venvPath".
@@ -1310,13 +1314,14 @@ export class ConfigOptions {
                 console.error(`Config "extraPaths" field must contain an array.`);
             } else {
                 const pathList = configObj.extraPaths as string[];
-                pathList.forEach((path, pathIndex) => {
+                for (let pathIndex = 0; pathIndex < pathList.length; pathIndex++) {
+                    const path = pathList[pathIndex];
                     if (typeof path !== 'string') {
                         console.error(`Config "extraPaths" field ${pathIndex} must be a string.`);
                     } else {
                         configExtraPaths!.push(configDirUri.resolvePaths(path));
                     }
-                });
+                }
                 this.defaultExtraPaths = [...configExtraPaths];
             }
         }
@@ -1412,7 +1417,7 @@ export class ConfigOptions {
                 console.error(`Config "defineConstant" field must contain a map indexed by constant names.`);
             } else {
                 const keys = Object.getOwnPropertyNames(configObj.defineConstant);
-                keys.forEach((key) => {
+                for (const key of keys) {
                     const value = configObj.defineConstant[key];
                     const valueType = typeof value;
                     if (valueType !== 'boolean' && valueType !== 'string') {
@@ -1420,7 +1425,7 @@ export class ConfigOptions {
                     } else {
                         this.defineConstant.set(key, value);
                     }
-                });
+                }
             }
         }
 
@@ -1492,9 +1497,9 @@ export class ConfigOptions {
         unusedConfigKeys.delete('executionEnvironments');
         unusedConfigKeys.delete('extends');
 
-        Array.from(unusedConfigKeys).forEach((unknownKey) => {
+        for (const unknownKey of Array.from(unusedConfigKeys)) {
             console.error(`Config contains unrecognized setting "${unknownKey}".`);
-        });
+        }
     }
 
     static resolveExtends(configObj: any, configDirUri: Uri): Uri | undefined {
@@ -1599,7 +1604,8 @@ export class ConfigOptions {
 
                 const execEnvironments = configObj.executionEnvironments as ExecutionEnvironment[];
 
-                execEnvironments.forEach((env, index) => {
+                for (let index = 0; index < execEnvironments.length; index++) {
+                    const env = execEnvironments[index];
                     const execEnv = this._initExecutionEnvironmentFromJson(
                         env,
                         configDirUri,
@@ -1614,7 +1620,7 @@ export class ConfigOptions {
                     if (execEnv) {
                         this.executionEnvironments.push(execEnv);
                     }
-                });
+                }
             }
         }
     }
@@ -1693,7 +1699,8 @@ export class ConfigOptions {
                     newExecEnv.extraPaths = [];
 
                     const pathList = envObj.extraPaths as string[];
-                    pathList.forEach((path, pathIndex) => {
+                    for (let pathIndex = 0; pathIndex < pathList.length; pathIndex++) {
+                        const path = pathList[pathIndex];
                         if (typeof path !== 'string') {
                             console.error(
                                 `Config executionEnvironments index ${index}:` +
@@ -1702,7 +1709,7 @@ export class ConfigOptions {
                         } else {
                             newExecEnv.extraPaths.push(configDirUri.resolvePaths(path));
                         }
-                    });
+                    }
                 }
             }
 
@@ -1742,28 +1749,28 @@ export class ConfigOptions {
             }
 
             // Apply overrides from the config file for the boolean overrides.
-            getBooleanDiagnosticRules(/* includeNonOverridable */ true).forEach((ruleName) => {
+            for (const ruleName of getBooleanDiagnosticRules(/* includeNonOverridable */ true)) {
                 unusedEnvKeys.delete(ruleName);
                 (newExecEnv.diagnosticRuleSet as any)[ruleName] = this._convertBoolean(
                     envObj[ruleName],
                     ruleName,
                     newExecEnv.diagnosticRuleSet[ruleName] as boolean
                 );
-            });
+            }
 
             // Apply overrides from the config file for the diagnostic level overrides.
-            getDiagLevelDiagnosticRules().forEach((ruleName) => {
+            for (const ruleName of getDiagLevelDiagnosticRules()) {
                 unusedEnvKeys.delete(ruleName);
                 (newExecEnv.diagnosticRuleSet as any)[ruleName] = this._convertDiagnosticLevel(
                     envObj[ruleName],
                     ruleName,
                     newExecEnv.diagnosticRuleSet[ruleName] as DiagnosticLevel
                 );
-            });
+            }
 
-            Array.from(unusedEnvKeys).forEach((unknownKey) => {
+            for (const unknownKey of Array.from(unusedEnvKeys)) {
                 console.error(`Config executionEnvironments index ${index}: unrecognized setting "${unknownKey}".`);
-            });
+            }
 
             return newExecEnv;
         } catch {

--- a/packages/pyright-internal/src/common/console.ts
+++ b/packages/pyright-internal/src/common/console.ts
@@ -260,7 +260,9 @@ export class ConsoleWithLogLevel implements ConsoleInterface, Chainable, Clonabl
     }
 
     private _processChains(level: LogLevel, message: string) {
-        this._chains.forEach((c) => log(c, level, message));
+        for (const c of this._chains) {
+            log(c, level, message);
+        }
     }
 }
 

--- a/packages/pyright-internal/src/common/diagnostic.ts
+++ b/packages/pyright-internal/src/common/diagnostic.ts
@@ -207,9 +207,9 @@ export class DiagnosticAddendum {
     }
 
     addMessageMultiline(message: string) {
-        message.split('\n').forEach((line) => {
+        for (const line of message.split('\n')) {
             this._messages.push(line);
-        });
+        }
     }
 
     addTextRange(range: TextRange) {

--- a/packages/pyright-internal/src/common/fullAccessHost.ts
+++ b/packages/pyright-internal/src/common/fullAccessHost.ts
@@ -99,9 +99,9 @@ export class FullAccessHost extends LimitedAccessHost {
         }
 
         importLogger?.log(`Received ${result.paths.length} paths from interpreter`);
-        result.paths.forEach((path) => {
+        for (const path of result.paths) {
             importLogger?.log(`  ${path}`);
-        });
+        }
 
         return result;
     }

--- a/packages/pyright-internal/src/common/languageInfoUtils.ts
+++ b/packages/pyright-internal/src/common/languageInfoUtils.ts
@@ -367,11 +367,11 @@ function getVarianceString(type: Variance) {
 
 function getFlagEnumString<E extends number>(enumMap: [E, string][], enumValue: E): string {
     const str: string[] = [];
-    enumMap.forEach((e) => {
+    for (const e of enumMap) {
         if (enumValue & e[0]) {
             str.push(e[1]);
         }
-    });
+    }
     if (str.length === 0) {
         if (enumValue === 0) {
             return 'None';

--- a/packages/pyright-internal/src/common/realFileSystem.ts
+++ b/packages/pyright-internal/src/common/realFileSystem.ts
@@ -504,12 +504,12 @@ export class WorkspaceFileWatcherProvider implements FileWatcherProvider, FileWa
         // is for source or library. so we need to solely rely on paths that can cause us
         // to raise events both for source and library if .venv is inside of workspace root
         // for a file change. It is event handler's job to filter those out.
-        this._fileWatchers.forEach((watcher) => {
+        for (const watcher of this._fileWatchers) {
             const dirUris = watcher.workspacePaths.map((d) => UriEx.file(d, fileUri.isCaseSensitive));
             if (dirUris.some((dir) => fileUri.startsWith(dir))) {
                 watcher.eventHandler(eventType, fileUri.getFilePath());
             }
-        });
+        }
     }
 }
 

--- a/packages/pyright-internal/src/common/serviceProvider.ts
+++ b/packages/pyright-internal/src/common/serviceProvider.ts
@@ -101,7 +101,7 @@ export class ServiceProvider {
 
     clone() {
         const serviceProvider = new ServiceProvider();
-        this._container.forEach((value, key) => {
+        for (const [key, value] of this._container) {
             if (Array.isArray(value)) {
                 serviceProvider._container.set(key, [...(value ?? [])]);
             } else if (value.clone !== undefined) {
@@ -109,7 +109,7 @@ export class ServiceProvider {
             } else {
                 serviceProvider._container.set(key, value);
             }
-        });
+        }
 
         return serviceProvider;
     }
@@ -136,9 +136,9 @@ export class ServiceProvider {
             }
         }
         this._container.clear();
-        essentials.forEach((value, key) => {
+        for (const [key, value] of essentials) {
             this._container.set(key, value);
-        });
+        }
     }
 
     private _addGroupService<T>(key: GroupServiceKey<T>, newValue: T | undefined) {

--- a/packages/pyright-internal/src/common/serviceProviderExtensions.ts
+++ b/packages/pyright-internal/src/common/serviceProviderExtensions.ts
@@ -37,7 +37,7 @@ export function createServiceProvider(...services: any): ServiceProvider {
     const sp = new ServiceProvider();
 
     // For known interfaces, register the service.
-    services.forEach((service: any) => {
+    for (const service of services) {
         if (FileSystem.is(service)) {
             sp.add(ServiceKeys.fs, service);
         }
@@ -71,7 +71,7 @@ export function createServiceProvider(...services: any): ServiceProvider {
         if (CancellationProvider.is(service)) {
             sp.add(ServiceKeys.cancellationProvider, service);
         }
-    });
+    }
     return sp;
 }
 

--- a/packages/pyright-internal/src/common/stringUtils.ts
+++ b/packages/pyright-internal/src/common/stringUtils.ts
@@ -11,21 +11,62 @@ import { compareComparableValues, Comparison } from './core';
 
 // Determines if typed string matches a symbol
 // name. Characters must appear in order.
-// Return true if all typed characters are in symbol
+// Return true if all typed characters are in symbol.
+// Uses a fast ASCII path to avoid toLocaleLowerCase() allocations
+// for the common case of ASCII-only Python identifiers.
 export function isPatternInSymbol(typedValue: string, symbolName: string): boolean {
+    const typedLength = typedValue.length;
+    const symbolLength = symbolName.length;
+
+    if (typedLength === 0) {
+        return true;
+    }
+
+    if (typedLength > symbolLength) {
+        return false;
+    }
+
+    // Fast path: if both strings are pure ASCII, do case-insensitive
+    // subsequence matching inline using charCodeAt, avoiding
+    // toLocaleLowerCase() string allocations.
+    if (_isAscii(typedValue) && _isAscii(symbolName)) {
+        let typedPos = 0;
+        let symbolPos = 0;
+        while (typedPos < typedLength && symbolPos < symbolLength) {
+            if (_asciiLower(typedValue.charCodeAt(typedPos)) === _asciiLower(symbolName.charCodeAt(symbolPos))) {
+                typedPos++;
+            }
+            symbolPos++;
+        }
+        return typedPos === typedLength;
+    }
+
+    // Slow path: fall back to toLocaleLowerCase() for non-ASCII identifiers.
     const typedLower = typedValue.toLocaleLowerCase();
     const symbolLower = symbolName.toLocaleLowerCase();
-    const typedLength = typedLower.length;
-    const symbolLength = symbolLower.length;
     let typedPos = 0;
     let symbolPos = 0;
     while (typedPos < typedLength && symbolPos < symbolLength) {
         if (typedLower[typedPos] === symbolLower[symbolPos]) {
-            typedPos += 1;
+            typedPos++;
         }
-        symbolPos += 1;
+        symbolPos++;
     }
     return typedPos === typedLength;
+}
+
+function _isAscii(s: string): boolean {
+    for (let i = 0; i < s.length; i++) {
+        if (s.charCodeAt(i) > 127) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function _asciiLower(charCode: number): number {
+    // A-Z (65-90) → a-z (97-122) by setting bit 5
+    return charCode >= 65 && charCode <= 90 ? charCode | 0x20 : charCode;
 }
 
 // This is a simple, non-cryptographic hash function for text.

--- a/packages/pyright-internal/src/common/stringUtils.ts
+++ b/packages/pyright-internal/src/common/stringUtils.ts
@@ -12,7 +12,7 @@ import { compareComparableValues, Comparison } from './core';
 // Determines if typed string matches a symbol
 // name. Characters must appear in order.
 // Return true if all typed characters are in symbol.
-// Uses a fast ASCII path to avoid toLocaleLowerCase() allocations
+// Uses inline ASCII matching to avoid toLocaleLowerCase() allocations
 // for the common case of ASCII-only Python identifiers.
 export function isPatternInSymbol(typedValue: string, symbolName: string): boolean {
     const typedLength = typedValue.length;
@@ -26,28 +26,21 @@ export function isPatternInSymbol(typedValue: string, symbolName: string): boole
         return false;
     }
 
-    // Fast path: if both strings are pure ASCII, do case-insensitive
-    // subsequence matching inline using charCodeAt, avoiding
-    // toLocaleLowerCase() string allocations.
-    if (_isAscii(typedValue) && _isAscii(symbolName)) {
-        let typedPos = 0;
-        let symbolPos = 0;
-        while (typedPos < typedLength && symbolPos < symbolLength) {
-            if (_asciiLower(typedValue.charCodeAt(typedPos)) === _asciiLower(symbolName.charCodeAt(symbolPos))) {
-                typedPos++;
-            }
-            symbolPos++;
-        }
-        return typedPos === typedLength;
-    }
-
-    // Slow path: fall back to toLocaleLowerCase() for non-ASCII identifiers.
-    const typedLower = typedValue.toLocaleLowerCase();
-    const symbolLower = symbolName.toLocaleLowerCase();
+    // Try ASCII-only matching first. If we encounter a non-ASCII char,
+    // bail to the locale-aware fallback. For ASCII chars (0-127),
+    // _asciiLower is equivalent to toLocaleLowerCase(), so partial
+    // progress is valid and doesn't need to be re-done.
     let typedPos = 0;
     let symbolPos = 0;
     while (typedPos < typedLength && symbolPos < symbolLength) {
-        if (typedLower[typedPos] === symbolLower[symbolPos]) {
+        const tc = typedValue.charCodeAt(typedPos);
+        const sc = symbolName.charCodeAt(symbolPos);
+        if (tc > 127 || sc > 127) {
+            // Non-ASCII encountered; fall back to locale-aware path
+            // starting from where we left off.
+            return _slowPatternMatch(typedValue, symbolName, typedPos, symbolPos);
+        }
+        if (_asciiLower(tc) === _asciiLower(sc)) {
             typedPos++;
         }
         symbolPos++;
@@ -55,13 +48,19 @@ export function isPatternInSymbol(typedValue: string, symbolName: string): boole
     return typedPos === typedLength;
 }
 
-function _isAscii(s: string): boolean {
-    for (let i = 0; i < s.length; i++) {
-        if (s.charCodeAt(i) > 127) {
-            return false;
+function _slowPatternMatch(typedValue: string, symbolName: string, typedPos: number, symbolPos: number): boolean {
+    // Continue from the current positions using locale-aware comparison.
+    const typedLower = typedValue.toLocaleLowerCase();
+    const symbolLower = symbolName.toLocaleLowerCase();
+    const typedLength = typedLower.length;
+    const symbolLength = symbolLower.length;
+    while (typedPos < typedLength && symbolPos < symbolLength) {
+        if (typedLower[typedPos] === symbolLower[symbolPos]) {
+            typedPos++;
         }
+        symbolPos++;
     }
-    return true;
+    return typedPos === typedLength;
 }
 
 function _asciiLower(charCode: number): number {

--- a/packages/pyright-internal/src/common/textEditTracker.ts
+++ b/packages/pyright-internal/src/common/textEditTracker.ts
@@ -49,7 +49,9 @@ export class TextEditTracker {
     }
 
     addEdits(...edits: FileEditAction[]) {
-        edits.forEach((e) => this.addEdit(e.fileUri, e.range, e.replacementText));
+        for (const e of edits) {
+            this.addEdit(e.fileUri, e.range, e.replacementText);
+        }
     }
 
     addEdit(fileUri: Uri, range: Range, replacementText: string) {
@@ -64,9 +66,9 @@ export class TextEditTracker {
             // first deleting existing edits and expanding the current edit's range
             // to cover all existing edits.
             this._removeEdits(edits, overlappingEdits);
-            overlappingEdits.forEach((e) => {
+            for (const e of overlappingEdits) {
                 extendRange(range, e.range);
-            });
+            }
         }
 
         edits.push({ fileUri: fileUri, range, replacementText });
@@ -99,7 +101,9 @@ export class TextEditTracker {
             imports.findIndex((v) => v === importToDelete)
         );
 
-        ranges.forEach((r) => this.addEditWithTextRange(parseFileResults, r, ''));
+        for (const r of ranges) {
+            this.addEditWithTextRange(parseFileResults, r, '');
+        }
 
         this._markNodeRemoved(importToDelete, parseFileResults);
 
@@ -170,7 +174,9 @@ export class TextEditTracker {
         this._processNodeRemoved(token);
 
         const edits: FileEditAction[] = [];
-        this._results.forEach((v) => appendArray(edits, v));
+        for (const v of this._results.values()) {
+            appendArray(edits, v);
+        }
 
         return edits;
     }
@@ -399,14 +405,18 @@ export class TextEditTracker {
         }
 
         const editSpans = getTextRangeForImportNameDeletion(nodeToRemove.parseFileResults, nameNodes, ...indices);
-        editSpans.forEach((e) => this.addEdit(info.fileUri, convertTextRangeToRange(e, info.lines), ''));
+        for (const e of editSpans) {
+            this.addEdit(info.fileUri, convertTextRangeToRange(e, info.lines), '');
+        }
 
         this._removeNodesHandled(nodesRemoved);
         return true;
     }
 
     private _removeNodesHandled(nodesRemoved: NodeToRemove[]) {
-        nodesRemoved.forEach((n) => this._markNodeRemoved(n.node, n.parseFileResults));
+        for (const n of nodesRemoved) {
+            this._markNodeRemoved(n.node, n.parseFileResults);
+        }
         removeArrayElements(this._pendingNodeToRemove, (n) => this._nodesRemoved.has(n.node));
     }
 
@@ -415,7 +425,9 @@ export class TextEditTracker {
         this._nodesRemoved.set(nodeToDelete, parseFileResults);
         if (nodeToDelete.nodeType === ParseNodeType.ImportAs) {
             this._nodesRemoved.set(nodeToDelete.d.module, parseFileResults);
-            nodeToDelete.d.module.d.nameParts.forEach((n) => this._nodesRemoved.set(n, parseFileResults));
+            for (const n of nodeToDelete.d.module.d.nameParts) {
+                this._nodesRemoved.set(n, parseFileResults);
+            }
             if (nodeToDelete.d.alias) {
                 this._nodesRemoved.set(nodeToDelete.d.alias, parseFileResults);
             }

--- a/packages/pyright-internal/src/common/uri/uriMap.ts
+++ b/packages/pyright-internal/src/common/uri/uriMap.ts
@@ -23,9 +23,9 @@ export class UriMap<T> implements Map<Uri, T> {
         this._values.clear();
     }
     forEach(callbackfn: (value: T, key: Uri, map: Map<Uri, T>) => void, thisArg?: any): void {
-        this._keys.forEach((v, k) => {
+        for (const [k, v] of this._keys) {
             callbackfn(this._values.get(k)!, v, this);
-        });
+        }
     }
     values(): IterableIterator<T> {
         return this._values.values();

--- a/packages/pyright-internal/src/common/uri/uriUtils.ts
+++ b/packages/pyright-internal/src/common/uri/uriUtils.ts
@@ -340,24 +340,31 @@ export function getDirectoryChangeKind(
 export function deduplicateFolders(listOfFolders: Uri[][], excludes: Uri[] = []): Uri[] {
     const foldersToWatch = new Map<string, Uri>();
 
-    listOfFolders.forEach((folders) => {
-        folders.forEach((p) => {
+    for (const folders of listOfFolders) {
+        for (const p of folders) {
             if (foldersToWatch.has(p.key)) {
                 // Bail out on exact match.
-                return;
+                continue;
             }
 
+            let excluded = false;
             for (const exclude of excludes) {
                 if (p.startsWith(exclude)) {
-                    return;
+                    excluded = true;
+                    break;
                 }
             }
+            if (excluded) {
+                continue;
+            }
 
+            let handled = false;
             for (const existing of foldersToWatch) {
                 // ex) p: "/user/test" existing: "/user"
                 if (p.startsWith(existing[1])) {
                     // We already have the parent folder in the watch list
-                    return;
+                    handled = true;
+                    break;
                 }
 
                 // ex) p: "/user" folderToWatch: "/user/test"
@@ -365,13 +372,16 @@ export function deduplicateFolders(listOfFolders: Uri[][], excludes: Uri[] = [])
                     // We found better one to watch. replace.
                     foldersToWatch.delete(existing[0]);
                     foldersToWatch.set(p.key, p);
-                    return;
+                    handled = true;
+                    break;
                 }
             }
 
-            foldersToWatch.set(p.key, p);
-        });
-    });
+            if (!handled) {
+                foldersToWatch.set(p.key, p);
+            }
+        }
+    }
 
     return [...foldersToWatch.values()];
 }

--- a/packages/pyright-internal/src/common/workspaceEditUtils.ts
+++ b/packages/pyright-internal/src/common/workspaceEditUtils.ts
@@ -67,11 +67,11 @@ export function convertToWorkspaceEdit(
 }
 
 export function appendToWorkspaceEdit(fs: ReadOnlyFileSystem, edits: FileEditAction[], workspaceEdit: WorkspaceEdit) {
-    edits.forEach((edit) => {
+    for (const edit of edits) {
         const uri = convertUriToLspUriString(fs, edit.fileUri);
         workspaceEdit.changes![uri] = workspaceEdit.changes![uri] || [];
         workspaceEdit.changes![uri].push({ range: edit.range, newText: edit.replacementText });
-    });
+    }
 }
 
 export function applyTextEditsToString(

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -344,27 +344,27 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
     }
 
     reanalyze() {
-        this.workspaceFactory.items().forEach((workspace) => {
+        for (const workspace of this.workspaceFactory.items()) {
             workspace.service.invalidateAndForceReanalysis(InvalidatedReason.Reanalyzed);
-        });
+        }
     }
 
     restart() {
-        this.workspaceFactory.items().forEach((workspace) => {
+        for (const workspace of this.workspaceFactory.items()) {
             workspace.service.restart();
-        });
+        }
     }
 
     updateSettingsForAllWorkspaces(): void {
         const tasks: Promise<void>[] = [];
-        this.workspaceFactory.items().forEach((workspace) => {
+        for (const workspace of this.workspaceFactory.items()) {
             // Updating settings can change workspace's file ownership. Make workspace uninitialized so that
             // features can wait until workspace gets new settings.
             // the file's ownership can also changed by `pyrightconfig.json` changes, but those are synchronous
             // operation, so it won't affect this.
             workspace.isInitialized = workspace.isInitialized.reset();
             tasks.push(this.updateSettingsForWorkspace(workspace, workspace.isInitialized));
-        });
+        }
 
         Promise.all(tasks).then(() => {
             this.dynamicFeatures.register();
@@ -1105,9 +1105,9 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
 
         // Send this open to all the workspaces that might contain this file.
         const workspaces = await this.getContainingWorkspacesForFile(uri);
-        workspaces.forEach((w) => {
+        for (const w of workspaces) {
             w.service.setFileOpened(uri, params.textDocument.version, params.textDocument.text, ipythonMode);
-        });
+        }
     }
 
     protected async onDidChangeTextDocument(params: DidChangeTextDocumentParams, ipythonMode = IPythonMode.None) {
@@ -1126,9 +1126,9 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
 
         // Send this change to all the workspaces that might contain this file.
         const workspaces = await this.getContainingWorkspacesForFile(uri);
-        workspaces.forEach((w) => {
+        for (const w of workspaces) {
             w.service.updateOpenFileContents(uri, params.textDocument.version, newContents, ipythonMode);
-        });
+        }
     }
 
     protected async onDidCloseTextDocument(params: DidCloseTextDocumentParams) {
@@ -1136,9 +1136,9 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
 
         // Send this close to all the workspaces that might contain this file.
         const workspaces = await this.getContainingWorkspacesForFile(uri);
-        workspaces.forEach((w) => {
+        for (const w of workspaces) {
             w.service.setFileClosed(uri);
-        });
+        }
 
         this.openFileMap.delete(uri.key);
     }
@@ -1227,9 +1227,9 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
             ? wrapProgressReporter(workDoneProgress)
             : undefined;
         this._workspaceDiagnosticsReporter = resultReporter;
-        this.workspaceFactory.getNonDefaultWorkspaces().forEach((workspace) => {
+        for (const workspace of this.workspaceFactory.getNonDefaultWorkspaces()) {
             workspace.service.invalidateAndScheduleReanalysis(InvalidatedReason.Reanalyzed);
-        });
+        }
 
         return new Promise<WorkspaceDiagnosticReport>((resolve, reject) => {
             // We never resolve as this should be a continually occurring process. Scheduling analysis
@@ -1242,11 +1242,11 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
     }
 
     protected onDidChangeWatchedFiles(params: DidChangeWatchedFilesParams) {
-        params.changes.forEach((change) => {
+        for (const change of params.changes) {
             const filePath = this.fs.realCasePath(this.convertLspUriStringToUri(change.uri));
             const eventType: FileWatcherEventType = change.type === 1 ? 'add' : 'change';
             this.serverOptions.fileWatcherHandler.onFileChange(eventType, filePath);
-        });
+        }
     }
 
     protected async onExecuteCommand(
@@ -1333,13 +1333,13 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
 
     protected onAnalysisCompletedHandler(fs: FileSystem, results: AnalysisResults): void {
         // Send the computed diagnostics to the client.
-        results.diagnostics.forEach((fileDiag) => {
+        for (const fileDiag of results.diagnostics) {
             if (!this.canNavigateToFile(fileDiag.fileUri, fs)) {
-                return;
+                continue;
             }
 
             this.sendDiagnostics(this.convertDiagnostics(fs, fileDiag));
-        });
+        }
 
         const reporter = this.getAnalysisProgressReporter();
         if (!reporter.isEnabled(results)) {
@@ -1442,9 +1442,9 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
         // Tell all of the services that the user is actively
         // interacting with one or more editors, so they should
         // back off from performing any work.
-        this.workspaceFactory.items().forEach((workspace: { service: { recordUserInteractionTime: () => void } }) => {
-            workspace.service.recordUserInteractionTime();
-        });
+        for (const workspace of this.workspaceFactory.items()) {
+            (workspace as { service: { recordUserInteractionTime: () => void } }).service.recordUserInteractionTime();
+        }
     }
 
     protected getDocumentationUrlForDiagnostic(diag: AnalyzerDiagnostic): string | undefined {
@@ -1527,7 +1527,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
     private _convertDiagnostics(fs: FileSystem, diags: AnalyzerDiagnostic[]): Diagnostic[] {
         const convertedDiags: Diagnostic[] = [];
 
-        diags.forEach((diag) => {
+        for (const diag of diags) {
             const severity = convertCategoryToSeverity(diag.category);
             const rule = diag.getRule();
             const code = this.getDiagCode(diag, rule);
@@ -1549,7 +1549,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
 
                 // If the client doesn't support "unnecessary" tags, don't report unused code.
                 if (!this.client.supportsUnnecessaryDiagnosticTag) {
-                    return;
+                    continue;
                 }
             } else if (diag.category === DiagnosticCategory.Deprecated) {
                 vsDiag.tags = [DiagnosticTag.Deprecated];
@@ -1557,11 +1557,11 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
 
                 // If the client doesn't support "deprecated" tags, don't report.
                 if (!this.client.supportsDeprecatedDiagnosticTag) {
-                    return;
+                    continue;
                 }
             } else if (diag.category === DiagnosticCategory.TaskItem) {
                 // TaskItem is not supported.
-                return;
+                continue;
             }
 
             if (rule) {
@@ -1586,7 +1586,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
             }
 
             convertedDiags.push(vsDiag);
-        });
+        }
 
         function convertCategoryToSeverity(category: DiagnosticCategory) {
             switch (category) {

--- a/packages/pyright-internal/src/languageService/autoImporter.ts
+++ b/packages/pyright-internal/src/languageService/autoImporter.ts
@@ -119,17 +119,17 @@ export type AutoImportResultMap = Map<string, AutoImportResult[]>;
 export function buildModuleSymbolsMap(program: ProgramView, files: readonly SourceFileInfo[]): ModuleSymbolMap {
     const moduleSymbolMap = new Map<string, ModuleSymbolTable>();
 
-    files.forEach((file) => {
+    for (const file of files) {
         if (file.shadows.length > 0) {
             // There is corresponding stub file. Don't add
             // duplicated files in the map.
-            return;
+            continue;
         }
 
         const uri = file.uri;
         const symbolTable = program.getModuleSymbolTable(uri);
         if (!symbolTable) {
-            return;
+            continue;
         }
 
         const fileName = stripFileExtension(uri.fileName);
@@ -137,7 +137,7 @@ export function buildModuleSymbolsMap(program: ProgramView, files: readonly Sour
         // Don't offer imports from files that are named with private
         // naming semantics like "_ast.py" unless they're in the current userfile list.
         if (SymbolNameUtils.isPrivateOrProtectedName(fileName) && !isUserCode(file)) {
-            return;
+            continue;
         }
 
         moduleSymbolMap.set(uri.key, {
@@ -179,8 +179,8 @@ export function buildModuleSymbolsMap(program: ProgramView, files: readonly Sour
                 }
             },
         });
-        return;
-    });
+        continue;
+    }
 
     return moduleSymbolMap;
 }
@@ -212,7 +212,9 @@ export class AutoImporter {
         const results: AutoImportResult[] = [];
         const map = this.getCandidates(word, similarityLimit, abbrFromUsers, token);
 
-        map.forEach((v) => appendArray(results, v));
+        for (const v of map.values()) {
+            appendArray(results, v);
+        }
         return results;
     }
 
@@ -247,7 +249,7 @@ export class AutoImporter {
         results: AutoImportResultMap,
         token: CancellationToken
     ) {
-        this.moduleSymbolMap.forEach((topLevelSymbols, key) => {
+        for (const topLevelSymbols of this.moduleSymbolMap.values()) {
             // See if this file should be offered as an implicit import.
             const uriProperties = this.getUriProperties(this.moduleSymbolMap!, topLevelSymbols.uri);
             this.processModuleSymbolTable(
@@ -261,7 +263,7 @@ export class AutoImporter {
                 results,
                 token
             );
-        });
+        }
     }
 
     protected addImportsFromImportAliasMap(
@@ -272,8 +274,8 @@ export class AutoImporter {
     ) {
         throwIfCancellationRequested(token);
 
-        importAliasMap.forEach((mapPerSymbolName) => {
-            mapPerSymbolName.forEach((importAliasData, originalName) => {
+        for (const mapPerSymbolName of importAliasMap.values()) {
+            for (const [originalName, importAliasData] of mapPerSymbolName) {
                 if (abbrFromUsers) {
                     // When alias name is used, our regular exclude mechanism would not work. we need to check
                     // whether import, the alias is referring to, already exists.
@@ -286,7 +288,7 @@ export class AutoImporter {
                     // If import statement for the module already exist, then bail out.
                     // ex) import module[.submodule] or from module[.submodule] import symbol
                     if (this._importStatements.mapByFilePath.has(importAliasData.importParts.fileUri.key)) {
-                        return;
+                        continue;
                     }
 
                     // If it is the module itself that got imported, make sure we don't import it again.
@@ -303,7 +305,7 @@ export class AutoImporter {
                                 (i) => i.d.name.d.value === importAliasData.importParts.symbolName
                             )
                         ) {
-                            return;
+                            continue;
                         }
                     }
                 }
@@ -314,7 +316,7 @@ export class AutoImporter {
                     results
                 );
                 if (alreadyIncluded) {
-                    return;
+                    continue;
                 }
 
                 const autoImportTextEdits = this._getTextEditsForAutoImportByFilePath(
@@ -339,8 +341,8 @@ export class AutoImporter {
                     originalName,
                     originalDeclUri: importAliasData.fileUri,
                 });
-            });
-        });
+            }
+        }
     }
 
     protected processModuleSymbolTable(

--- a/packages/pyright-internal/src/languageService/callHierarchyProvider.ts
+++ b/packages/pyright-internal/src/languageService/callHierarchyProvider.ts
@@ -321,9 +321,9 @@ class FindOutgoingCallTreeWalker extends ParseTreeWalker {
                 // TODO - it would be better if we could match the call to the
                 // specific declaration (e.g. a specific overload of a property
                 // setter vs getter). For now, add callees for all declarations.
-                declarations.forEach((decl) => {
+                for (const decl of declarations) {
                     this._addOutgoingCallForDeclaration(nameNode!, decl);
-                });
+                }
             }
         }
 
@@ -361,9 +361,9 @@ class FindOutgoingCallTreeWalker extends ParseTreeWalker {
                 }
 
                 if (isClassInstance(memberType) && ClassType.isPropertyClass(memberType)) {
-                    propertyDecls.forEach((decl) => {
+                    for (const decl of propertyDecls) {
                         this._addOutgoingCallForDeclaration(node.d.member, decl);
-                    });
+                    }
                 }
             });
         }
@@ -442,7 +442,9 @@ class FindIncomingCallTreeWalker extends ParseTreeWalker {
             .filter(isDefined);
 
         this._declarations.push(this._targetDeclaration);
-        this._usageProviders.forEach((p) => p.appendDeclarationsTo(this._declarations));
+        for (const p of this._usageProviders) {
+            p.appendDeclarationsTo(this._declarations);
+        }
     }
 
     findCalls(): CallHierarchyIncomingCall[] {
@@ -546,7 +548,9 @@ class FindIncomingCallTreeWalker extends ParseTreeWalker {
         );
 
         const results = [...declarations];
-        this._usageProviders.forEach((p) => p.appendDeclarationsAt(node, declarations, results));
+        for (const p of this._usageProviders) {
+            p.appendDeclarationsAt(node, declarations, results);
+        }
 
         return results;
     }

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -2582,7 +2582,11 @@ export class CompletionProvider {
         const excludes = new Set(existingKeys);
 
         for (const typedDict of typedDicts) {
-            for (const key of getTypedDictMembersForClass(this.evaluator, typedDict, /* allowNarrowed */ true).knownItems.keys()) {
+            for (const key of getTypedDictMembersForClass(
+                this.evaluator,
+                typedDict,
+                /* allowNarrowed */ true
+            ).knownItems.keys()) {
                 // Unions of TypedDicts may define the same key.
                 if (excludes.has(key) || completionMap.has(key)) {
                     continue;

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -442,13 +442,13 @@ export class CompletionProvider {
 
         const completionMap = new CompletionMap();
 
-        symbolTable.forEach((symbol, name) => {
+        for (const [name, symbol] of symbolTable) {
             let decl = getLastTypedDeclarationForSymbol(symbol);
             if (decl && decl.type === DeclarationType.Function) {
                 if (StringUtils.isPatternInSymbol(partialName.d.value, name)) {
                     const declaredType = this.evaluator.getTypeForDeclaration(decl)?.type;
                     if (!declaredType) {
-                        return;
+                        continue;
                     }
 
                     let isProperty = isClassInstance(declaredType) && ClassType.isPropertyClass(declaredType);
@@ -459,7 +459,7 @@ export class CompletionProvider {
                     }
 
                     if (!isFunction(declaredType) && !isProperty) {
-                        return;
+                        continue;
                     }
 
                     if (isProperty) {
@@ -482,7 +482,7 @@ export class CompletionProvider {
                         name !== '__init_subclass__';
 
                     if (staticmethod !== isDeclaredStaticMethod || classmethod !== isDeclaredClassMethod) {
-                        return;
+                        continue;
                     }
 
                     const methodSignature = this._printMethodSignature(classResults.classType, decl);
@@ -513,7 +513,7 @@ export class CompletionProvider {
                     });
                 }
             }
-        });
+        }
 
         return completionMap;
     }
@@ -1757,14 +1757,14 @@ export class CompletionProvider {
         }
 
         const completionMap = new CompletionMap();
-        symbolTable.forEach((symbol, name) => {
+        for (const [name, symbol] of symbolTable) {
             if (
                 SymbolNameUtils.isPrivateName(name) ||
                 symbol.isPrivateMember() ||
                 symbol.isExternallyHidden() ||
                 !StringUtils.isPatternInSymbol(partialName.d.value, name)
             ) {
-                return;
+                continue;
             }
 
             const decls = symbol
@@ -1776,11 +1776,11 @@ export class CompletionProvider {
                 decls.length === 0 ||
                 decls.some((d) => d.node && ParseTreeUtils.getEnclosingClass(d.node, false) === enclosingClass)
             ) {
-                return;
+                continue;
             }
 
             this.addSymbol(name, symbol, partialName.d.value, completionMap, {});
-        });
+        }
 
         return completionMap.size > 0 ? completionMap : undefined;
     }
@@ -1795,21 +1795,21 @@ export class CompletionProvider {
         const completionMap = new CompletionMap();
 
         const enclosingFunc = ParseTreeUtils.getEnclosingFunction(partialName);
-        symbolTable.forEach((symbol, name) => {
+        for (const [name, symbol] of symbolTable) {
             const decl = getLastTypedDeclarationForSymbol(symbol);
             if (!decl || decl.type !== DeclarationType.Function) {
-                return;
+                continue;
             }
 
             if (!decl.node.d.decorators.some((d) => this._isOverload(d))) {
                 // Only consider ones that have overload decorator.
-                return;
+                continue;
             }
 
             const decls = symbol.getDeclarations();
             if (decls.length === 1 && decls.some((d) => d.node === enclosingFunc)) {
                 // Don't show itself.
-                return;
+                continue;
             }
 
             if (StringUtils.isPatternInSymbol(partialName.d.value, name)) {
@@ -1819,7 +1819,7 @@ export class CompletionProvider {
                     edits: { textEdit },
                 });
             }
-        });
+        }
 
         return completionMap;
 
@@ -2066,22 +2066,21 @@ export class CompletionProvider {
         postText: string,
         completionMap: CompletionMap
     ) {
-        signatureInfo.signatures.forEach((signature) => {
+        for (const signature of signatureInfo.signatures) {
             if (!signature.activeParam) {
-                return undefined;
+                continue;
             }
 
             const type = signature.type;
             const paramIndex = type.shared.parameters.indexOf(signature.activeParam);
 
             if (paramIndex < 0) {
-                return undefined;
+                continue;
             }
 
             const paramType = FunctionType.getParamType(type, paramIndex);
             this._addLiteralValuesForTargetType(paramType, priorWord, priorText, postText, completionMap);
-            return undefined;
-        });
+        }
     }
 
     private _addLiteralValuesForTargetType(
@@ -2092,7 +2091,7 @@ export class CompletionProvider {
         completionMap: CompletionMap
     ) {
         const quoteValue = this._getQuoteInfo(priorWord, priorText);
-        this._getSubTypesWithLiteralValues(type).forEach((v) => {
+        for (const v of this._getSubTypesWithLiteralValues(type)) {
             if (ClassType.isBuiltIn(v, 'str')) {
                 const value = printLiteralValue(v, quoteValue.quoteCharacter);
                 if (quoteValue.stringValue === undefined) {
@@ -2108,7 +2107,7 @@ export class CompletionProvider {
                     );
                 }
             }
-        });
+        }
     }
 
     private _getDictExpressionStringKeys(parseNode: ParseNode, excludeIds?: Set<number | undefined>) {
@@ -2194,7 +2193,7 @@ export class CompletionProvider {
         if (subscriptType) {
             const keys: string[] = [];
 
-            this._getSubTypesWithLiteralValues(subscriptType).forEach((v) => {
+            for (const v of this._getSubTypesWithLiteralValues(subscriptType)) {
                 if (
                     !ClassType.isBuiltIn(v, 'str') &&
                     !ClassType.isBuiltIn(v, 'int') &&
@@ -2202,11 +2201,11 @@ export class CompletionProvider {
                     !ClassType.isBuiltIn(v, 'bytes') &&
                     !ClassType.isEnumClass(v)
                 ) {
-                    return;
+                    continue;
                 }
 
                 keys.push(printLiteralValue(v, this.parseResults.tokenizerOutput.predominantSingleQuoteCharacter));
-            });
+            }
 
             if (keys.length > 0) {
                 return keys;
@@ -2582,20 +2581,18 @@ export class CompletionProvider {
         const quoteInfo = this._getQuoteInfo(priorWord, priorText);
         const excludes = new Set(existingKeys);
 
-        typedDicts.forEach((typedDict) => {
-            getTypedDictMembersForClass(this.evaluator, typedDict, /* allowNarrowed */ true).knownItems.forEach(
-                (_, key) => {
-                    // Unions of TypedDicts may define the same key.
-                    if (excludes.has(key) || completionMap.has(key)) {
-                        return;
-                    }
-
-                    excludes.add(key);
-
-                    this._addStringLiteralToCompletions(key, quoteInfo, postText, completionMap);
+        for (const typedDict of typedDicts) {
+            for (const key of getTypedDictMembersForClass(this.evaluator, typedDict, /* allowNarrowed */ true).knownItems.keys()) {
+                // Unions of TypedDicts may define the same key.
+                if (excludes.has(key) || completionMap.has(key)) {
+                    continue;
                 }
-            );
-        });
+
+                excludes.add(key);
+
+                this._addStringLiteralToCompletions(key, quoteInfo, postText, completionMap);
+            }
+        }
 
         return true;
     }
@@ -2832,13 +2829,15 @@ export class CompletionProvider {
         priorWord: string,
         completionMap: CompletionMap
     ) {
-        importInfo.implicitImports?.forEach((implImport) => {
-            if (!importFromNode.d.imports.find((imp) => imp.d.name.d.value === implImport.name)) {
-                this.addNameToCompletions(implImport.name, CompletionItemKind.Module, priorWord, completionMap, {
-                    moduleUri: implImport.uri,
-                });
+        if (importInfo.implicitImports) {
+            for (const implImport of importInfo.implicitImports.values()) {
+                if (!importFromNode.d.imports.find((imp) => imp.d.name.d.value === implImport.name)) {
+                    this.addNameToCompletions(implImport.name, CompletionItemKind.Module, priorWord, completionMap, {
+                        moduleUri: implImport.uri,
+                    });
+                }
             }
-        });
+        }
     }
 
     private _findMatchingKeywords(keywordList: string[], partialMatch: string): string[] {
@@ -2854,33 +2853,35 @@ export class CompletionProvider {
     private _addNamedParameters(signatureInfo: CallSignatureInfo, priorWord: string, completionMap: CompletionMap) {
         const argNameSet = new Set<string>();
 
-        signatureInfo.signatures.forEach((signature) => {
+        for (const signature of signatureInfo.signatures) {
             this._addNamedParametersToMap(signature.type, argNameSet);
-        });
+        }
 
         // Add keys from typed dict outside signatures.
-        signatureInfo.signatures.forEach((signature) => {
+        for (const signature of signatureInfo.signatures) {
             if (signature.type.priv.boundToType) {
                 const keys = Array.from(
                     signature.type.priv.boundToType.shared.typedDictEntries?.knownItems.keys() || []
                 );
-                keys.forEach((key: string) => argNameSet.add(key));
+                for (const key of keys) {
+                    argNameSet.add(key);
+                }
             }
-        });
+        }
 
         // Remove any named parameters that are already provided.
-        signatureInfo.callNode.d.args!.forEach((arg) => {
+        for (const arg of signatureInfo.callNode.d.args!) {
             if (arg.d.name) {
                 argNameSet.delete(arg.d.name.d.value);
             }
-        });
+        }
 
         // Add the remaining unique parameter names to the completion list.
-        argNameSet.forEach((argName) => {
+        for (const argName of argNameSet) {
             if (StringUtils.isPatternInSymbol(priorWord, argName)) {
                 const label = argName + '=';
                 if (completionMap.has(label)) {
-                    return;
+                    continue;
                 }
 
                 const completionItem = CompletionItem.create(label);
@@ -2896,13 +2897,13 @@ export class CompletionProvider {
 
                 completionMap.set(completionItem);
             }
-        });
+        }
     }
 
     private _addNamedParametersToMap(type: FunctionType, names: Set<string>) {
         const paramDetails = getParamListDetails(type);
 
-        paramDetails.params.forEach((paramInfo) => {
+        for (const paramInfo of paramDetails.params) {
             if (
                 paramInfo.param.name &&
                 paramInfo.kind !== ParamKind.Positional &&
@@ -2915,7 +2916,7 @@ export class CompletionProvider {
                     names.add(paramInfo.param.name);
                 }
             }
-        });
+        }
     }
 
     private _addSymbols(node: ParseNode, priorWord: string, completionMap: CompletionMap) {
@@ -2942,7 +2943,7 @@ export class CompletionProvider {
                 if (curNode.nodeType === ParseNodeType.Class) {
                     const classType = this.evaluator.getTypeOfClass(curNode);
                     if (classType && isInstantiableClass(classType.classType)) {
-                        classType.classType.shared.mro.forEach((baseClass, index) => {
+                        for (const baseClass of classType.classType.shared.mro) {
                             if (isInstantiableClass(baseClass)) {
                                 this._addSymbolsForSymbolTable(
                                     ClassType.getSymbolTable(baseClass),
@@ -2963,7 +2964,7 @@ export class CompletionProvider {
                                     completionMap
                                 );
                             }
-                        });
+                        }
                     }
                 }
                 break;
@@ -2985,7 +2986,7 @@ export class CompletionProvider {
         const insideTypeAnnotation =
             ParseTreeUtils.isWithinAnnotationComment(node) ||
             ParseTreeUtils.isWithinTypeAnnotation(node, /* requireQuotedAnnotation */ false);
-        symbolTable.forEach((symbol, name) => {
+        for (const [name, symbol] of symbolTable) {
             // If there are no declarations or the symbol is not
             // exported from this scope, don't include it in the
             // suggestion list unless we are in the same file.
@@ -3005,7 +3006,7 @@ export class CompletionProvider {
                     });
                 }
             }
-        });
+        }
     }
 
     private _shouldShowAutoParensForClass(symbol: Symbol, node: ParseNode) {
@@ -3175,12 +3176,12 @@ export class CompletionProvider {
             completionMap.set(completionItem);
         }
 
-        completions.forEach((modulePath, completionName) => {
+        for (const [completionName, modulePath] of completions) {
             this.addNameToCompletions(completionName, CompletionItemKind.Module, '', completionMap, {
                 sortText: this._makeSortText(SortCategory.ImportModuleName, completionName),
                 moduleUri: modulePath,
             });
-        });
+        }
 
         return completionMap;
     }
@@ -3263,15 +3264,17 @@ export class CompletionMap {
 
     toArray(): CompletionItem[] {
         const items: CompletionItem[] = [];
-        this._completions?.forEach((value) => {
-            if (Array.isArray(value)) {
-                value.forEach((item) => {
-                    items.push(item);
-                });
-            } else {
-                items.push(value);
+        if (this._completions) {
+            for (const value of this._completions.values()) {
+                if (Array.isArray(value)) {
+                    for (const item of value) {
+                        items.push(item);
+                    }
+                } else {
+                    items.push(value);
+                }
             }
-        });
+        }
         return items;
     }
 

--- a/packages/pyright-internal/src/languageService/definitionProvider.ts
+++ b/packages/pyright-internal/src/languageService/definitionProvider.ts
@@ -54,19 +54,19 @@ export function addDeclarationsToDefinitions(
         return;
     }
 
-    declarations.forEach((decl) => {
+    for (const decl of declarations) {
         let resolvedDecl = evaluator.resolveAliasDeclaration(decl, /* resolveLocalNames */ true, {
             allowExternallyHiddenAccess: true,
         });
 
         if (!resolvedDecl || resolvedDecl.uri.isEmpty()) {
-            return;
+            continue;
         }
 
         // If the decl is an unresolved import, skip it.
         if (resolvedDecl.type === DeclarationType.Alias) {
             if (resolvedDecl.isUnresolved || isUnresolvedAliasDeclaration(resolvedDecl)) {
-                return;
+                continue;
             }
         }
 
@@ -103,17 +103,18 @@ export function addDeclarationsToDefinitions(
         }
 
         if (!isStubFile(resolvedDecl.uri)) {
-            return;
+            continue;
         }
 
         if (resolvedDecl.type === DeclarationType.Alias) {
             // Add matching source module
-            sourceMapper
+            for (const f of sourceMapper
                 .findModules(resolvedDecl.uri)
                 .map((m) => getFileInfo(m)?.fileUri)
-                .filter(isDefined)
-                .forEach((f) => _addIfUnique(definitions, _createModuleEntry(f)));
-            return;
+                .filter(isDefined)) {
+                _addIfUnique(definitions, _createModuleEntry(f));
+            }
+            continue;
         }
 
         const implDecls = sourceMapper.findDeclarations(resolvedDecl);
@@ -125,7 +126,7 @@ export function addDeclarationsToDefinitions(
                 });
             }
         }
-    });
+    }
 }
 
 export function filterDefinitions(filter: DefinitionFilter, definitions: DocumentRange[]) {
@@ -162,10 +163,10 @@ class DefinitionProviderBase {
 
         const factories = this._serviceProvider?.tryGet(ServiceKeys.symbolDefinitionProvider);
         if (factories) {
-            factories.forEach((f) => {
+            for (const f of factories) {
                 const declarations = f.tryGetDeclarations(node, offset, this.token);
                 this.resolveDeclarations(declarations, definitions);
-            });
+            }
         }
 
         // There should be only one 'definition', so only if extensions failed should we try again.

--- a/packages/pyright-internal/src/languageService/documentSymbolCollector.ts
+++ b/packages/pyright-internal/src/languageService/documentSymbolCollector.ts
@@ -117,7 +117,9 @@ export class DocumentSymbolCollector extends ParseTreeWalker {
         this._aliasResolver = new AliasResolver(this._program.evaluator!);
 
         // Start with the symbols passed in
-        symbolNames.forEach((s) => this._symbolNames.add(s));
+        for (const s of symbolNames) {
+            this._symbolNames.add(s);
+        }
         this._declarations.push(...declarations);
 
         this._treatModuleInImportAndFromImportSame = options?.treatModuleInImportAndFromImportSame ?? false;
@@ -132,10 +134,10 @@ export class DocumentSymbolCollector extends ParseTreeWalker {
 
         if (options?.providers === undefined) {
             // Check whether we need to add new symbol names and declarations.
-            this._usageProviders.forEach((p) => {
+            for (const p of this._usageProviders) {
                 p.appendSymbolNamesTo(this._symbolNames);
                 p.appendDeclarationsTo(this._declarations);
-            });
+            }
         }
 
         // Don't report strings in __all__ right away, that will
@@ -194,7 +196,7 @@ export class DocumentSymbolCollector extends ParseTreeWalker {
 
         const resolvedDeclarations: Declaration[] = [];
         const sourceMapper = findImplementations ? program.getSourceMapper(fileUri, token) : undefined;
-        declarations.forEach((decl) => {
+        for (const decl of declarations) {
             const resolvedDecl = evaluator.resolveAliasDeclaration(decl, resolveLocalNames);
             if (resolvedDecl) {
                 addDeclarationIfUnique(resolvedDeclarations, resolvedDecl);
@@ -207,7 +209,7 @@ export class DocumentSymbolCollector extends ParseTreeWalker {
                     }
                 }
             }
-        });
+        }
 
         const sourceFileInfo = program.getSourceFileInfo(fileUri);
         if (sourceFileInfo && sourceFileInfo.ipythonMode === IPythonMode.CellDocs) {
@@ -221,28 +223,30 @@ export class DocumentSymbolCollector extends ParseTreeWalker {
 
             // Add declarations from files that implicitly import the target file.
             const implicitlyImportedBy = collectImportedByCells(program, sourceFileInfo);
-            implicitlyImportedBy.forEach((implicitImport) => {
+            for (const implicitImport of implicitlyImportedBy) {
                 const parseTree = program.getParseResults(implicitImport.uri)?.parserOutput.parseTree;
                 if (parseTree) {
                     const scope = AnalyzerNodeInfo.getScope(parseTree);
                     const symbol = scope?.lookUpSymbol(node.d.value);
                     appendSymbolDeclarations(symbol, resolvedDeclarations);
                 }
-            });
+            }
         }
 
         return resolvedDeclarations;
 
         function appendSymbolDeclarations(symbol: Symbol | undefined, declarations: Declaration[]) {
-            symbol
+            const decls = symbol
                 ?.getDeclarations()
-                .filter((d) => !isAliasDeclaration(d))
-                .forEach((decl) => {
+                .filter((d) => !isAliasDeclaration(d));
+            if (decls) {
+                for (const decl of decls) {
                     const resolvedDecl = evaluator!.resolveAliasDeclaration(decl, resolveLocalNames);
                     if (resolvedDecl) {
                         addDeclarationIfUnique(declarations, resolvedDecl);
                     }
-                });
+                }
+            }
         }
     }
 
@@ -326,7 +330,9 @@ export class DocumentSymbolCollector extends ParseTreeWalker {
 
     private _resultsContainsDeclaration(usage: ParseNode, declarations: readonly Declaration[]) {
         const results = [...declarations];
-        this._usageProviders.forEach((p) => p.appendDeclarationsAt(usage, declarations, results));
+        for (const p of this._usageProviders) {
+            p.appendDeclarationsAt(usage, declarations, results);
+        }
 
         return results.some((declaration) => {
             // Resolve the declaration.
@@ -391,22 +397,22 @@ export class DocumentSymbolCollector extends ParseTreeWalker {
             return;
         }
 
-        dunderAllInfo.stringNodes.forEach((stringNode) => {
+        for (const stringNode of dunderAllInfo.stringNodes) {
             if (!this._symbolNames.has(stringNode.d.value)) {
-                return;
+                continue;
             }
 
             const symbolInScope = moduleScope.lookUpSymbolRecursive(stringNode.d.value);
             if (!symbolInScope) {
-                return;
+                continue;
             }
 
             if (!this._resultsContainsDeclaration(stringNode, symbolInScope.symbol.getDeclarations())) {
-                return;
+                continue;
             }
 
             this._dunderAllNameNodes.add(stringNode);
-        });
+        }
     }
 }
 

--- a/packages/pyright-internal/src/languageService/documentSymbolCollector.ts
+++ b/packages/pyright-internal/src/languageService/documentSymbolCollector.ts
@@ -236,9 +236,7 @@ export class DocumentSymbolCollector extends ParseTreeWalker {
         return resolvedDeclarations;
 
         function appendSymbolDeclarations(symbol: Symbol | undefined, declarations: Declaration[]) {
-            const decls = symbol
-                ?.getDeclarations()
-                .filter((d) => !isAliasDeclaration(d));
+            const decls = symbol?.getDeclarations().filter((d) => !isAliasDeclaration(d));
             if (decls) {
                 for (const decl of decls) {
                     const resolvedDecl = evaluator!.resolveAliasDeclaration(decl, resolveLocalNames);

--- a/packages/pyright-internal/src/languageService/fileWatcherDynamicFeature.ts
+++ b/packages/pyright-internal/src/languageService/fileWatcherDynamicFeature.ts
@@ -60,13 +60,13 @@ export class FileWatcherDynamicFeature extends DynamicFeature {
                     .filter(isDefined)
             );
 
-            foldersToWatch.forEach((p) => {
+            for (const p of foldersToWatch) {
                 const globPattern = isFile(this._fs, p, /* treatZipDirectoryAsFile */ true)
                     ? { baseUri: p.getDirectory().toString(), pattern: p.fileName }
                     : { baseUri: p.toString(), pattern: '**' };
 
                 watchers.push({ globPattern, kind: watchKind });
-            });
+            }
         }
 
         return this._connection.client.register(DidChangeWatchedFilesNotification.type, { watchers });

--- a/packages/pyright-internal/src/languageService/hoverProvider.ts
+++ b/packages/pyright-internal/src/languageService/hoverProvider.ts
@@ -292,9 +292,9 @@ export class HoverProvider {
                 this._addResultsForDeclaration(results.parts, primaryDeclaration, node);
             } else if (declInfo && declInfo.synthesizedTypes.length > 0) {
                 const nameNode = node;
-                declInfo?.synthesizedTypes.forEach((type) => {
+                for (const type of declInfo.synthesizedTypes) {
                     this._addResultsForSynthesizedType(results.parts, type, nameNode);
-                });
+                }
                 this._addDocumentationPart(results.parts, node, /* resolvedDecl */ undefined);
             } else if (!node.parent || node.parent.nodeType !== ParseNodeType.ModuleName) {
                 // If we had no declaration, see if we can provide a minimal tooltip. We'll skip

--- a/packages/pyright-internal/src/languageService/referencesProvider.ts
+++ b/packages/pyright-internal/src/languageService/referencesProvider.ts
@@ -358,10 +358,10 @@ export class ReferencesProvider {
             .filter(isDefined);
 
         // Check whether we need to add new symbol names and declarations.
-        providers.forEach((p) => {
+        for (const p of providers) {
             p.appendSymbolNamesTo(symbolNames);
             p.appendDeclarationsTo(declarations);
-        });
+        }
 
         return new ReferencesResult(
             requiresGlobalSearch,

--- a/packages/pyright-internal/src/languageService/renameProvider.ts
+++ b/packages/pyright-internal/src/languageService/renameProvider.ts
@@ -119,14 +119,14 @@ export class RenameProvider {
         }
 
         const edits: FileEditAction[] = [];
-        referencesResult.results.forEach((result) => {
+        for (const result of referencesResult.results) {
             // Special case the renames of keyword arguments.
             edits.push({
                 fileUri: result.location.uri,
                 range: result.location.range,
                 replacementText: newName,
             });
-        });
+        }
 
         return convertToWorkspaceEdit(this._program.fileSystem, { edits, fileOperations: [] });
     }

--- a/packages/pyright-internal/src/languageService/signatureHelpProvider.ts
+++ b/packages/pyright-internal/src/languageService/signatureHelpProvider.ts
@@ -241,7 +241,8 @@ export class SignatureHelpProvider {
         let activeParameter: number | undefined;
         const params = functionType.shared.parameters;
 
-        stringParts[0].forEach((paramString: string, paramIndex) => {
+        for (let paramIndex = 0; paramIndex < stringParts[0].length; paramIndex++) {
+            const paramString = stringParts[0][paramIndex];
             let paramName = '';
             if (paramIndex < params.length) {
                 paramName = params[paramIndex].name || '';
@@ -273,7 +274,7 @@ export class SignatureHelpProvider {
 
                 label += paramString;
             }
-        });
+        }
 
         label += ') -> ' + stringParts[1];
 

--- a/packages/pyright-internal/src/languageService/symbolIndexer.ts
+++ b/packages/pyright-internal/src/languageService/symbolIndexer.ts
@@ -105,9 +105,9 @@ function collectSymbolIndexData(
     }
 
     const symbolTable = scope.symbolTable;
-    symbolTable.forEach((symbol, name) => {
+    for (const [name, symbol] of symbolTable) {
         if (symbol.isIgnoredForProtocolMatch()) {
-            return;
+            continue;
         }
 
         // Prefer declarations with a defined type.
@@ -119,11 +119,11 @@ function collectSymbolIndexData(
         }
 
         if (!declaration) {
-            return;
+            continue;
         }
 
         if (DeclarationType.Alias === declaration.type && !shouldAliasBeIndexed(declaration, indexOptions)) {
-            return;
+            continue;
         }
 
         // We rely on ExternallyHidden flag to determine what
@@ -138,7 +138,7 @@ function collectSymbolIndexData(
             indexSymbolData,
             token
         );
-    });
+    }
 }
 
 function collectSymbolIndexDataForName(

--- a/packages/pyright-internal/src/languageService/tooltipUtils.ts
+++ b/packages/pyright-internal/src/languageService/tooltipUtils.ts
@@ -165,9 +165,9 @@ export function getConstructorTooltip(
         const overloads = OverloadedType.getOverloads(type).map((overload) =>
             getConstructorTooltip(constructorName, overload, evaluator, functionSignatureDisplay)
         );
-        overloads.forEach((overload, index) => {
+        for (const overload of overloads) {
             signature += overload + ': ...' + '\n\n';
-        });
+        }
     } else if (isFunction(type)) {
         const indentStr =
             functionSignatureDisplay === SignatureDisplayType.formatted

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -30,9 +30,9 @@ export class ParameterizedString<T extends {}> {
 
     format(params: T): string {
         let str = this._formatString;
-        Object.keys(params).forEach((key) => {
+        for (const key of Object.keys(params)) {
             str = str.replace(new RegExp(`{${key}}`, 'g'), (params as any)[key].toString());
-        });
+        }
         return str;
     }
 

--- a/packages/pyright-internal/src/parser/characters.ts
+++ b/packages/pyright-internal/src/parser/characters.ts
@@ -248,7 +248,7 @@ function _buildIdentifierLookupTableFromSurrogateRangeTable(
 function _buildIdentifierLookupTable(fastTableOnly: boolean): void {
     _identifierCharFastTable.fill(CharCategory.NotIdentifierChar);
 
-    _identifierCharRanges.forEach((table) => {
+    for (const table of _identifierCharRanges) {
         _buildIdentifierLookupTableFromUnicodeRangeTable(
             table,
             CharCategory.IdentifierChar,
@@ -256,9 +256,9 @@ function _buildIdentifierLookupTable(fastTableOnly: boolean): void {
             _identifierCharFastTable,
             _identifierCharMap
         );
-    });
+    }
 
-    _startIdentifierCharRanges.forEach((table) => {
+    for (const table of _startIdentifierCharRanges) {
         _buildIdentifierLookupTableFromUnicodeRangeTable(
             table,
             CharCategory.StartIdentifierChar,
@@ -266,7 +266,7 @@ function _buildIdentifierLookupTable(fastTableOnly: boolean): void {
             _identifierCharFastTable,
             _identifierCharMap
         );
-    });
+    }
 
     // Populate the surrogate tables for characters that require two
     // character codes.

--- a/packages/pyright-internal/src/parser/parseNodes.ts
+++ b/packages/pyright-internal/src/parser/parseNodes.ts
@@ -640,10 +640,10 @@ export namespace ClassNode {
             },
         };
 
-        decorators.forEach((decorator) => {
+        for (const decorator of decorators) {
             decorator.parent = node;
             extendRange(node, decorator);
-        });
+        }
 
         node.d.name.parent = node;
         node.d.suite.parent = node;
@@ -885,9 +885,9 @@ export namespace ErrorNode {
         }
 
         if (decorators) {
-            decorators.forEach((decorator) => {
+            for (const decorator of decorators) {
                 decorator.parent = node;
-            });
+            }
 
             if (decorators.length > 0) {
                 extendRange(node, decorators[0]);
@@ -1115,10 +1115,10 @@ export namespace TypeParameterListNode {
 
         extendRange(node, endToken);
 
-        params.forEach((param) => {
+        for (const param of params) {
             extendRange(node, param);
             param.parent = node;
-        });
+        }
 
         return node;
     }
@@ -1228,9 +1228,9 @@ export namespace FunctionAnnotationNode {
             },
         };
 
-        paramAnnotations.forEach((p) => {
+        for (const p of paramAnnotations) {
             p.parent = node;
-        });
+        }
         returnAnnotation.parent = node;
 
         extendRange(node, returnAnnotation);
@@ -1429,9 +1429,9 @@ export namespace CallNode {
         leftExpr.parent = node;
 
         if (args.length > 0) {
-            args.forEach((arg) => {
+            for (const arg of args) {
                 arg.parent = node;
-            });
+            }
             extendRange(node, args[args.length - 1]);
         }
 
@@ -1501,9 +1501,9 @@ export namespace IndexNode {
         };
 
         leftExpr.parent = node;
-        items.forEach((item) => {
+        for (const item of items) {
             item.parent = node;
-        });
+        }
 
         extendRange(node, closeBracketToken);
 
@@ -1806,16 +1806,16 @@ export namespace FormatStringNode {
             },
         };
 
-        fieldExprs.forEach((expr) => {
+        for (const expr of fieldExprs) {
             expr.parent = node;
             extendRange(node, expr);
-        });
+        }
 
         if (formatExprs) {
-            formatExprs.forEach((expr) => {
+            for (const expr of formatExprs) {
                 expr.parent = node;
                 extendRange(node, expr);
-            });
+            }
         }
 
         if (endToken) {
@@ -1857,9 +1857,9 @@ export namespace StringListNode {
         };
 
         if (strings.length > 0) {
-            strings.forEach((str) => {
+            for (const str of strings) {
                 str.parent = node;
-            });
+            }
             extendRange(node, strings[strings.length - 1]);
         }
 
@@ -2469,9 +2469,9 @@ export namespace PatternSequenceNode {
             extendRange(node, entries[entries.length - 1]);
         }
 
-        entries.forEach((entry) => {
+        for (const entry of entries) {
             entry.parent = node;
-        });
+        }
 
         return node;
     }
@@ -2503,9 +2503,9 @@ export namespace PatternAsNode {
             extendRange(node, orPatterns[orPatterns.length - 1]);
         }
 
-        orPatterns.forEach((pattern) => {
+        for (const pattern of orPatterns) {
             pattern.parent = node;
-        });
+        }
 
         if (target) {
             extendRange(node, target);
@@ -2563,9 +2563,9 @@ export namespace PatternClassNode {
         };
 
         className.parent = node;
-        args.forEach((arg) => {
+        for (const arg of args) {
             arg.parent = node;
-        });
+        }
 
         if (args.length > 0) {
             extendRange(node, args[args.length - 1]);
@@ -2664,9 +2664,9 @@ export namespace PatternMappingNode {
             extendRange(node, entries[entries.length - 1]);
         }
 
-        entries.forEach((entry) => {
+        for (const entry of entries) {
             entry.parent = node;
-        });
+        }
 
         return node;
     }

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -232,6 +232,8 @@ const maxChildNodeDepth = 256;
 export class Parser {
     private _fileContents?: string;
     private _tokenizerOutput?: TokenizerOutput;
+    private _tokens?: TextRangeCollection<Token>;
+    private _tokenCount = 0;
     private _tokenIndex = 0;
     private _areErrorsSuppressed = false;
     private _parseOptions: ParseOptions = new ParseOptions();
@@ -406,6 +408,8 @@ export class Parser {
             initialParenDepth,
             this._parseOptions.useNotebookMode
         );
+        this._tokens = this._tokenizerOutput.tokens;
+        this._tokenCount = this._tokens.count;
         this._tokenIndex = 0;
     }
 
@@ -5261,7 +5265,7 @@ export class Parser {
     }
 
     private _getNextToken(): Token {
-        const token = this._tokenizerOutput!.tokens.getItemAt(this._tokenIndex);
+        const token = this._tokens!.getItemAt(this._tokenIndex);
         if (!this._atEof()) {
             this._tokenIndex++;
         }
@@ -5272,19 +5276,20 @@ export class Parser {
     private _atEof(): boolean {
         // Are we pointing at the last token in the stream (which is
         // assumed to be an end-of-stream token)?
-        return this._tokenIndex >= this._tokenizerOutput!.tokens.count - 1;
+        return this._tokenIndex >= this._tokenCount - 1;
     }
 
     private _peekToken(count = 0): Token {
-        if (this._tokenIndex + count < 0) {
-            return this._tokenizerOutput!.tokens.getItemAt(0);
+        const targetIndex = this._tokenIndex + count;
+        if (targetIndex < 0) {
+            return this._tokens!.getItemAt(0);
         }
 
-        if (this._tokenIndex + count >= this._tokenizerOutput!.tokens.count) {
-            return this._tokenizerOutput!.tokens.getItemAt(this._tokenizerOutput!.tokens.count - 1);
+        if (targetIndex >= this._tokenCount) {
+            return this._tokens!.getItemAt(this._tokenCount - 1);
         }
 
-        return this._tokenizerOutput!.tokens.getItemAt(this._tokenIndex + count);
+        return this._tokens!.getItemAt(targetIndex);
     }
 
     private _peekTokenType(): TokenType {

--- a/packages/pyright-internal/src/parser/parser.ts
+++ b/packages/pyright-internal/src/parser/parser.ts
@@ -845,16 +845,16 @@ export class Parser {
 
         switch (node.nodeType) {
             case ParseNodeType.PatternSequence: {
-                node.d.entries.forEach((subpattern) => {
+                for (const subpattern of node.d.entries) {
                     this._reportDuplicatePatternCaptureTargets(subpattern, globalNameMap, localNameMap);
-                });
+                }
                 break;
             }
 
             case ParseNodeType.PatternClass: {
-                node.d.args.forEach((arg) => {
+                for (const arg of node.d.args) {
                     this._reportDuplicatePatternCaptureTargets(arg.d.pattern, globalNameMap, localNameMap);
-                });
+                }
                 break;
             }
 
@@ -870,14 +870,14 @@ export class Parser {
                 });
 
                 const combinedLocalOrNameMap = new Map<string, NameNode>();
-                orLocalNameMaps.forEach((orLocalNameMap) => {
-                    orLocalNameMap.forEach((node) => {
+                for (const orLocalNameMap of orLocalNameMaps) {
+                    for (const node of orLocalNameMap.values()) {
                         if (!combinedLocalOrNameMap.has(node.d.value)) {
                             combinedLocalOrNameMap.set(node.d.value, node);
                             reportTargetIfDuplicate(node);
                         }
-                    });
-                });
+                    }
+                }
                 break;
             }
 
@@ -889,7 +889,7 @@ export class Parser {
             }
 
             case ParseNodeType.PatternMapping: {
-                node.d.entries.forEach((mapEntry) => {
+                for (const mapEntry of node.d.entries) {
                     if (mapEntry.nodeType === ParseNodeType.PatternMappingExpandEntry) {
                         reportTargetIfDuplicate(mapEntry.d.target);
                     } else {
@@ -900,7 +900,7 @@ export class Parser {
                             localNameMap
                         );
                     }
-                });
+                }
                 break;
             }
 
@@ -915,16 +915,16 @@ export class Parser {
     private _getPatternTargetNames(node: PatternAtomNode, nameSet: Set<string>): void {
         switch (node.nodeType) {
             case ParseNodeType.PatternSequence: {
-                node.d.entries.forEach((subpattern) => {
+                for (const subpattern of node.d.entries) {
                     this._getPatternTargetNames(subpattern, nameSet);
-                });
+                }
                 break;
             }
 
             case ParseNodeType.PatternClass: {
-                node.d.args.forEach((arg) => {
+                for (const arg of node.d.args) {
                     this._getPatternTargetNames(arg.d.pattern, nameSet);
-                });
+                }
                 break;
             }
 
@@ -932,9 +932,9 @@ export class Parser {
                 if (node.d.target) {
                     nameSet.add(node.d.target.d.value);
                 }
-                node.d.orPatterns.forEach((subpattern) => {
+                for (const subpattern of node.d.orPatterns) {
                     this._getPatternTargetNames(subpattern, nameSet);
-                });
+                }
                 break;
             }
 
@@ -946,14 +946,14 @@ export class Parser {
             }
 
             case ParseNodeType.PatternMapping: {
-                node.d.entries.forEach((mapEntry) => {
+                for (const mapEntry of node.d.entries) {
                     if (mapEntry.nodeType === ParseNodeType.PatternMappingExpandEntry) {
                         nameSet.add(mapEntry.d.target.d.value);
                     } else {
                         this._getPatternTargetNames(mapEntry.d.keyPattern, nameSet);
                         this._getPatternTargetNames(mapEntry.d.valuePattern, nameSet);
                     }
-                });
+                }
                 break;
             }
 
@@ -999,11 +999,11 @@ export class Parser {
 
         if (orPatterns.length > 1) {
             // Star patterns cannot be ORed with other patterns.
-            orPatterns.forEach((patternAtom) => {
+            for (const patternAtom of orPatterns) {
                 if (patternAtom.nodeType === ParseNodeType.PatternCapture && patternAtom.d.isStar) {
                     this._addSyntaxError(LocMessage.starPatternInOrPattern(), patternAtom);
                 }
-            });
+            }
         }
 
         let target: NameNode | undefined;
@@ -1027,19 +1027,20 @@ export class Parser {
         }
 
         // Validate that irrefutable patterns are not in any entries other than the last.
-        orPatterns.forEach((orPattern, index) => {
+        for (let index = 0; index < orPatterns.length; index++) {
+            const orPattern = orPatterns[index];
             if (index < orPatterns.length - 1 && this._isPatternIrrefutable(orPattern)) {
                 this._addSyntaxError(LocMessage.orPatternIrrefutable(), orPattern);
             }
-        });
+        }
 
         // Validate that all bound variables are the same within all or patterns.
         const fullNameSet = new Set<string>();
-        orPatterns.forEach((orPattern) => {
+        for (const orPattern of orPatterns) {
             this._getPatternTargetNames(orPattern, fullNameSet);
-        });
+        }
 
-        orPatterns.forEach((orPattern) => {
+        for (const orPattern of orPatterns) {
             const localNameSet = new Set<string>();
             this._getPatternTargetNames(orPattern, localNameSet);
 
@@ -1053,7 +1054,7 @@ export class Parser {
                 );
                 this._addSyntaxError(LocMessage.orPatternMissingName() + diag.getString(), orPattern);
             }
-        });
+        }
 
         return PatternAsNode.create(orPatterns, target);
     }
@@ -1271,11 +1272,11 @@ export class Parser {
             assert(stringList.nodeType === ParseNodeType.StringList);
 
             // Check for f-strings, which are not allowed.
-            stringList.d.strings.forEach((stringAtom) => {
+            for (const stringAtom of stringList.d.strings) {
                 if (stringAtom.nodeType === ParseNodeType.FormatString) {
                     this._addSyntaxError(LocMessage.formatStringInPattern(), stringAtom);
                 }
-            });
+            }
 
             return PatternLiteralNode.create(stringList);
         }
@@ -1699,12 +1700,12 @@ export class Parser {
             ) {
                 if (seqExpr.nodeType === ParseNodeType.Tuple && !seqExpr.d.hasParens) {
                     let sawStar = false;
-                    seqExpr.d.items.forEach((expr) => {
+                    for (const expr of seqExpr.d.items) {
                         if (expr.nodeType === ParseNodeType.Unpack && !sawStar) {
                             this._addSyntaxError(LocMessage.unpackOperatorNotAllowed(), expr);
                             sawStar = true;
                         }
-                    });
+                    }
                 }
             }
 
@@ -1761,9 +1762,9 @@ export class Parser {
 
         compNode.d.forIfNodes = forIfList;
         if (forIfList.length > 0) {
-            forIfList.forEach((comp) => {
+            for (const comp of forIfList) {
                 comp.parent = compNode;
-            });
+            }
             extendRange(compNode, forIfList[forIfList.length - 1]);
         }
         return compNode;
@@ -2067,15 +2068,15 @@ export class Parser {
         }
 
         functionNode.d.params = paramList;
-        paramList.forEach((param) => {
+        for (const param of paramList) {
             param.parent = functionNode;
-        });
+        }
 
         if (decorators) {
             functionNode.d.decorators = decorators;
-            decorators.forEach((decorator) => {
+            for (const decorator of decorators) {
                 decorator.parent = functionNode;
-            });
+            }
 
             if (decorators.length > 0) {
                 extendRange(functionNode, decorators[0]);
@@ -2395,9 +2396,9 @@ export class Parser {
         }
 
         withNode.d.withItems = withItemList;
-        withItemList.forEach((withItem) => {
+        for (const withItem of withItemList) {
             withItem.parent = withNode;
-        });
+        }
 
         return withNode;
     }
@@ -2535,16 +2536,16 @@ export class Parser {
 
         const classNode = ClassNode.create(classToken, NameNode.create(nameToken), suite, typeParameters);
         classNode.d.arguments = argList;
-        argList.forEach((arg) => {
+        for (const arg of argList) {
             arg.parent = classNode;
-        });
+        }
 
         if (decorators) {
             classNode.d.decorators = decorators;
             if (decorators.length > 0) {
-                decorators.forEach((decorator) => {
+                for (const decorator of decorators) {
                     decorator.parent = classNode;
-                });
+                }
                 extendRange(classNode, decorators[0]);
             }
         }
@@ -2733,15 +2734,15 @@ export class Parser {
             const typingSymbolsOfInterest = ['Literal', 'TypeAlias', 'Annotated'];
 
             if (importFromNode.d.isWildcardImport) {
-                typingSymbolsOfInterest.forEach((s) => {
+                for (const s of typingSymbolsOfInterest) {
                     this._typingSymbolAliases.set(s, s);
-                });
+                }
             } else {
-                importFromNode.d.imports.forEach((imp) => {
+                for (const imp of importFromNode.d.imports) {
                     if (typingSymbolsOfInterest.some((s) => s === imp.d.name.d.value)) {
                         this._typingSymbolAliases.set(imp.d.alias?.d.value || imp.d.name.d.value, imp.d.name.d.value);
                     }
-                });
+                }
             }
         }
 
@@ -2795,14 +2796,14 @@ export class Parser {
             } else {
                 // Implicitly import all modules in the multi-part name if we
                 // are not assigning the final module to an alias.
-                importAsNode.d.module.d.nameParts.forEach((_, index) => {
+                for (let index = 0; index < importAsNode.d.module.d.nameParts.length; index++) {
                     this._importedModules.push({
                         nameNode: importAsNode.d.module,
                         leadingDots: importAsNode.d.module.d.leadingDots,
                         nameParts: nameParts.slice(0, index + 1),
                         importedSymbols: undefined,
                     });
-                });
+                }
             }
 
             if (modName.d.nameParts.length === 1) {
@@ -2877,9 +2878,9 @@ export class Parser {
         const globalNode = GlobalNode.create(globalToken);
         globalNode.d.targets = this._parseNameList();
         if (globalNode.d.targets.length > 0) {
-            globalNode.d.targets.forEach((name) => {
+            for (const name of globalNode.d.targets) {
                 name.parent = globalNode;
-            });
+            }
             extendRange(globalNode, globalNode.d.targets[globalNode.d.targets.length - 1]);
         }
         return globalNode;
@@ -2891,9 +2892,9 @@ export class Parser {
         const nonlocalNode = NonlocalNode.create(nonlocalToken);
         nonlocalNode.d.targets = this._parseNameList();
         if (nonlocalNode.d.targets.length > 0) {
-            nonlocalNode.d.targets.forEach((name) => {
+            for (const name of nonlocalNode.d.targets) {
                 name.parent = nonlocalNode;
-            });
+            }
             extendRange(nonlocalNode, nonlocalNode.d.targets[nonlocalNode.d.targets.length - 1]);
         }
         return nonlocalNode;
@@ -2968,9 +2969,9 @@ export class Parser {
         const delNode = DelNode.create(delToken);
         delNode.d.targets = exprListResult.list;
         if (delNode.d.targets.length > 0) {
-            delNode.d.targets.forEach((expr) => {
+            for (const expr of delNode.d.targets) {
                 expr.parent = delNode;
-            });
+            }
             extendRange(delNode, delNode.d.targets[delNode.d.targets.length - 1]);
         }
         return delNode;
@@ -3170,9 +3171,9 @@ export class Parser {
         const tupleNode = TupleNode.create(tupleStartRange, enclosedInParens);
         tupleNode.d.items = exprListResult.list;
         if (exprListResult.list.length > 0) {
-            exprListResult.list.forEach((expr) => {
+            for (const expr of exprListResult.list) {
                 expr.parent = tupleNode;
-            });
+            }
             extendRange(tupleNode, exprListResult.list[exprListResult.list.length - 1]);
         }
 
@@ -3650,13 +3651,13 @@ export class Parser {
                 const callNode = CallNode.create(atomExpression, argListResult.args, argListResult.trailingComma);
 
                 if (argListResult.args.length > 1 || argListResult.trailingComma) {
-                    argListResult.args.forEach((arg) => {
+                    for (const arg of argListResult.args) {
                         if (arg.d.valueExpr.nodeType === ParseNodeType.Comprehension) {
                             if (!arg.d.valueExpr.d.hasParens) {
                                 this._addSyntaxError(LocMessage.generatorNotParenthesized(), arg.d.valueExpr);
                             }
                         }
-                    });
+                    }
                 }
 
                 const nextToken = this._peekToken();
@@ -4173,9 +4174,9 @@ export class Parser {
 
         const lambdaNode = LambdaNode.create(lambdaToken, testExpr);
         lambdaNode.d.params = argList;
-        argList.forEach((arg) => {
+        for (const arg of argList) {
             arg.parent = lambdaNode;
-        });
+        }
         return lambdaNode;
     }
 
@@ -4255,9 +4256,9 @@ export class Parser {
             }
 
             if (exprListResult.list.length > 0) {
-                exprListResult.list.forEach((expr) => {
+                for (const expr of exprListResult.list) {
                     expr.parent = listAtom;
-                });
+                }
                 extendRange(listAtom, exprListResult.list[exprListResult.list.length - 1]);
             }
 
@@ -4436,9 +4437,9 @@ export class Parser {
                 extendRange(setAtom, setEntries[setEntries.length - 1]);
             }
 
-            setEntries.forEach((entry) => {
+            for (const entry of setEntries) {
                 entry.parent = setAtom;
-            });
+            }
 
             setAtom.d.items = setEntries;
             return setAtom;
@@ -4456,9 +4457,9 @@ export class Parser {
         }
 
         if (dictionaryEntries.length > 0) {
-            dictionaryEntries.forEach((entry) => {
+            for (const entry of dictionaryEntries) {
                 entry.parent = dictionaryAtom;
-            });
+            }
             extendRange(dictionaryAtom, dictionaryEntries[dictionaryEntries.length - 1]);
         }
         dictionaryAtom.d.items = dictionaryEntries;
@@ -4637,11 +4638,12 @@ export class Parser {
             }
         }
 
-        assignmentTargets.forEach((target, index) => {
+        for (let index = 0; index < assignmentTargets.length; index++) {
+            const target = assignmentTargets[index];
             if (index > 0) {
                 assignmentNode = AssignmentNode.create(target, assignmentNode);
             }
-        });
+        }
 
         return assignmentNode;
     }
@@ -4839,9 +4841,9 @@ export class Parser {
             this._typingSymbolAliases
         );
 
-        parseResults.diagnostics.forEach((diag) => {
+        for (const diag of parseResults.diagnostics) {
             this._addSyntaxError(diag.message, stringListNode);
-        });
+        }
 
         if (!parseResults.parseTree) {
             return undefined;
@@ -4864,9 +4866,9 @@ export class Parser {
             this._typingSymbolAliases
         );
 
-        parseResults.diagnostics.forEach((diag) => {
+        for (const diag of parseResults.diagnostics) {
             this._addSyntaxError(diag.message, stringListNode);
-        });
+        }
 
         if (!parseResults.parseTree) {
             return;
@@ -5152,9 +5154,9 @@ export class Parser {
                         parseResults.diagnostics.length === 0 ||
                         this._parseOptions.reportErrorsForParsedStringContents
                     ) {
-                        parseResults.diagnostics.forEach((diag) => {
+                        for (const diag of parseResults.diagnostics) {
                             this._addSyntaxError(diag.message, stringNode);
-                        });
+                        }
 
                         if (parseResults.parseTree) {
                             stringNode.d.annotation = parseResults.parseTree;

--- a/packages/pyright-internal/src/parser/tokenizer.ts
+++ b/packages/pyright-internal/src/parser/tokenizer.ts
@@ -859,7 +859,8 @@ export class Tokenizer {
                     this._indentAmounts.pop();
                 }
 
-                dedentPoints.forEach((dedentAmount, index) => {
+                for (let index = 0; index < dedentPoints.length; index++) {
+                    const dedentAmount = dedentPoints[index];
                     const matchesIndent = index < dedentPoints.length - 1 || dedentAmount === tab8Spaces;
                     const actualDedentAmount = index < dedentPoints.length - 1 ? dedentAmount : tab8Spaces;
                     this._tokens.push(
@@ -874,7 +875,7 @@ export class Tokenizer {
                     );
 
                     isDedentAmbiguous = false;
-                });
+                }
             }
         }
     }

--- a/packages/pyright-internal/src/parser/tokenizer.ts
+++ b/packages/pyright-internal/src/parser/tokenizer.ts
@@ -92,6 +92,63 @@ const _keywords: Map<string, KeywordType> = new Map([
 
 const _softKeywords = new Set(['match', 'case', 'type']);
 
+const _keywordFirstCharTable: boolean[] = (() => {
+    const table = new Array<boolean>(128).fill(false);
+    for (const keyword of _keywords.keys()) {
+        const firstCharCode = keyword.charCodeAt(0);
+        if (firstCharCode < 128) {
+            table[firstCharCode] = true;
+        }
+    }
+    return table;
+})();
+
+const _keywordMinLen = 2;
+const _keywordMaxLen = 9; // __debug__
+
+interface KeywordEntry {
+    text: string;
+    type: KeywordType;
+}
+
+// For keyword-like identifiers, compare directly against the source text slice
+// to avoid creating temporary substring objects on the keyword path.
+const _keywordEntriesByFirstChar: Array<KeywordEntry[] | undefined> = (() => {
+    const entriesByFirstChar: Array<KeywordEntry[] | undefined> = new Array(128);
+    for (const [text, type] of _keywords.entries()) {
+        const firstCharCode = text.charCodeAt(0);
+        if (firstCharCode < 128) {
+            const entries = entriesByFirstChar[firstCharCode] ?? (entriesByFirstChar[firstCharCode] = []);
+            entries.push({ text, type });
+        }
+    }
+    return entriesByFirstChar;
+})();
+
+function getKeywordTypeFromTextSlice(text: string, start: number, length: number): KeywordType | undefined {
+    if (length < _keywordMinLen || length > _keywordMaxLen) {
+        return undefined;
+    }
+
+    const firstCharCode = text.charCodeAt(start);
+    if (firstCharCode >= 128 || !_keywordFirstCharTable[firstCharCode]) {
+        return undefined;
+    }
+
+    const candidates = _keywordEntriesByFirstChar[firstCharCode];
+    if (!candidates) {
+        return undefined;
+    }
+
+    for (const candidate of candidates) {
+        if (candidate.text.length === length && text.startsWith(candidate.text, start)) {
+            return candidate.type;
+        }
+    }
+
+    return undefined;
+}
+
 const _operatorInfo: { [key: number]: OperatorFlags } = {
     [OperatorType.Add]: OperatorFlags.Unary | OperatorFlags.Binary,
     [OperatorType.AddEqual]: OperatorFlags.Assignment,
@@ -138,13 +195,116 @@ const _operatorInfo: { [key: number]: OperatorFlags } = {
     [OperatorType.NotIn]: OperatorFlags.Binary,
 };
 
+const _unsetSingleCharOperatorType = -1;
+const _singleCharOperatorTypeTable: Int16Array = (() => {
+    const table = new Int16Array(128);
+    table.fill(_unsetSingleCharOperatorType);
+    table[Char.Equal] = OperatorType.Assign;
+    table[Char.Plus] = OperatorType.Add;
+    table[Char.Hyphen] = OperatorType.Subtract;
+    table[Char.Asterisk] = OperatorType.Multiply;
+    table[Char.Slash] = OperatorType.Divide;
+    table[Char.Ampersand] = OperatorType.BitwiseAnd;
+    table[Char.Bar] = OperatorType.BitwiseOr;
+    table[Char.Caret] = OperatorType.BitwiseXor;
+    table[Char.Percent] = OperatorType.Mod;
+    table[Char.Tilde] = OperatorType.BitwiseInvert;
+    table[Char.At] = OperatorType.MatrixMultiply;
+    table[Char.Less] = OperatorType.LessThan;
+    table[Char.Greater] = OperatorType.GreaterThan;
+    return table;
+})();
+
+const _singleCharEqualOperatorTypeTable: Int16Array = (() => {
+    const table = new Int16Array(128);
+    table.fill(_unsetSingleCharOperatorType);
+    table[Char.Plus] = OperatorType.AddEqual;
+    table[Char.Hyphen] = OperatorType.SubtractEqual;
+    table[Char.Asterisk] = OperatorType.MultiplyEqual;
+    table[Char.Slash] = OperatorType.DivideEqual;
+    table[Char.Ampersand] = OperatorType.BitwiseAndEqual;
+    table[Char.Bar] = OperatorType.BitwiseOrEqual;
+    table[Char.Caret] = OperatorType.BitwiseXorEqual;
+    table[Char.Percent] = OperatorType.ModEqual;
+    table[Char.At] = OperatorType.MatrixMultiplyEqual;
+    return table;
+})();
+
+function getTwoCharKey(char1: number, char2: number): number {
+    return (char1 << 8) | char2;
+}
+
+const _unsetTwoCharOperatorType = -1;
+const _twoCharOperatorTypeTable: Int16Array = (() => {
+    const table = new Int16Array(1 << 16);
+    table.fill(_unsetTwoCharOperatorType);
+    table[getTwoCharKey(Char.Equal, Char.Equal)] = OperatorType.Equals;
+    table[getTwoCharKey(Char.ExclamationMark, Char.Equal)] = OperatorType.NotEquals;
+    table[getTwoCharKey(Char.Less, Char.Equal)] = OperatorType.LessThanOrEqual;
+    table[getTwoCharKey(Char.Greater, Char.Equal)] = OperatorType.GreaterThanOrEqual;
+    table[getTwoCharKey(Char.Less, Char.Greater)] = OperatorType.LessOrGreaterThan;
+    return table;
+})();
+
+const _unsetTwoCharSpecialTokenType = -1;
+const _twoCharSpecialTokenTypeTable: Int16Array = (() => {
+    const table = new Int16Array(1 << 16);
+    table.fill(_unsetTwoCharSpecialTokenType);
+    table[getTwoCharKey(Char.Hyphen, Char.Greater)] = TokenType.Arrow;
+    return table;
+})();
+
+const _repeatedCharOperatorTypeTable: Int16Array = (() => {
+    const table = new Int16Array(128);
+    table.fill(_unsetSingleCharOperatorType);
+    table[Char.Asterisk] = OperatorType.Power;
+    table[Char.Slash] = OperatorType.FloorDivide;
+    table[Char.Less] = OperatorType.LeftShift;
+    table[Char.Greater] = OperatorType.RightShift;
+    return table;
+})();
+
+const _repeatedCharEqualOperatorTypeTable: Int16Array = (() => {
+    const table = new Int16Array(128);
+    table.fill(_unsetSingleCharOperatorType);
+    table[Char.Asterisk] = OperatorType.PowerEqual;
+    table[Char.Slash] = OperatorType.FloorDivideEqual;
+    table[Char.Less] = OperatorType.LeftShiftEqual;
+    table[Char.Greater] = OperatorType.RightShiftEqual;
+    return table;
+})();
+
 const _byteOrderMarker = 0xfeff;
 
 const defaultTabSize = 8;
 const magicsRegEx = /\\\s*$/;
 const typeIgnoreCommentRegEx = /((^|#)\s*)type:\s*ignore(\s*\[([\s\w-,]*)\]|\s|$)/;
 const pyrightIgnoreCommentRegEx = /((^|#)\s*)pyright:\s*ignore(\s*\[([\s\w-,]*)\]|\s|$)/;
-const underscoreRegEx = /_/g;
+
+// Strip underscore characters from a source text range without first creating
+// an intermediate substring.
+function removeUnderscoresFromRange(text: string, start: number, end: number): string {
+    let firstUnderscoreIndex = -1;
+    for (let i = start; i < end; i++) {
+        if (text.charCodeAt(i) === Char.Underscore) {
+            firstUnderscoreIndex = i;
+            break;
+        }
+    }
+
+    if (firstUnderscoreIndex < 0) {
+        return text.slice(start, end);
+    }
+
+    let result = text.slice(start, firstUnderscoreIndex);
+    for (let i = firstUnderscoreIndex + 1; i < end; i++) {
+        if (text.charCodeAt(i) !== Char.Underscore) {
+            result += text[i];
+        }
+    }
+
+    return result;
+}
 
 export interface TokenizerOutput {
     // List of all tokens.
@@ -227,6 +387,7 @@ export class Tokenizer {
     private _typeIgnoreLines = new Map<number, IgnoreComment>();
     private _pyrightIgnoreLines = new Map<number, IgnoreComment>();
     private _comments: Comment[] | undefined;
+    private _identifierInternMap = new Map<string, string>();
     private _fStringStack: FStringContext[] = [];
     private _activeFString: FStringContext | undefined;
 
@@ -283,6 +444,7 @@ export class Tokenizer {
         this._parenDepth = initialParenDepth;
         this._lineRanges = [];
         this._indentAmounts = [];
+        this._identifierInternMap = new Map<string, string>();
         this._useNotebookMode = useNotebookMode;
 
         const end = start + length;
@@ -892,19 +1054,30 @@ export class Tokenizer {
         }
 
         if (this._cs.position > start) {
-            const value = this._cs.getText().slice(start, this._cs.position);
-            if (_keywords.has(value)) {
-                this._tokens.push(
-                    KeywordToken.create(start, this._cs.position - start, _keywords.get(value)!, this._getComments())
-                );
+            const end = this._cs.position;
+            const length = end - start;
+            const text = this._cs.getText();
+            const keywordType = getKeywordTypeFromTextSlice(text, start, length);
+
+            if (keywordType !== undefined) {
+                this._tokens.push(KeywordToken.create(start, length, keywordType, this._getComments()));
             } else {
-                this._tokens.push(
-                    IdentifierToken.create(start, this._cs.position - start, cloneStr(value), this._getComments())
-                );
+                const value = this._internIdentifierText(text.slice(start, end));
+                this._tokens.push(IdentifierToken.create(start, length, value, this._getComments()));
             }
             return true;
         }
         return false;
+    }
+
+    private _internIdentifierText(value: string): string {
+        const internedValue = this._identifierInternMap.get(value);
+        if (internedValue !== undefined) {
+            return internedValue;
+        }
+
+        this._identifierInternMap.set(value, value);
+        return value;
     }
 
     private _isPossibleNumber(): boolean {
@@ -973,8 +1146,9 @@ export class Tokenizer {
             }
 
             if (radix > 0) {
-                const text = this._cs.getText().slice(start, this._cs.position);
-                const simpleIntText = text.replace(underscoreRegEx, '');
+                const end = this._cs.position;
+                const text = this._cs.getText();
+                const simpleIntText = removeUnderscoresFromRange(text, start, end);
                 let intValue: number | bigint = parseInt(simpleIntText.slice(leadingChars), radix);
 
                 if (!isNaN(intValue)) {
@@ -988,7 +1162,7 @@ export class Tokenizer {
                     }
 
                     this._tokens.push(
-                        NumberToken.create(start, text.length, intValue, true, false, this._getComments())
+                        NumberToken.create(start, end - start, intValue, true, false, this._getComments())
                     );
                     return true;
                 }
@@ -1026,12 +1200,14 @@ export class Tokenizer {
         }
 
         if (isDecimalInteger) {
-            let text = this._cs.getText().slice(start, this._cs.position);
-            const simpleIntText = text.replace(underscoreRegEx, '');
+            const textEnd = this._cs.position;
+            const sourceText = this._cs.getText();
+            const simpleIntText = removeUnderscoresFromRange(sourceText, start, textEnd);
             let intValue: number | bigint = parseInt(simpleIntText, 10);
 
             if (!isNaN(intValue)) {
                 let isImaginary = false;
+                let tokenLength = textEnd - start;
 
                 const bigIntValue = BigInt(simpleIntText);
                 if (
@@ -1044,12 +1220,12 @@ export class Tokenizer {
 
                 if (this._cs.currentChar === Char.j || this._cs.currentChar === Char.J) {
                     isImaginary = true;
-                    text += String.fromCharCode(this._cs.currentChar);
                     this._cs.moveNext();
+                    tokenLength += 1;
                 }
 
                 this._tokens.push(
-                    NumberToken.create(start, text.length, intValue, true, isImaginary, this._getComments())
+                    NumberToken.create(start, tokenLength, intValue, true, isImaginary, this._getComments())
                 );
                 return true;
             }
@@ -1062,24 +1238,19 @@ export class Tokenizer {
             (this._cs.currentChar === Char.Period && this._cs.nextChar >= Char._0 && this._cs.nextChar <= Char._9)
         ) {
             if (this._skipFloatingPointCandidate()) {
-                let text = this._cs.getText().slice(start, this._cs.position);
-                const value = parseFloat(text);
+                const floatEnd = this._cs.position;
+                const floatText = this._cs.getText().slice(start, floatEnd);
+                const value = parseFloat(floatText);
                 if (!isNaN(value)) {
                     let isImaginary = false;
+                    let tokenLength = floatEnd - start;
                     if (this._cs.currentChar === Char.j || this._cs.currentChar === Char.J) {
                         isImaginary = true;
-                        text += String.fromCharCode(this._cs.currentChar);
                         this._cs.moveNext();
+                        tokenLength += 1;
                     }
                     this._tokens.push(
-                        NumberToken.create(
-                            start,
-                            this._cs.position - start,
-                            value,
-                            false,
-                            isImaginary,
-                            this._getComments()
-                        )
+                        NumberToken.create(start, tokenLength, value, false, isImaginary, this._getComments())
                     );
                     return true;
                 }
@@ -1091,139 +1262,80 @@ export class Tokenizer {
     }
 
     private _tryOperator(): boolean {
+        const currentChar = this._cs.currentChar;
         let length = 0;
         const nextChar = this._cs.nextChar;
         let operatorType: OperatorType;
 
-        switch (this._cs.currentChar) {
-            case Char.Plus:
-                length = nextChar === Char.Equal ? 2 : 1;
-                operatorType = length === 2 ? OperatorType.AddEqual : OperatorType.Add;
-                break;
+        if (currentChar < 128 && nextChar < 128) {
+            const twoCharKey = (currentChar << 8) | nextChar;
+            const specialTokenType = _twoCharSpecialTokenTypeTable[twoCharKey];
+            if (specialTokenType !== _unsetTwoCharSpecialTokenType) {
+                this._tokens.push(
+                    Token.create(specialTokenType as TokenType, this._cs.position, 2, this._getComments())
+                );
+                this._cs.advance(2);
+                return true;
+            }
 
-            case Char.Ampersand:
-                length = nextChar === Char.Equal ? 2 : 1;
-                operatorType = length === 2 ? OperatorType.BitwiseAndEqual : OperatorType.BitwiseAnd;
-                break;
+            const twoCharOperatorType = _twoCharOperatorTypeTable[twoCharKey];
+            if (twoCharOperatorType !== _unsetTwoCharOperatorType) {
+                this._tokens.push(
+                    OperatorToken.create(this._cs.position, 2, twoCharOperatorType as OperatorType, this._getComments())
+                );
+                this._cs.advance(2);
+                return true;
+            }
 
-            case Char.Bar:
-                length = nextChar === Char.Equal ? 2 : 1;
-                operatorType = length === 2 ? OperatorType.BitwiseOrEqual : OperatorType.BitwiseOr;
-                break;
-
-            case Char.Caret:
-                length = nextChar === Char.Equal ? 2 : 1;
-                operatorType = length === 2 ? OperatorType.BitwiseXorEqual : OperatorType.BitwiseXor;
-                break;
-
-            case Char.Equal:
-                if (
-                    this._activeFString?.activeReplacementField &&
-                    this._activeFString?.activeReplacementField.parenDepth === this._parenDepth &&
-                    !this._activeFString.activeReplacementField.inFormatSpecifier &&
-                    nextChar !== Char.Equal
-                ) {
-                    length = 1;
-                    operatorType = OperatorType.Assign;
-                    break;
-                }
-
-                length = nextChar === Char.Equal ? 2 : 1;
-                operatorType = length === 2 ? OperatorType.Equals : OperatorType.Assign;
-                break;
-
-            case Char.ExclamationMark:
-                if (nextChar !== Char.Equal) {
-                    if (this._activeFString) {
-                        // Handle the conversion separator (!) within an f-string.
-                        this._tokens.push(
-                            Token.create(TokenType.ExclamationMark, this._cs.position, 1, this._getComments())
-                        );
-                        this._cs.advance(1);
-                        return true;
-                    }
-
-                    return false;
-                }
-                length = 2;
-                operatorType = OperatorType.NotEquals;
-                break;
-
-            case Char.Percent:
-                length = nextChar === Char.Equal ? 2 : 1;
-                operatorType = length === 2 ? OperatorType.ModEqual : OperatorType.Mod;
-                break;
-
-            case Char.Tilde:
-                length = 1;
-                operatorType = OperatorType.BitwiseInvert;
-                break;
-
-            case Char.Hyphen:
-                if (nextChar === Char.Greater) {
-                    this._tokens.push(Token.create(TokenType.Arrow, this._cs.position, 2, this._getComments()));
-                    this._cs.advance(2);
+            if (currentChar === nextChar) {
+                const repeatedOperatorType = _repeatedCharOperatorTypeTable[currentChar];
+                if (repeatedOperatorType !== _unsetSingleCharOperatorType) {
+                    const hasTrailingEqual = this._cs.lookAhead(2) === Char.Equal;
+                    const repeatedLength = hasTrailingEqual ? 3 : 2;
+                    const operatorType = hasTrailingEqual
+                        ? _repeatedCharEqualOperatorTypeTable[currentChar]
+                        : repeatedOperatorType;
+                    this._tokens.push(
+                        OperatorToken.create(
+                            this._cs.position,
+                            repeatedLength,
+                            operatorType as OperatorType,
+                            this._getComments()
+                        )
+                    );
+                    this._cs.advance(repeatedLength);
                     return true;
                 }
-
-                length = nextChar === Char.Equal ? 2 : 1;
-                operatorType = length === 2 ? OperatorType.SubtractEqual : OperatorType.Subtract;
-                break;
-
-            case Char.Asterisk:
-                if (nextChar === Char.Asterisk) {
-                    length = this._cs.lookAhead(2) === Char.Equal ? 3 : 2;
-                    operatorType = length === 3 ? OperatorType.PowerEqual : OperatorType.Power;
-                } else {
-                    length = nextChar === Char.Equal ? 2 : 1;
-                    operatorType = length === 2 ? OperatorType.MultiplyEqual : OperatorType.Multiply;
-                }
-                break;
-
-            case Char.Slash:
-                if (nextChar === Char.Slash) {
-                    length = this._cs.lookAhead(2) === Char.Equal ? 3 : 2;
-                    operatorType = length === 3 ? OperatorType.FloorDivideEqual : OperatorType.FloorDivide;
-                } else {
-                    length = nextChar === Char.Equal ? 2 : 1;
-                    operatorType = length === 2 ? OperatorType.DivideEqual : OperatorType.Divide;
-                }
-                break;
-
-            case Char.Less:
-                if (nextChar === Char.Less) {
-                    length = this._cs.lookAhead(2) === Char.Equal ? 3 : 2;
-                    operatorType = length === 3 ? OperatorType.LeftShiftEqual : OperatorType.LeftShift;
-                } else if (nextChar === Char.Greater) {
-                    length = 2;
-                    operatorType = OperatorType.LessOrGreaterThan;
-                } else {
-                    length = nextChar === Char.Equal ? 2 : 1;
-                    operatorType = length === 2 ? OperatorType.LessThanOrEqual : OperatorType.LessThan;
-                }
-                break;
-
-            case Char.Greater:
-                if (nextChar === Char.Greater) {
-                    length = this._cs.lookAhead(2) === Char.Equal ? 3 : 2;
-                    operatorType = length === 3 ? OperatorType.RightShiftEqual : OperatorType.RightShift;
-                } else {
-                    length = nextChar === Char.Equal ? 2 : 1;
-                    operatorType = length === 2 ? OperatorType.GreaterThanOrEqual : OperatorType.GreaterThan;
-                }
-                break;
-
-            case Char.At:
-                length = nextChar === Char.Equal ? 2 : 1;
-                operatorType = length === 2 ? OperatorType.MatrixMultiplyEqual : OperatorType.MatrixMultiply;
-                break;
-
-            default:
-                return false;
+            }
         }
-        this._tokens.push(OperatorToken.create(this._cs.position, length, operatorType, this._getComments()));
-        this._cs.advance(length);
-        return length > 0;
+
+        if (currentChar < 128) {
+            const singleCharOperatorType = _singleCharOperatorTypeTable[currentChar];
+            if (singleCharOperatorType !== _unsetSingleCharOperatorType) {
+                const equalOperatorType = _singleCharEqualOperatorTypeTable[currentChar];
+                if (nextChar === Char.Equal && equalOperatorType !== _unsetSingleCharOperatorType) {
+                    length = 2;
+                    operatorType = equalOperatorType as OperatorType;
+                } else {
+                    length = 1;
+                    operatorType = singleCharOperatorType as OperatorType;
+                }
+
+                this._tokens.push(OperatorToken.create(this._cs.position, length, operatorType, this._getComments()));
+                this._cs.advance(length);
+                return true;
+            }
+        }
+
+        // `!=` is handled by the 2-char fast path above.
+        if (currentChar === Char.ExclamationMark && this._activeFString) {
+            // Handle the conversion separator (!) within an f-string.
+            this._tokens.push(Token.create(TokenType.ExclamationMark, this._cs.position, 1, this._getComments()));
+            this._cs.advance(1);
+            return true;
+        }
+
+        return false;
     }
 
     private _handleInvalid(): boolean {

--- a/packages/pyright-internal/src/parser/tokenizer.ts
+++ b/packages/pyright-internal/src/parser/tokenizer.ts
@@ -880,27 +880,14 @@ export class Tokenizer {
     }
 
     private _tryIdentifier(): boolean {
-        const swallowRemainingChars = () => {
-            while (true) {
-                if (isIdentifierChar(this._cs.currentChar)) {
-                    this._cs.moveNext();
-                } else if (isIdentifierChar(this._cs.currentChar, this._cs.nextChar)) {
-                    this._cs.moveNext();
-                    this._cs.moveNext();
-                } else {
-                    break;
-                }
-            }
-        };
-
         const start = this._cs.position;
         if (isIdentifierStartChar(this._cs.currentChar)) {
             this._cs.moveNext();
-            swallowRemainingChars();
+            this._swallowIdentifierChars();
         } else if (isIdentifierStartChar(this._cs.currentChar, this._cs.nextChar)) {
             this._cs.moveNext();
             this._cs.moveNext();
-            swallowRemainingChars();
+            this._swallowIdentifierChars();
         }
 
         if (this._cs.position > start) {
@@ -929,6 +916,19 @@ export class Tokenizer {
         }
 
         return false;
+    }
+
+    private _swallowIdentifierChars(): void {
+        while (true) {
+            if (isIdentifierChar(this._cs.currentChar)) {
+                this._cs.moveNext();
+            } else if (isIdentifierChar(this._cs.currentChar, this._cs.nextChar)) {
+                this._cs.moveNext();
+                this._cs.moveNext();
+            } else {
+                break;
+            }
+        }
     }
 
     private _tryNumber(): boolean {

--- a/packages/pyright-internal/src/parser/tokenizerTypes.ts
+++ b/packages/pyright-internal/src/parser/tokenizerTypes.ts
@@ -215,15 +215,21 @@ export interface TokenBase extends TextRange {
 export interface Token extends TokenBase {}
 
 export namespace Token {
-    export function create(type: TokenType, start: number, length: number, comments: Comment[] | undefined) {
-        const token: Token = {
+    export function create(type: TokenType, start: number, length: number, comments: Comment[] | undefined): Token {
+        if (comments !== undefined) {
+            return {
+                start,
+                length,
+                type,
+                comments,
+            };
+        }
+
+        return {
             start,
             length,
             type,
-            comments,
         };
-
-        return token;
     }
 }
 
@@ -240,17 +246,25 @@ export namespace IndentToken {
         indentAmount: number,
         isIndentAmbiguous: boolean,
         comments: Comment[] | undefined
-    ) {
-        const token: IndentToken = {
+    ): IndentToken {
+        if (comments !== undefined) {
+            return {
+                start,
+                length,
+                type: TokenType.Indent,
+                isIndentAmbiguous,
+                comments,
+                indentAmount,
+            };
+        }
+
+        return {
             start,
             length,
             type: TokenType.Indent,
             isIndentAmbiguous,
-            comments,
             indentAmount,
         };
-
-        return token;
     }
 }
 
@@ -269,18 +283,27 @@ export namespace DedentToken {
         matchesIndent: boolean,
         isDedentAmbiguous: boolean,
         comments: Comment[] | undefined
-    ) {
-        const token: DedentToken = {
+    ): DedentToken {
+        if (comments !== undefined) {
+            return {
+                start,
+                length,
+                type: TokenType.Dedent,
+                comments,
+                indentAmount,
+                matchesIndent,
+                isDedentAmbiguous,
+            };
+        }
+
+        return {
             start,
             length,
             type: TokenType.Dedent,
-            comments,
             indentAmount,
             matchesIndent,
             isDedentAmbiguous,
         };
-
-        return token;
     }
 }
 
@@ -290,16 +313,28 @@ export interface NewLineToken extends Token {
 }
 
 export namespace NewLineToken {
-    export function create(start: number, length: number, newLineType: NewLineType, comments: Comment[] | undefined) {
-        const token: NewLineToken = {
+    export function create(
+        start: number,
+        length: number,
+        newLineType: NewLineType,
+        comments: Comment[] | undefined
+    ): NewLineToken {
+        if (comments !== undefined) {
+            return {
+                start,
+                length,
+                type: TokenType.NewLine,
+                comments,
+                newLineType,
+            };
+        }
+
+        return {
             start,
             length,
             type: TokenType.NewLine,
-            comments,
             newLineType,
         };
-
-        return token;
     }
 }
 
@@ -309,16 +344,28 @@ export interface KeywordToken extends Token {
 }
 
 export namespace KeywordToken {
-    export function create(start: number, length: number, keywordType: KeywordType, comments: Comment[] | undefined) {
-        const token: KeywordToken = {
+    export function create(
+        start: number,
+        length: number,
+        keywordType: KeywordType,
+        comments: Comment[] | undefined
+    ): KeywordToken {
+        if (comments !== undefined) {
+            return {
+                start,
+                length,
+                type: TokenType.Keyword,
+                comments,
+                keywordType,
+            };
+        }
+
+        return {
             start,
             length,
             type: TokenType.Keyword,
-            comments,
             keywordType,
         };
-
-        return token;
     }
 
     export function isSoftKeyword(token: KeywordToken) {
@@ -350,19 +397,30 @@ export namespace StringToken {
         escapedValue: string,
         prefixLength: number,
         comments: Comment[] | undefined
-    ) {
-        const token: StringToken = {
+    ): StringToken {
+        const quoteMarkLength = flags & StringTokenFlags.Triplicate ? 3 : 1;
+        if (comments !== undefined) {
+            return {
+                start,
+                length,
+                type: TokenType.String,
+                flags,
+                escapedValue,
+                prefixLength,
+                quoteMarkLength,
+                comments,
+            };
+        }
+
+        return {
             start,
             length,
             type: TokenType.String,
             flags,
             escapedValue,
             prefixLength,
-            quoteMarkLength: flags & StringTokenFlags.Triplicate ? 3 : 1,
-            comments,
+            quoteMarkLength,
         };
-
-        return token;
     }
 }
 
@@ -386,18 +444,28 @@ export namespace FStringStartToken {
         flags: StringTokenFlags,
         prefixLength: number,
         comments: Comment[] | undefined
-    ) {
-        const token: FStringStartToken = {
+    ): FStringStartToken {
+        const quoteMarkLength = flags & StringTokenFlags.Triplicate ? 3 : 1;
+        if (comments !== undefined) {
+            return {
+                start,
+                length,
+                type: TokenType.FStringStart,
+                flags,
+                prefixLength,
+                quoteMarkLength,
+                comments,
+            };
+        }
+
+        return {
             start,
             length,
             type: TokenType.FStringStart,
             flags,
             prefixLength,
-            quoteMarkLength: flags & StringTokenFlags.Triplicate ? 3 : 1,
-            comments,
+            quoteMarkLength,
         };
-
-        return token;
     }
 }
 
@@ -456,18 +524,27 @@ export namespace NumberToken {
         isInteger: boolean,
         isImaginary: boolean,
         comments: Comment[] | undefined
-    ) {
-        const token: NumberToken = {
+    ): NumberToken {
+        if (comments !== undefined) {
+            return {
+                start,
+                length,
+                type: TokenType.Number,
+                isInteger,
+                isImaginary,
+                value,
+                comments,
+            };
+        }
+
+        return {
             start,
             length,
             type: TokenType.Number,
             isInteger,
             isImaginary,
             value,
-            comments,
         };
-
-        return token;
     }
 }
 
@@ -477,16 +554,28 @@ export interface OperatorToken extends Token {
 }
 
 export namespace OperatorToken {
-    export function create(start: number, length: number, operatorType: OperatorType, comments: Comment[] | undefined) {
-        const token: OperatorToken = {
+    export function create(
+        start: number,
+        length: number,
+        operatorType: OperatorType,
+        comments: Comment[] | undefined
+    ): OperatorToken {
+        if (comments !== undefined) {
+            return {
+                start,
+                length,
+                type: TokenType.Operator,
+                operatorType,
+                comments,
+            };
+        }
+
+        return {
             start,
             length,
             type: TokenType.Operator,
             operatorType,
-            comments,
         };
-
-        return token;
     }
 }
 
@@ -496,18 +585,36 @@ export interface IdentifierToken extends Token {
 }
 
 export namespace IdentifierToken {
-    export function create(start: number, length: number, value: string, comments: Comment[] | undefined) {
+    export function create(
+        start: number,
+        length: number,
+        value: string,
+        comments: Comment[] | undefined
+    ): IdentifierToken {
         // Perform "NFKC normalization", as per the Python lexical spec.
-        const normalizedValue = value.normalize('NFKC');
+        let normalizedValue = value;
+        for (let i = 0; i < value.length; i++) {
+            if (value.charCodeAt(i) > 0x7f) {
+                normalizedValue = value.normalize('NFKC');
+                break;
+            }
+        }
 
-        const token: IdentifierToken = {
+        if (comments !== undefined) {
+            return {
+                start,
+                length,
+                type: TokenType.Identifier,
+                value: normalizedValue,
+                comments,
+            };
+        }
+
+        return {
             start,
             length,
             type: TokenType.Identifier,
             value: normalizedValue,
-            comments,
         };
-
-        return token;
     }
 }

--- a/packages/pyright-internal/src/partialStubService.ts
+++ b/packages/pyright-internal/src/partialStubService.ts
@@ -134,7 +134,9 @@ export class PartialStubService implements SupportPartialStubs {
     clearPartialStubs(): void {
         this._rootSearched.clear();
         this._partialStubPackagePaths.clear();
-        this._movedDirectories.forEach((d) => d.dispose());
+        for (const d of this._movedDirectories) {
+            d.dispose();
+        }
         this._movedDirectories = [];
     }
 

--- a/packages/pyright-internal/src/pyright.ts
+++ b/packages/pyright-internal/src/pyright.ts
@@ -772,9 +772,9 @@ function runWorkerMessageLoop(workerNum: number, tempFolderName: string) {
             case 'setOptions': {
                 const options = new PyrightCommandLineOptions(process.cwd(), false);
 
-                Object.keys(messageObj.data).forEach((key) => {
+                for (const key of Object.keys(messageObj.data)) {
                     (options as any)[key] = messageObj.data[key];
-                });
+                }
 
                 let logLevel = LogLevel.Error;
                 if (options.configSettings.verboseOutput) {
@@ -907,13 +907,13 @@ function buildTypeCompletenessReport(
     };
 
     // Add the general diagnostics.
-    completenessReport.generalDiagnostics.forEach((diag) => {
+    for (const diag of completenessReport.generalDiagnostics) {
         const jsonDiag = convertDiagnosticToJson('', diag);
         if (isDiagnosticIncluded(jsonDiag.severity, minSeverityLevel)) {
             report.generalDiagnostics.push(jsonDiag);
         }
         accumulateReportDiagnosticStats(jsonDiag, report);
-    });
+    }
 
     report.typeCompleteness = {
         packageName,
@@ -941,25 +941,25 @@ function buildTypeCompletenessReport(
     };
 
     // Add the modules.
-    completenessReport.modules.forEach((module) => {
+    for (const module of completenessReport.modules.values()) {
         const jsonModule: PyrightPublicModuleReport = {
             name: module.name,
         };
 
         report.typeCompleteness!.modules.push(jsonModule);
-    });
+    }
 
     // Add the symbols.
-    completenessReport.symbols.forEach((symbol) => {
+    for (const symbol of completenessReport.symbols.values()) {
         const diagnostics: PyrightJsonDiagnostic[] = [];
 
         // Convert and filter the diagnostics.
-        symbol.diagnostics.forEach((diag) => {
+        for (const diag of symbol.diagnostics) {
             const jsonDiag = convertDiagnosticToJson(diag.uri.getFilePath(), diag.diagnostic);
             if (isDiagnosticIncluded(jsonDiag.severity, minSeverityLevel)) {
                 diagnostics.push(jsonDiag);
             }
-        });
+        }
 
         const jsonSymbol: PyrightPublicSymbolReport = {
             category: PackageTypeVerifier.getSymbolCategoryString(symbol.category),
@@ -998,7 +998,7 @@ function buildTypeCompletenessReport(
                 report.typeCompleteness!.otherSymbolCounts.withUnknownType++;
             }
         }
-    });
+    }
 
     const unknownSymbolCount = report.typeCompleteness.exportedSymbolCounts.withUnknownType;
     const ambiguousSymbolCount = report.typeCompleteness.exportedSymbolCounts.withAmbiguousType;
@@ -1031,52 +1031,52 @@ function printTypeCompletenessReportText(results: PyrightJsonResults, verboseOut
     if (completenessReport.modules.length > 0) {
         console.info('');
         console.info(`Public modules: ${completenessReport.modules.length}`);
-        completenessReport.modules.forEach((module) => {
+        for (const module of completenessReport.modules) {
             console.info(`   ${module.name}`);
-        });
+        }
     }
 
     // Print list of all symbols.
     if (completenessReport.symbols.length > 0 && verboseOutput) {
         console.info('');
         console.info(`Exported symbols: ${completenessReport.symbols.filter((sym) => sym.isExported).length}`);
-        completenessReport.symbols.forEach((symbol) => {
+        for (const symbol of completenessReport.symbols) {
             if (symbol.isExported) {
                 const refCount = symbol.referenceCount > 1 ? ` (${symbol.referenceCount} references)` : '';
                 console.info(`   ${symbol.name}${refCount}`);
             }
-        });
+        }
 
         console.info('');
         console.info(`Other referenced symbols: ${completenessReport.symbols.filter((sym) => !sym.isExported).length}`);
-        completenessReport.symbols.forEach((symbol) => {
+        for (const symbol of completenessReport.symbols) {
             if (!symbol.isExported) {
                 const refCount = symbol.referenceCount > 1 ? ` (${symbol.referenceCount} references)` : '';
                 console.info(`   ${symbol.name}${refCount}`);
             }
-        });
+        }
     }
 
     // Print all the general diagnostics.
-    results.generalDiagnostics.forEach((diag) => {
+    for (const diag of results.generalDiagnostics) {
         logDiagnosticToConsole(diag);
-    });
+    }
 
     // Print all the symbol-specific diagnostics.
     console.info('');
     console.info(`Symbols used in public interface:`);
-    results.typeCompleteness!.symbols.forEach((symbol) => {
+    for (const symbol of results.typeCompleteness!.symbols) {
         let diagnostics = symbol.diagnostics;
         if (!verboseOutput) {
             diagnostics = diagnostics.filter((diag) => diag.severity === 'error');
         }
         if (diagnostics.length > 0) {
             console.info(`${symbol.name}`);
-            diagnostics.forEach((diag) => {
+            for (const diag of diagnostics) {
                 logDiagnosticToConsole(diag);
-            });
+            }
         }
-    });
+    }
 
     // Print other stats.
     console.info('');
@@ -1175,8 +1175,8 @@ function reportDiagnosticsAsJson(
         },
     };
 
-    fileDiagnostics.forEach((fileDiag) => {
-        fileDiag.diagnostics.sort(compareDiagnostics).forEach((diag) => {
+    for (const fileDiag of fileDiagnostics) {
+        for (const diag of fileDiag.diagnostics.sort(compareDiagnostics)) {
             if (
                 diag.category === DiagnosticCategory.Error ||
                 diag.category === DiagnosticCategory.Warning ||
@@ -1189,8 +1189,8 @@ function reportDiagnosticsAsJson(
 
                 accumulateReportDiagnosticStats(jsonDiag, report);
             }
-        });
-    });
+        }
+    }
 
     console.info(JSON.stringify(report, /* replacer */ undefined, 4));
 
@@ -1255,9 +1255,9 @@ function reportDiagnosticsAsText(
     let warningCount = 0;
     let informationCount = 0;
 
-    fileDiagnostics.forEach((fileDiagnostics) => {
+    for (const fileDiag of fileDiagnostics) {
         // Don't report unused code or deprecated diagnostics.
-        const fileErrorsAndWarnings = fileDiagnostics.diagnostics
+        const fileErrorsAndWarnings = fileDiag.diagnostics
             .filter(
                 (diag) =>
                     diag.category !== DiagnosticCategory.UnusedCode &&
@@ -1268,9 +1268,9 @@ function reportDiagnosticsAsText(
             .sort(compareDiagnostics);
 
         if (fileErrorsAndWarnings.length > 0) {
-            console.info(`${fileDiagnostics.fileUri.toUserVisibleString()}`);
-            fileErrorsAndWarnings.forEach((diag) => {
-                const jsonDiag = convertDiagnosticToJson(fileDiagnostics.fileUri.getFilePath(), diag);
+            console.info(`${fileDiag.fileUri.toUserVisibleString()}`);
+            for (const diag of fileErrorsAndWarnings) {
+                const jsonDiag = convertDiagnosticToJson(fileDiag.fileUri.getFilePath(), diag);
                 logDiagnosticToConsole(jsonDiag);
 
                 if (diag.category === DiagnosticCategory.Error) {
@@ -1280,9 +1280,9 @@ function reportDiagnosticsAsText(
                 } else if (diag.category === DiagnosticCategory.Information) {
                     informationCount++;
                 }
-            });
+            }
         }
-    });
+    }
 
     console.info(
         `${errorCount.toString()} ${errorCount === 1 ? 'error' : 'errors'}, ` +

--- a/packages/pyright-internal/src/workspaceFactory.ts
+++ b/packages/pyright-internal/src/workspaceFactory.ts
@@ -130,49 +130,51 @@ export class WorkspaceFactory implements IWorkspaceFactory {
     handleInitialize(params: InitializeParams) {
         // Create a service instance for each of the workspace folders.
         if (params.workspaceFolders) {
-            params.workspaceFolders.forEach((folder) => {
+            for (const folder of params.workspaceFolders) {
                 this._add(Uri.parse(folder.uri, this._serviceProvider), folder.name, [WellKnownWorkspaceKinds.Regular]);
-            });
+            }
         } else if (params.rootPath) {
             this._add(Uri.file(params.rootPath, this._serviceProvider), '', [WellKnownWorkspaceKinds.Regular]);
         }
     }
 
     handleWorkspaceFoldersChanged(params: WorkspaceFoldersChangeEvent, workspaces: lspWorkspaceFolder[] | null) {
-        params.removed.forEach((workspaceInfo) => {
+        for (const workspaceInfo of params.removed) {
             const uri = Uri.parse(workspaceInfo.uri, this._serviceProvider);
             // Delete all workspaces for this folder. Even the ones generated for notebook kernels.
             const workspaces = this.getNonDefaultWorkspaces().filter((w) => w.rootUri.equals(uri));
-            workspaces.forEach((w) => {
+            for (const w of workspaces) {
                 this._remove(w);
-            });
-        });
+            }
+        }
 
-        params.added.forEach((workspaceInfo) => {
+        for (const workspaceInfo of params.added) {
             const uri = Uri.parse(workspaceInfo.uri, this._serviceProvider);
 
             // Skip if workspace already exists (e.g., created during initialize)
             if (this.getNonDefaultWorkspaces().some((w) => w.rootUri.equals(uri))) {
-                return;
+                continue;
             }
 
             this._add(uri, workspaceInfo.name, [WellKnownWorkspaceKinds.Regular]);
-        });
+        }
 
         // Ensure name changes are also reflected.
         const foldersToCheck =
             workspaces?.filter(
                 (w) => !params.added.some((a) => a.uri === w.uri) && !params.removed.some((a) => a.uri === w.uri)
             ) ?? [];
-        foldersToCheck.forEach((workspaceInfo) => {
+        for (const workspaceInfo of foldersToCheck) {
             const uri = Uri.parse(workspaceInfo.uri, this._serviceProvider);
 
             const workspaces = this.getNonDefaultWorkspaces().filter(
                 (w) => w.rootUri.equals(uri) && w.workspaceName !== workspaceInfo.name
             );
 
-            workspaces.forEach((w) => renameWorkspace(w, workspaceInfo.name));
-        });
+            for (const w of workspaces) {
+                renameWorkspace(w, workspaceInfo.name);
+            }
+        }
     }
 
     items() {
@@ -180,10 +182,10 @@ export class WorkspaceFactory implements IWorkspaceFactory {
     }
 
     clear() {
-        this._map.forEach((workspace) => {
+        for (const workspace of this._map.values()) {
             workspace.isInitialized.resolve();
             workspace.service.dispose();
-        });
+        }
         this._map.clear();
         this._console.log(`WorkspaceFactory ${this._id} clear`);
     }
@@ -215,17 +217,17 @@ export class WorkspaceFactory implements IWorkspaceFactory {
 
     getNonDefaultWorkspaces(kind?: string): NormalWorkspace[] {
         const workspaces: NormalWorkspace[] = [];
-        this._map.forEach((workspace) => {
+        for (const workspace of this._map.values()) {
             if (!workspace.rootUri) {
-                return;
+                continue;
             }
 
             if (kind && !workspace.kinds.some((k) => k === kind)) {
-                return;
+                continue;
             }
 
             workspaces.push(workspace);
-        });
+        }
 
         return workspaces;
     }


### PR DESCRIPTION
## Summary

This PR ports the pyrx Pyright optimization stack into this repo, including the Section 5 Type Evaluator optimizations plus related parser/tokenizer and loop-allocation reductions.

The migration preserved commit granularity/history by replaying the original stack (starting at `28b44c48432e7fc16a27299c57925e4bad28fcfa`) and then applying a small reconciliation commit for drift against current `main`.

## What changed

### Core performance work
- Type evaluator hot-path allocation and closure reductions.
- Overload resolution / call validation / variadic argument path optimizations.
- `typeUtils`, `typeGuards`, `constructors`, `constraintSolver`, `protocols`, `parameterUtils` hot-path loop conversions and option-object reuse.
- Broad `.forEach`/`.some`/`.find` to `for`/`for...of` conversions across `pyright-internal`.
- Tokenizer/parser optimizations:
  - keyword fast-reject and slice-based keyword checks
  - identifier interning
  - operator classification tables
  - underscore stripping without regex
  - ASCII fast path updates

### Correctness fix included from source stack
- `_validateEnumMembers`: corrected `return` -> `continue` semantics after callback-to-loop conversion.

## Benchmark methodology

Compared this branch vs baseline using built `pyright` CLI bundles against the same target:

- Target: `Q:\dev\pytorch`
- Command: `node packages/pyright/index.js Q:\dev\pytorch`
- Warmup: 1 run per branch
- Measured: 3 alternating runs per branch
- Both branches exited with code `1` (project diagnostics), but timing is directly comparable since invocation/target were identical.

## Benchmark results (PyTorch)

### Earlier (stale local/fork main baseline, now superseded)

| Branch | Run 1 (ms) | Run 2 (ms) | Run 3 (ms) | Median (ms) |
|---|---:|---:|---:|---:|
| `pyright-optimize` | 382,239 | 380,030 | 377,322 | **382,239** |
| `main` (stale baseline) | 410,305 | 404,522 | 399,780 | **410,305** |

Measured improvement there was +6.84%, but that baseline was out of date.

### Corrected baseline: latest `upstream/main`

Baseline commit: `3619ecdf4f41ede49fe297196c976d4761cf4733`  
Candidate commit: `49d54b7808bdb5ddef77a785fff486d7e49d04b5`

| Branch | Run 1 (ms) | Run 2 (ms) | Run 3 (ms) | Median (ms) |
|---|---:|---:|---:|---:|
| `pyright-optimize` | 400,556 | 395,753 | 387,905 | **400,556** |
| `upstream/main` | 397,619 | 380,249 | 369,224 | **397,619** |

**Net result vs latest upstream main:** **-0.74%** (candidate is slightly slower by median wall-clock).

Artifacts:
- `pyright-cli-pytorch-benchmark.json` (stale-baseline run)
- `pyright-cli-pytorch-benchmark-upstream-main.json` (corrected upstream-main run)

## Validation

- `npm run check:eslint -- --quiet`
- `npm --prefix packages/pyright-internal run build`
- `npm --prefix packages/pyright-internal run test`
