### PR TITLE
DO NOT MERGE: Test ecosystem benchmark regression reporting

### DIFF
--- a/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
@@ -310,7 +310,13 @@ export function executeEcosystemBenchmark(
         ? executeEcosystemBenchmarkSuite(selectedProjects, config.projectRoot, config.baselineExecutable)
         : undefined;
     const candidateResults = config.candidateExecutable
-        ? executeEcosystemBenchmarkSuite(selectedProjects, config.projectRoot, config.candidateExecutable)
+        ? // Intentional test-only slowdown for verifying ecosystem benchmark PR comments.
+          executeEcosystemBenchmarkSuite(selectedProjects, config.projectRoot, config.candidateExecutable).map(
+              (result) => ({
+                  ...result,
+                  totalTimeMs: result.totalTimeMs !== undefined ? result.totalTimeMs + 5000 : result.totalTimeMs,
+              })
+          )
         : undefined;
 
     const artifactPaths: EcosystemBenchmarkExecutionArtifactPaths = {};


### PR DESCRIPTION
Throwaway PR to verify ecosystem benchmark comments report a deliberately inflated candidate timing regression.\n\nThis intentionally adds 5000ms to candidate ecosystem benchmark result timings in the runner. Do not merge.\n\nValidation:\n- npx prettier -w packages\\pyright-internal\\src\\tests\\benchmarks\\runEcosystemBenchmark.ts\n- cd packages\\pyright-internal && npm run build\n- PYRIGHT_RUN_BENCHMARKS=1 npx jest runEcosystemBenchmark.test --forceExit --runInBand\n- ESLINT_USE_FLAT_CONFIG=false npx eslint packages\\pyright-internal\\src\\tests\\benchmarks\\runEcosystemBenchmark.ts