### PR TITLE
Clarify ecosystem benchmark PR comment heading

### DIFF
--- a/.github/workflows/pyright_ecosystem_benchmark.yaml
+++ b/.github/workflows/pyright_ecosystem_benchmark.yaml
@@ -228,7 +228,9 @@ jobs:
                 comparison = `${comparison.slice(0, maxCharacters)}\n\n... benchmark report truncated; see workflow artifacts for the full comparison.`;
               }
 
-              body = [marker, comparison, '', `[Workflow run](${runUrl})`].join('\n');
+              body = [marker, '## Pyright ecosystem benchmark stats', '', comparison, '', `[Workflow run](${runUrl})`].join(
+                '\n'
+              );
             } else if (process.env.BASELINE_READY !== 'true') {
               const reason = process.env.BASELINE_REASON || 'The checked-in ecosystem smoke baseline is not ready.';
               body = [


### PR DESCRIPTION
Prepend a clear `Pyright ecosystem benchmark stats` heading before comparison.md content so PR comments are easy to recognize as benchmark stats.

Validation:
- `npx prettier -c .github\workflows\pyright_ecosystem_benchmark.yaml`
- Updated PR #10 comment body to verify the presentation.