### PR TITLE
Cache and shard mypy_primer workflows

### DIFF
--- a/.github/workflows/mypy_primer_comment.yaml
+++ b/.github/workflows/mypy_primer_comment.yaml
@@ -14,6 +14,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   comment:
     name: Comment PR from mypy_primer

--- a/.github/workflows/mypy_primer_pr.yaml
+++ b/.github/workflows/mypy_primer_pr.yaml
@@ -8,10 +8,8 @@
 # This workflow definition borrows liberally from the mypy repo. The original
 # workflow was designed to work in a sharded manner where n copies of
 # mypy_primer are started in parallel. Each instance runs 1/n of the projects.
-# For now, we run only one instance because pyright is fast, and the number
-# of projects that use pyright for type checking is small. To change this in
-# the future, change the 'shard_index' matrix to [0, 1, ..., n-1] and set
-# 'num-shards' to n.
+# We use eight shards here so project checkout and type-checking work is
+# distributed across runners.
 
 name: Run mypy_primer on PR
 
@@ -34,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      MYPY_PRIMER_BASE_DIR: ${{ runner.temp }}/mypy_primer_cache
     strategy:
       matrix:
         shard-index: [0, 1, 2, 3, 4, 5, 6, 7]
@@ -46,6 +46,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Restore mypy_primer project cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.MYPY_PRIMER_BASE_DIR }}
+          key: ${{ runner.os }}-mypy-primer-pr-shard-${{ matrix.shard-index }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-mypy-primer-pr-shard-${{ matrix.shard-index }}-
+            ${{ runner.os }}-mypy-primer-
       - name: Install dependencies
         run: |
           python -m pip install -U pip
@@ -71,6 +79,7 @@ jobs:
             --type-checker pyright \
             --new $GITHUB_SHA --old base_commit \
             --num-shards 8 --shard-index ${{ matrix.shard-index }} \
+            --base-dir "$MYPY_PRIMER_BASE_DIR" \
             --debug \
             --output concise \
             | tee diff_${{ matrix.shard-index }}.txt

--- a/.github/workflows/mypy_primer_pr.yaml
+++ b/.github/workflows/mypy_primer_pr.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Restore mypy_primer project cache
         uses: actions/cache@v4
         with:
-          path: ${{ env.MYPY_PRIMER_BASE_DIR }}
+          path: ${{ env.MYPY_PRIMER_BASE_DIR }}/projects
           key: ${{ runner.os }}-mypy-primer-pr-shard-${{ matrix.shard-index }}-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-mypy-primer-pr-shard-${{ matrix.shard-index }}-
@@ -85,6 +85,13 @@ jobs:
             --output concise \
             | tee diff_${{ matrix.shard-index }}.txt
           ) || [ $? -eq 1 ]
+      - name: Trim mypy_primer project cache
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          if [[ -d "$MYPY_PRIMER_BASE_DIR/projects" ]]; then
+            find "$MYPY_PRIMER_BASE_DIR/projects" -maxdepth 1 -type d -name '_*_venv' -exec rm -rf {} +
+          fi
       - name: Upload mypy_primer diff
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/mypy_primer_pr.yaml
+++ b/.github/workflows/mypy_primer_pr.yaml
@@ -17,6 +17,7 @@ on:
   # Run on the creation or update of a PR.
   pull_request:
     paths:
+      - '.github/workflows/mypy_primer_*.yaml'
       - 'packages/pyright/**'
       - 'packages/pyright-internal/src/**'
       - 'packages/pyright-internal/typeshed-fallback/**'

--- a/.github/workflows/mypy_primer_pr.yaml
+++ b/.github/workflows/mypy_primer_pr.yaml
@@ -23,7 +23,7 @@ on:
       - 'packages/pyright-internal/typeshed-fallback/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/mypy_primer_pr.yaml
+++ b/.github/workflows/mypy_primer_pr.yaml
@@ -33,7 +33,7 @@ jobs:
     permissions:
       contents: read
     env:
-      MYPY_PRIMER_BASE_DIR: ${{ runner.temp }}/mypy_primer_cache
+      MYPY_PRIMER_BASE_DIR: ${{ github.workspace }}/.mypy_primer_cache
     strategy:
       matrix:
         shard-index: [0, 1, 2, 3, 4, 5, 6, 7]

--- a/.github/workflows/mypy_primer_push.yaml
+++ b/.github/workflows/mypy_primer_push.yaml
@@ -27,7 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      MYPY_PRIMER_BASE_DIR: ${{ runner.temp }}/mypy_primer_cache
     strategy:
+      matrix:
+        shard-index: [0, 1, 2, 3, 4, 5, 6, 7]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -37,6 +41,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Restore mypy_primer project cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.MYPY_PRIMER_BASE_DIR }}
+          key: ${{ runner.os }}-mypy-primer-push-shard-${{ matrix.shard-index }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-mypy-primer-push-shard-${{ matrix.shard-index }}-
+            ${{ runner.os }}-mypy-primer-
       - name: Install dependencies
         run: |
           python -m pip install -U pip
@@ -55,12 +67,14 @@ jobs:
             --repo pyright_to_test \
             --type-checker pyright \
             --new $GITHUB_SHA \
+            --num-shards 8 --shard-index ${{ matrix.shard-index }} \
+            --base-dir "$MYPY_PRIMER_BASE_DIR" \
             --debug \
             --output concise \
-            | tee diff.txt
+            | tee diff_${{ matrix.shard-index }}.txt
           ) || [ $? -eq 1 ]
       - name: Upload mypy_primer diff
         uses: actions/upload-artifact@v4
         with:
-          name: mypy_primer_diffs
-          path: diff.txt
+          name: mypy_primer_diffs_${{ matrix.shard-index }}
+          path: diff_${{ matrix.shard-index }}.txt

--- a/.github/workflows/mypy_primer_push.yaml
+++ b/.github/workflows/mypy_primer_push.yaml
@@ -31,7 +31,7 @@ jobs:
       MYPY_PRIMER_BASE_DIR: ${{ github.workspace }}/.mypy_primer_cache
     strategy:
       matrix:
-        shard-index: [0, 1, 2, 3, 4, 5, 6, 7]
+        shard-index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
       - name: Restore mypy_primer project cache
         uses: actions/cache@v4
         with:
-          path: ${{ env.MYPY_PRIMER_BASE_DIR }}
+          path: ${{ env.MYPY_PRIMER_BASE_DIR }}/projects
           key: ${{ runner.os }}-mypy-primer-push-shard-${{ matrix.shard-index }}-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-mypy-primer-push-shard-${{ matrix.shard-index }}-
@@ -67,12 +67,19 @@ jobs:
             --repo pyright_to_test \
             --type-checker pyright \
             --new $GITHUB_SHA \
-            --num-shards 8 --shard-index ${{ matrix.shard-index }} \
+            --num-shards 16 --shard-index ${{ matrix.shard-index }} \
             --base-dir "$MYPY_PRIMER_BASE_DIR" \
             --debug \
             --output concise \
             | tee diff_${{ matrix.shard-index }}.txt
           ) || [ $? -eq 1 ]
+      - name: Trim mypy_primer project cache
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          if [[ -d "$MYPY_PRIMER_BASE_DIR/projects" ]]; then
+            find "$MYPY_PRIMER_BASE_DIR/projects" -maxdepth 1 -type d -name '_*_venv' -exec rm -rf {} +
+          fi
       - name: Upload mypy_primer diff
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/mypy_primer_push.yaml
+++ b/.github/workflows/mypy_primer_push.yaml
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: read
     env:
-      MYPY_PRIMER_BASE_DIR: ${{ runner.temp }}/mypy_primer_cache
+      MYPY_PRIMER_BASE_DIR: ${{ github.workspace }}/.mypy_primer_cache
     strategy:
       matrix:
         shard-index: [0, 1, 2, 3, 4, 5, 6, 7]

--- a/.github/workflows/mypy_primer_push.yaml
+++ b/.github/workflows/mypy_primer_push.yaml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Speed up mypy_primer workflows by restoring a persistent mypy_primer --base-dir cache and using the same 8-way shard layout for push runs that PR runs already use.\n\nNotes:\n- The linked slow job had setup/install complete quickly; the long step was Run mypy_primer.\n- The cache uses per-shard restore keys and passes --base-dir to mypy_primer.\n- Push runs now upload one diff artifact per shard.\n\nValidation:\n- npx prettier -c .github\\workflows\\mypy_primer_pr.yaml .github\\workflows\\mypy_primer_push.yaml\n- git diff --check