### PR TITLE
Add colored benchmark comparison status

### DIFF
--- a/packages/pyright-internal/src/tests/benchmarks/benchmarkComparison.test.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/benchmarkComparison.test.ts
@@ -139,11 +139,40 @@ benchmarkSuite('Benchmark Comparison', () => {
         const markdown = renderBenchmarkComparisonMarkdown(comparison);
 
         expect(markdown).toContain('## Summary');
-        expect(markdown).toContain('Regressions: 1');
-        expect(markdown).toContain('Improvements: 1');
+        expect(markdown).toContain('Status: 🔴 Regressions detected');
+        expect(markdown).toContain('Regressions: 🔴 1');
+        expect(markdown).toContain('Improvements: 🟢 1');
         expect(markdown).toContain('## Largest Regressions');
         expect(markdown).toContain('## Largest Improvements');
         expect(markdown).toContain('| case_a | medianMs | 100.00 | 110.00 |');
+        expect(markdown).toContain('| case_a | medianMs | 100.00 | 110.00 | 10.00 | 10.00% | 🔴 regression |');
+    });
+
+    test('renders a green markdown status when there are no regressions', () => {
+        const comparison = compareBenchmarkResultSets<TestResult>(
+            [{ name: 'case_a', medianMs: 100 }],
+            [{ name: 'case_a', medianMs: 80 }],
+            (result) => result.name,
+            [{ name: 'medianMs', getValue: (result) => result.medianMs }]
+        );
+        const markdown = renderBenchmarkComparisonMarkdown(comparison);
+
+        expect(markdown).toContain('Status: 🟢 No regressions; improvements detected');
+        expect(markdown).toContain('Regressions: 0');
+        expect(markdown).toContain('Improvements: 🟢 1');
+    });
+
+    test('renders a neutral markdown status when there are no benchmark changes', () => {
+        const comparison = compareBenchmarkResultSets<TestResult>(
+            [{ name: 'case_a', medianMs: 100 }],
+            [{ name: 'case_a', medianMs: 100 }],
+            (result) => result.name,
+            [{ name: 'medianMs', getValue: (result) => result.medianMs }]
+        );
+        const markdown = renderBenchmarkComparisonMarkdown(comparison);
+
+        expect(markdown).toContain('Status: ⚪ No benchmark changes');
+        expect(markdown).toContain('Unchanged: ⚪ 1');
     });
 
     test('summarizes benchmark comparison directions', () => {

--- a/packages/pyright-internal/src/tests/benchmarks/benchmarkComparison.test.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/benchmarkComparison.test.ts
@@ -145,7 +145,10 @@ benchmarkSuite('Benchmark Comparison', () => {
         expect(markdown).toContain('## Largest Regressions');
         expect(markdown).toContain('## Largest Improvements');
         expect(markdown).toContain('| case_a | medianMs | 100.00 | 110.00 |');
-        expect(markdown).toContain('| case_a | medianMs | 100.00 | 110.00 | 10.00 | 10.00% | 🔴 regression |');
+        expect(markdown).toContain('| Case | Metric | Baseline | Candidate | Delta | Delta % |');
+        expect(markdown).not.toContain('Direction');
+        expect(markdown).toContain('| case_a | medianMs | 100.00 | 110.00 | 🔴 10.00 | 🔴 10.00% |');
+        expect(markdown).toContain('| case_b | medianMs | 100.00 | 80.00 | 🟢 -20.00 | 🟢 -20.00% |');
     });
 
     test('renders a green markdown status when there are no regressions', () => {
@@ -173,6 +176,7 @@ benchmarkSuite('Benchmark Comparison', () => {
 
         expect(markdown).toContain('Status: ⚪ No benchmark changes');
         expect(markdown).toContain('Unchanged: ⚪ 1');
+        expect(markdown).toContain('| case_a | medianMs | 100.00 | 100.00 | ⚪ 0.00 | ⚪ 0.00% |');
     });
 
     test('summarizes benchmark comparison directions', () => {

--- a/packages/pyright-internal/src/tests/benchmarks/benchmarkComparison.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/benchmarkComparison.ts
@@ -229,8 +229,8 @@ export function renderBenchmarkComparisonMarkdown(comparison: BenchmarkResultSet
     lines.push(
         '## Details',
         '',
-        '| Case | Metric | Baseline | Candidate | Delta | Delta % | Direction |',
-        '|---|---:|---:|---:|---:|---:|---|'
+        '| Case | Metric | Baseline | Candidate | Delta | Delta % |',
+        '|---|---:|---:|---:|---:|---:|'
     );
 
     for (const result of comparison.compared) {
@@ -238,9 +238,10 @@ export function renderBenchmarkComparisonMarkdown(comparison: BenchmarkResultSet
             lines.push(
                 `| ${result.key} | ${metric.metric} | ${formatMetric(metric.baselineValue)} | ${formatMetric(
                     metric.candidateValue
-                )} | ${formatMetric(metric.absoluteDelta)} | ${formatPercent(
-                    metric.percentDelta
-                )} | ${formatDirectionWithColor(metric.direction)} |`
+                )} | ${formatDeltaWithColor(metric.absoluteDelta, metric.direction)} | ${formatPercentDeltaWithColor(
+                    metric.percentDelta,
+                    metric.direction
+                )} |`
             );
         }
     }
@@ -276,8 +277,12 @@ function formatCountWithColor(count: number, direction: BenchmarkMetricDirection
     return `${getDirectionColor(direction)} ${count}`;
 }
 
-function formatDirectionWithColor(direction: BenchmarkMetricDirection): string {
-    return `${getDirectionColor(direction)} ${direction}`;
+function formatDeltaWithColor(value: number, direction: BenchmarkMetricDirection): string {
+    return `${getDirectionColor(direction)} ${formatMetric(value)}`;
+}
+
+function formatPercentDeltaWithColor(value: number | undefined, direction: BenchmarkMetricDirection): string {
+    return `${getDirectionColor(direction)} ${formatPercent(value)}`;
 }
 
 function getDirectionColor(direction: BenchmarkMetricDirection): string {
@@ -309,7 +314,10 @@ function appendMetricEntryTable(
         lines.push(
             `| ${entry.key} | ${entry.metric} | ${formatMetric(entry.baselineValue)} | ${formatMetric(
                 entry.candidateValue
-            )} | ${formatMetric(entry.absoluteDelta)} | ${formatPercent(entry.percentDelta)} |`
+            )} | ${formatDeltaWithColor(entry.absoluteDelta, entry.direction)} | ${formatPercentDeltaWithColor(
+                entry.percentDelta,
+                entry.direction
+            )} |`
         );
     }
 

--- a/packages/pyright-internal/src/tests/benchmarks/benchmarkComparison.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/benchmarkComparison.ts
@@ -214,11 +214,12 @@ export function renderBenchmarkComparisonMarkdown(comparison: BenchmarkResultSet
     const lines = [
         '## Summary',
         '',
+        `Status: ${formatSummaryStatus(summary)}`,
         `Compared cases: ${summary.comparedResultCount}`,
         `Compared metrics: ${summary.metricCount}`,
-        `Regressions: ${summary.regressionCount}`,
-        `Improvements: ${summary.improvementCount}`,
-        `Unchanged: ${summary.unchangedCount}`,
+        `Regressions: ${formatCountWithColor(summary.regressionCount, 'regression')}`,
+        `Improvements: ${formatCountWithColor(summary.improvementCount, 'improvement')}`,
+        `Unchanged: ${formatCountWithColor(summary.unchangedCount, 'unchanged')}`,
         '',
     ];
 
@@ -237,9 +238,9 @@ export function renderBenchmarkComparisonMarkdown(comparison: BenchmarkResultSet
             lines.push(
                 `| ${result.key} | ${metric.metric} | ${formatMetric(metric.baselineValue)} | ${formatMetric(
                     metric.candidateValue
-                )} | ${formatMetric(metric.absoluteDelta)} | ${formatPercent(metric.percentDelta)} | ${
-                    metric.direction
-                } |`
+                )} | ${formatMetric(metric.absoluteDelta)} | ${formatPercent(
+                    metric.percentDelta
+                )} | ${formatDirectionWithColor(metric.direction)} |`
             );
         }
     }
@@ -253,6 +254,41 @@ export function renderBenchmarkComparisonMarkdown(comparison: BenchmarkResultSet
     }
 
     return `${lines.join('\n')}\n`;
+}
+
+function formatSummaryStatus(summary: BenchmarkComparisonSummary): string {
+    if (summary.regressionCount > 0) {
+        return '🔴 Regressions detected';
+    }
+
+    if (summary.improvementCount > 0) {
+        return '🟢 No regressions; improvements detected';
+    }
+
+    return '⚪ No benchmark changes';
+}
+
+function formatCountWithColor(count: number, direction: BenchmarkMetricDirection): string {
+    if (count === 0) {
+        return '0';
+    }
+
+    return `${getDirectionColor(direction)} ${count}`;
+}
+
+function formatDirectionWithColor(direction: BenchmarkMetricDirection): string {
+    return `${getDirectionColor(direction)} ${direction}`;
+}
+
+function getDirectionColor(direction: BenchmarkMetricDirection): string {
+    switch (direction) {
+        case 'regression':
+            return '🔴';
+        case 'improvement':
+            return '🟢';
+        case 'unchanged':
+            return '⚪';
+    }
 }
 
 function appendMetricEntryTable(


### PR DESCRIPTION
Add red/green/neutral status indicators to benchmark comparison markdown so ecosystem benchmark PR comments clearly show bad, good, or unchanged results.\n\nValidation:\n- cd packages\\pyright-internal && npm run build\n- PYRIGHT_RUN_BENCHMARKS=1 npx jest benchmarkComparison.test --forceExit --runInBand\n- ESLINT_USE_FLAT_CONFIG=false npx eslint packages\\pyright-internal\\src\\tests\\benchmarks\\benchmarkComparison.ts packages\\pyright-internal\\src\\tests\\benchmarks\\benchmarkComparison.test.ts