### PR TITLE
Load TOML before ecosystem benchmark CLI runs

### DIFF
--- a/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
@@ -3,7 +3,7 @@ import commandLineArgs, { CommandLineOptions, OptionDefinition } from 'command-l
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { parse } from '../../common/tomlUtils';
+import { ensureTomlModuleLoaded, parse } from '../../common/tomlUtils';
 
 import {
     BenchmarkMetricDefinition,
@@ -991,5 +991,10 @@ function writeNamedBenchmarkReport<ResultT>(
 }
 
 if (require.main === module) {
-    runEcosystemBenchmark(process.argv.slice(2));
+    void ensureTomlModuleLoaded()
+        .then(() => runEcosystemBenchmark(process.argv.slice(2)))
+        .catch((error: unknown) => {
+            console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+            process.exitCode = 1;
+        });
 }


### PR DESCRIPTION
Fixes the fork-main refresh-baseline workflow failure where the standalone ecosystem benchmark runner parsed pyproject.toml before the async TOML module finished loading.\n\nValidation:\n- npx prettier -c packages\\pyright-internal\\src\\tests\\benchmarks\\runEcosystemBenchmark.ts\n- cd packages\\pyright-internal && npm run build\n- PYRIGHT_RUN_BENCHMARKS=1 npx jest runEcosystemBenchmark.test --forceExit --runInBand\n- Standalone compiled runner smoke with pyproject.toml and --update-main-baseline