### PR TITLE
Fix ecosystem baseline output path

### DIFF
--- a/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
@@ -977,7 +977,7 @@ function getWritableBenchmarkFilePath(...pathParts: string[]): string {
         return sourceFilePath;
     }
 
-    return path.resolve(__dirname, '..', '..', '..', '..', 'src', 'tests', 'benchmarks', ...pathParts);
+    return path.resolve(__dirname, '..', '..', '..', '..', '..', '..', 'src', 'tests', 'benchmarks', ...pathParts);
 }
 
 function writeNamedBenchmarkReport<ResultT>(


### PR DESCRIPTION
Fix the built benchmark runner fallback path so refresh-baseline writes the checked-in source baseline file instead of a file under out/.\n\nValidation:\n- npx prettier -c packages\\pyright-internal\\src\\tests\\benchmarks\\runEcosystemBenchmark.ts\n- cd packages\\pyright-internal && npm run build\n- PYRIGHT_RUN_BENCHMARKS=1 npx jest runEcosystemBenchmark.test --forceExit --runInBand\n- ESLINT_USE_FLAT_CONFIG=false npx eslint src\\tests\\benchmarks\\runEcosystemBenchmark.ts