### PR TITLE
Use colored text in benchmark comparisons

### DIFF
--- a/packages/pyright-internal/src/tests/benchmarks/benchmarkComparison.test.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/benchmarkComparison.test.ts
@@ -139,16 +139,20 @@ benchmarkSuite('Benchmark Comparison', () => {
         const markdown = renderBenchmarkComparisonMarkdown(comparison);
 
         expect(markdown).toContain('## Summary');
-        expect(markdown).toContain('Status: 🔴 Regressions detected');
-        expect(markdown).toContain('Regressions: 🔴 1');
-        expect(markdown).toContain('Improvements: 🟢 1');
+        expect(markdown).toContain('Status: $\\textcolor{red}{Regressions\\ detected}$');
+        expect(markdown).toContain('Regressions: $\\textcolor{red}{1}$');
+        expect(markdown).toContain('Improvements: $\\textcolor{green}{1}$');
         expect(markdown).toContain('## Largest Regressions');
         expect(markdown).toContain('## Largest Improvements');
         expect(markdown).toContain('| case_a | medianMs | 100.00 | 110.00 |');
         expect(markdown).toContain('| Case | Metric | Baseline | Candidate | Delta | Delta % |');
         expect(markdown).not.toContain('Direction');
-        expect(markdown).toContain('| case_a | medianMs | 100.00 | 110.00 | 🔴 10.00 | 🔴 10.00% |');
-        expect(markdown).toContain('| case_b | medianMs | 100.00 | 80.00 | 🟢 -20.00 | 🟢 -20.00% |');
+        expect(markdown).toContain(
+            '| case_a | medianMs | 100.00 | 110.00 | $\\textcolor{red}{10.00}$ | $\\textcolor{red}{10.00\\%}$ |'
+        );
+        expect(markdown).toContain(
+            '| case_b | medianMs | 100.00 | 80.00 | $\\textcolor{green}{-20.00}$ | $\\textcolor{green}{-20.00\\%}$ |'
+        );
     });
 
     test('renders a green markdown status when there are no regressions', () => {
@@ -160,9 +164,9 @@ benchmarkSuite('Benchmark Comparison', () => {
         );
         const markdown = renderBenchmarkComparisonMarkdown(comparison);
 
-        expect(markdown).toContain('Status: 🟢 No regressions; improvements detected');
+        expect(markdown).toContain('Status: $\\textcolor{green}{No\\ regressions;\\ improvements\\ detected}$');
         expect(markdown).toContain('Regressions: 0');
-        expect(markdown).toContain('Improvements: 🟢 1');
+        expect(markdown).toContain('Improvements: $\\textcolor{green}{1}$');
     });
 
     test('renders a neutral markdown status when there are no benchmark changes', () => {
@@ -174,9 +178,11 @@ benchmarkSuite('Benchmark Comparison', () => {
         );
         const markdown = renderBenchmarkComparisonMarkdown(comparison);
 
-        expect(markdown).toContain('Status: ⚪ No benchmark changes');
-        expect(markdown).toContain('Unchanged: ⚪ 1');
-        expect(markdown).toContain('| case_a | medianMs | 100.00 | 100.00 | ⚪ 0.00 | ⚪ 0.00% |');
+        expect(markdown).toContain('Status: $\\textcolor{gray}{No\\ benchmark\\ changes}$');
+        expect(markdown).toContain('Unchanged: $\\textcolor{gray}{1}$');
+        expect(markdown).toContain(
+            '| case_a | medianMs | 100.00 | 100.00 | $\\textcolor{gray}{0.00}$ | $\\textcolor{gray}{0.00\\%}$ |'
+        );
     });
 
     test('summarizes benchmark comparison directions', () => {

--- a/packages/pyright-internal/src/tests/benchmarks/benchmarkComparison.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/benchmarkComparison.ts
@@ -259,14 +259,14 @@ export function renderBenchmarkComparisonMarkdown(comparison: BenchmarkResultSet
 
 function formatSummaryStatus(summary: BenchmarkComparisonSummary): string {
     if (summary.regressionCount > 0) {
-        return '🔴 Regressions detected';
+        return formatTextWithColor('Regressions detected', 'regression');
     }
 
     if (summary.improvementCount > 0) {
-        return '🟢 No regressions; improvements detected';
+        return formatTextWithColor('No regressions; improvements detected', 'improvement');
     }
 
-    return '⚪ No benchmark changes';
+    return formatTextWithColor('No benchmark changes', 'unchanged');
 }
 
 function formatCountWithColor(count: number, direction: BenchmarkMetricDirection): string {
@@ -274,26 +274,34 @@ function formatCountWithColor(count: number, direction: BenchmarkMetricDirection
         return '0';
     }
 
-    return `${getDirectionColor(direction)} ${count}`;
+    return formatTextWithColor(count.toString(), direction);
 }
 
 function formatDeltaWithColor(value: number, direction: BenchmarkMetricDirection): string {
-    return `${getDirectionColor(direction)} ${formatMetric(value)}`;
+    return formatTextWithColor(formatMetric(value), direction);
 }
 
 function formatPercentDeltaWithColor(value: number | undefined, direction: BenchmarkMetricDirection): string {
-    return `${getDirectionColor(direction)} ${formatPercent(value)}`;
+    return formatTextWithColor(formatPercent(value), direction);
 }
 
-function getDirectionColor(direction: BenchmarkMetricDirection): string {
+function formatTextWithColor(text: string, direction: BenchmarkMetricDirection): string {
+    return `$\\textcolor{${getDirectionTextColor(direction)}}{${escapeMathText(text)}}$`;
+}
+
+function getDirectionTextColor(direction: BenchmarkMetricDirection): string {
     switch (direction) {
         case 'regression':
-            return '🔴';
+            return 'red';
         case 'improvement':
-            return '🟢';
+            return 'green';
         case 'unchanged':
-            return '⚪';
+            return 'gray';
     }
+}
+
+function escapeMathText(text: string): string {
+    return text.replace(/\\/g, '\\backslash{}').replace(/ /g, '\\ ').replace(/%/g, '\\%').replace(/_/g, '\\_');
 }
 
 function appendMetricEntryTable(


### PR DESCRIPTION
Replace colored circle markers with GitHub-rendered colored text in benchmark comparison markdown. Delta and Delta % cells remain colored directly, and the Direction column stays removed.\n\nValidation:\n- cd packages\\pyright-internal && npm run build\n- PYRIGHT_RUN_BENCHMARKS=1 npx jest benchmarkComparison.test --forceExit --runInBand\n- ESLINT_USE_FLAT_CONFIG=false npx eslint packages\\pyright-internal\\src\\tests\\benchmarks\\benchmarkComparison.ts packages\\pyright-internal\\src\\tests\\benchmarks\\benchmarkComparison.test.ts