### PR TITLE
Bound mypy_primer push benchmark scope

### DIFF
--- a/.github/workflows/mypy_primer_push.yaml
+++ b/.github/workflows/mypy_primer_push.yaml
@@ -79,7 +79,7 @@ jobs:
             --new $GITHUB_SHA \
             --num-shards 8 --shard-index ${{ matrix.shard-index }} \
             --base-dir "$MYPY_PRIMER_BASE_DIR" \
-            --project "$MYPY_PRIMER_PROJECT_SELECTOR" \
+            --project-selector "$MYPY_PRIMER_PROJECT_SELECTOR" \
             --debug \
             --output concise \
             | tee diff_${{ matrix.shard-index }}.txt

--- a/.github/workflows/mypy_primer_push.yaml
+++ b/.github/workflows/mypy_primer_push.yaml
@@ -1,7 +1,8 @@
 # This workflow runs mypy_primer, a tool that runs pyright on a variety
 # of open-source Python projects that are known to type check with pyright.
 # It builds pyright from the latest commit and the last release tag and
-# compares the output of both. It uploads the diffs as an artifact.
+# compares the output of both. Push runs use a bounded smoke project set by
+# default; manual runs can override the project regex for broader coverage.
 name: Run mypy_primer on push
 
 on:
@@ -15,6 +16,12 @@ on:
       - 'packages/pyright-internal/typeshed-fallback/**'
   # Also run manually if requested.
   workflow_dispatch:
+    inputs:
+      project:
+        description: 'Project location regex passed to mypy_primer. The default is a bounded smoke set; use .* for the full corpus.'
+        required: false
+        default: 'https://github.com/(python-attrs/attrs|pydantic/pydantic|pallets/werkzeug|pallets/jinja|pypa/packaging|encode/starlette|aio-libs/aiohttp|pytest-dev/pytest)$'
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,13 +32,15 @@ jobs:
     if: github.repository == 'microsoft/pyright' || github.repository == 'bschnurr/pyright'
     name: Run mypy_primer on push
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     env:
       MYPY_PRIMER_BASE_DIR: ${{ github.workspace }}/.mypy_primer_cache
+      MYPY_PRIMER_PROJECT_SELECTOR: ${{ inputs.project || 'https://github.com/(python-attrs/attrs|pydantic/pydantic|pallets/werkzeug|pallets/jinja|pypa/packaging|encode/starlette|aio-libs/aiohttp|pytest-dev/pytest)$' }}
     strategy:
       matrix:
-        shard-index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        shard-index: [0, 1, 2, 3, 4, 5, 6, 7]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -61,14 +70,16 @@ jobs:
           git rev-list --format=%s --max-count=1 $GITHUB_SHA
 
           cd ..
+          echo "project selector: $MYPY_PRIMER_PROJECT_SELECTOR"
           # fail action if exit code isn't zero or one
           (
             mypy_primer \
             --repo pyright_to_test \
             --type-checker pyright \
             --new $GITHUB_SHA \
-            --num-shards 16 --shard-index ${{ matrix.shard-index }} \
+            --num-shards 8 --shard-index ${{ matrix.shard-index }} \
             --base-dir "$MYPY_PRIMER_BASE_DIR" \
+            --project "$MYPY_PRIMER_PROJECT_SELECTOR" \
             --debug \
             --output concise \
             | tee diff_${{ matrix.shard-index }}.txt
@@ -81,6 +92,7 @@ jobs:
             find "$MYPY_PRIMER_BASE_DIR/projects" -maxdepth 1 -type d -name '_*_venv' -exec rm -rf {} +
           fi
       - name: Upload mypy_primer diff
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: mypy_primer_diffs_${{ matrix.shard-index }}


### PR DESCRIPTION
Make the mypy_primer push benchmark bounded by default so routine push/manual validation does not hang on a few huge projects. The workflow now runs an 8-project smoke selector by default, uses 8 shards, has a 60-minute job cap, uploads artifacts even on failure, and allows manual project regex override for broader runs.\n\nValidation: actionlint .github/workflows/mypy_primer_push.yaml