### PR TITLE
Avoid duplicate automatic benchmark runs

### DIFF
--- a/.github/workflows/mypy_primer_pr.yaml
+++ b/.github/workflows/mypy_primer_pr.yaml
@@ -20,6 +20,7 @@ on:
       - '.github/workflows/mypy_primer_*.yaml'
       - 'packages/pyright/**'
       - 'packages/pyright-internal/src/**'
+      - '!packages/pyright-internal/src/tests/benchmarks/**'
       - 'packages/pyright-internal/typeshed-fallback/**'
 
 concurrency:

--- a/.github/workflows/pyright_ecosystem_benchmark.yaml
+++ b/.github/workflows/pyright_ecosystem_benchmark.yaml
@@ -5,13 +5,11 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/mypy_primer_*.yaml'
       - '.github/workflows/pyright_ecosystem_benchmark.yaml'
-      - 'packages/pyright/**'
+      - '.github/workflows/sync_mypy_primer_ecosystem.yaml'
       - 'packages/pyright-internal/package.json'
       - 'packages/pyright-internal/package-lock.json'
-      - 'packages/pyright-internal/src/**'
-      - 'packages/pyright-internal/typeshed-fallback/**'
+      - 'packages/pyright-internal/src/tests/benchmarks/**'
   workflow_dispatch:
     inputs:
       mode:

--- a/.github/workflows/sync_mypy_primer_ecosystem.yaml
+++ b/.github/workflows/sync_mypy_primer_ecosystem.yaml
@@ -1,0 +1,102 @@
+name: Sync mypy_primer ecosystem metadata
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '20 9 * * 1'
+
+concurrency:
+  group: sync-mypy-primer-ecosystem
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    if: github.repository == 'bschnurr/pyright'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Fetch upstream mypy_primer projects
+        id: upstream
+        shell: bash
+        run: |
+          set -euo pipefail
+          upstream_repo="hauntsaninja/mypy_primer"
+          upstream_ref="$(gh api "repos/${upstream_repo}/commits/main" --jq .sha)"
+          snapshot_path="packages/pyright-internal/src/tests/benchmarks/mypy_primer.smoke_projects.snapshot.py"
+          url="https://raw.githubusercontent.com/${upstream_repo}/${upstream_ref}/mypy_primer/projects.py"
+
+          curl --fail --show-error --location "$url" --output "$snapshot_path"
+          project_count="$(grep -c 'Project(' "$snapshot_path")"
+          if [[ "$project_count" -lt 10 ]]; then
+            echo "Fetched projects.py contains only ${project_count} Project entries." >&2
+            exit 1
+          fi
+
+          {
+            echo "sha=$upstream_ref"
+            echo "project_count=$project_count"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Regenerate ecosystem metadata
+        run: |
+          npm ci
+          cd packages/pyright-internal
+          npm run build
+          npm run bench:ecosystem:sync
+
+      - name: Check for changes
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- packages/pyright-internal/src/tests/benchmarks/mypy_primer.smoke_projects.snapshot.py packages/pyright-internal/src/tests/benchmarks/ecosystem-projects.generated.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open sync pull request
+        if: steps.changes.outputs.changed == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          branch="automation/sync-mypy-primer-ecosystem"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -C "$branch"
+          git add packages/pyright-internal/src/tests/benchmarks/mypy_primer.smoke_projects.snapshot.py packages/pyright-internal/src/tests/benchmarks/ecosystem-projects.generated.json
+          git commit -m "Sync ecosystem mypy_primer metadata"
+          git push --force-with-lease origin "$branch"
+
+          body_file="$(mktemp)"
+          printf '%s\n' \
+            "Syncs the checked-in ecosystem benchmark mypy_primer snapshot and generated metadata from upstream mypy_primer." \
+            "" \
+            "Upstream: https://github.com/hauntsaninja/mypy_primer/commit/${{ steps.upstream.outputs.sha }}" \
+            "Project definitions fetched: ${{ steps.upstream.outputs.project_count }}" \
+            "" \
+            "After merge, run the ecosystem benchmark \`refresh-baseline\` workflow on main if the smoke project set changed." \
+            "" \
+            "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>" \
+            > "$body_file"
+
+          existing_pr="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // ""')"
+          if [[ -n "$existing_pr" ]]; then
+            gh pr edit "$existing_pr" --title "Sync ecosystem mypy_primer metadata" --body-file "$body_file"
+          else
+            gh pr create --head "$branch" --base main --title "Sync ecosystem mypy_primer metadata" --body-file "$body_file"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/packages/pyright-internal/src/tests/benchmarks/README.md
+++ b/packages/pyright-internal/src/tests/benchmarks/README.md
@@ -26,7 +26,7 @@ src/tests/benchmarks/.generated/benchmark-results/
     filters, writes a run manifest artifact, executes selected local project checkouts with provided Pyright commands,
     and compares existing or freshly executed ecosystem report files into
     `old.json`/`new.json`/`comparison.json`/`comparison.md` artifacts, including diagnostic count metrics and added/removed
-    diagnostic summaries.
+    diagnostic changes rendered as a mypy_primer-style diff block.
 - `syncMypyPrimerProjects.ts` is the first sync scaffold for normalizing `mypy_primer` project definitions into the
     generated ecosystem metadata file consumed by the smoke manifest. The checked-in smoke snapshot now carries the
     upstream `pyright_cmd` and `paths` data for the current smoke suite, so generated project configs can target real
@@ -132,8 +132,15 @@ PR comparison mode can then use the checked-in baseline by passing only the cand
 npm run bench:ecosystem:run -- --candidate-report ./src/tests/benchmarks/.generated/benchmark-results/ecosystem-pr/candidate-report.json --output ./src/tests/benchmarks/.generated/benchmark-results/ecosystem-pr-comparison
 ```
 
-The GitHub workflow posts `comparison.md` back to the PR when compare mode runs for a pull request, or when a manual
-compare run supplies the optional `pr_number` input. If a PR run skips comparison because the checked-in baseline is
-still the seed placeholder, the workflow posts a status comment explaining that benchmark stats are blocked until the
-real baseline is committed. The comment is updated in place using a hidden marker so repeated runs do not leave multiple
-benchmark comments.
+The GitHub workflow posts `comparison.md` back to the PR when compare mode runs for an ecosystem benchmark
+infrastructure pull request, or when a manual compare run supplies the optional `pr_number` input. General Pyright
+source changes use the `mypy_primer` PR workflow as the automatic ecosystem check; run this workflow manually when
+reviewers need the performance table. If a PR run skips comparison because the checked-in baseline is still the seed
+placeholder, the workflow posts a status comment explaining that benchmark stats are blocked until the real baseline is
+committed. The comment is updated in place using a hidden marker so repeated runs do not leave multiple benchmark
+comments.
+
+The checked-in mypy_primer snapshot can be refreshed with the `Sync mypy_primer ecosystem metadata` workflow. It runs on
+a weekly schedule and can also be dispatched manually. When upstream project metadata changes, the workflow updates
+`mypy_primer.smoke_projects.snapshot.py` and `ecosystem-projects.generated.json` on an automation branch and opens or
+updates a PR. If the smoke project set changes, refresh the main ecosystem baseline after merging the sync PR.

--- a/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.test.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.test.ts
@@ -429,8 +429,8 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
             expect(result.warningCount).toBe(1);
             expect(result.informationCount).toBe(0);
             expect(result.diagnostics).toEqual([
-                { file: undefined, severity: 'error', message: '' },
-                { file: undefined, severity: 'warning', message: '' },
+                { file: undefined, range: undefined, severity: 'error', message: '' },
+                { file: undefined, range: undefined, severity: 'warning', message: '' },
             ]);
             expect(result.totalTimeMs).toBeGreaterThanOrEqual(0);
         } finally {
@@ -978,7 +978,14 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
                             diagnosticCount: 1,
                             errorCount: 1,
                             warningCount: 0,
-                            diagnostics: [{ file: 'src/a.py', severity: 'error', message: 'old diagnostic' }],
+                            diagnostics: [
+                                {
+                                    file: 'src/a.py',
+                                    range: { start: { line: 4, character: 8 } },
+                                    severity: 'error',
+                                    message: 'old diagnostic',
+                                },
+                            ],
                         },
                     ]),
                     undefined,
@@ -996,8 +1003,18 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
                             errorCount: 1,
                             warningCount: 1,
                             diagnostics: [
-                                { file: 'src/a.py', severity: 'error', message: 'old diagnostic' },
-                                { file: 'src/b.py', severity: 'warning', message: 'new diagnostic' },
+                                {
+                                    file: 'src/a.py',
+                                    range: { start: { line: 4, character: 8 } },
+                                    severity: 'error',
+                                    message: 'old diagnostic',
+                                },
+                                {
+                                    file: 'src/b.py',
+                                    range: { start: { line: 9, character: 1 } },
+                                    severity: 'warning',
+                                    message: 'new diagnostic',
+                                },
                             ],
                         },
                     ]),
@@ -1018,12 +1035,16 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
             expect(comparison.diagnosticDiffs).toEqual([
                 {
                     projectName: 'black',
-                    added: ['warning | src/b.py | new diagnostic'],
+                    added: ['warning | src/b.py:10:2 | new diagnostic'],
                     removed: [],
                 },
             ]);
             expect(fs.readFileSync(artifactPaths.markdownPath, 'utf-8')).toContain('diagnosticCount');
-            expect(fs.readFileSync(artifactPaths.markdownPath, 'utf-8')).toContain('## Diagnostic Diffs');
+            expect(fs.readFileSync(artifactPaths.markdownPath, 'utf-8')).toContain('## Type Check Result Diff');
+            expect(fs.readFileSync(artifactPaths.markdownPath, 'utf-8')).toContain('```diff');
+            expect(fs.readFileSync(artifactPaths.markdownPath, 'utf-8')).toContain(
+                '+ warning | src/b.py:10:2 | new diagnostic'
+            );
         } finally {
             fs.rmSync(reportsDir, { force: true, recursive: true });
             fs.rmSync(outputDir, { force: true, recursive: true });
@@ -1045,7 +1066,12 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
                 {
                     projectName: 'black',
                     diagnostics: [
-                        { file: 'src/b.py', severity: 'information', message: 'new diagnostic' },
+                        {
+                            file: 'src/b.py',
+                            range: { start: { line: 2, character: 3 } },
+                            severity: 'information',
+                            message: 'new diagnostic',
+                        },
                         { file: 'src/stable.py', severity: 'warning', message: 'stable diagnostic' },
                     ],
                 },
@@ -1055,9 +1081,44 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
         expect(comparison.diagnosticDiffs).toEqual([
             {
                 projectName: 'black',
-                added: ['information | src/b.py | new diagnostic'],
+                added: ['information | src/b.py:3:4 | new diagnostic'],
                 removed: ['error | src/a.py | old diagnostic'],
             },
+        ]);
+    });
+
+    test('keeps repeated diagnostic messages distinct by location', () => {
+        const comparison = compareEcosystemBenchmarkReportData(
+            createEcosystemBenchmarkReport('2026-05-07T00:00:00.000Z', [
+                {
+                    projectName: 'black',
+                    diagnostics: [],
+                },
+            ]),
+            createEcosystemBenchmarkReport('2026-05-07T01:00:00.000Z', [
+                {
+                    projectName: 'black',
+                    diagnostics: [
+                        {
+                            file: 'src/repeated.py',
+                            range: { start: { line: 0, character: 0 } },
+                            severity: 'error',
+                            message: 'same diagnostic',
+                        },
+                        {
+                            file: 'src/repeated.py',
+                            range: { start: { line: 1, character: 0 } },
+                            severity: 'error',
+                            message: 'same diagnostic',
+                        },
+                    ],
+                },
+            ])
+        );
+
+        expect(comparison.diagnosticDiffs[0].added).toEqual([
+            'error | src/repeated.py:1:1 | same diagnostic',
+            'error | src/repeated.py:2:1 | same diagnostic',
         ]);
     });
 

--- a/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.test.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.test.ts
@@ -1122,6 +1122,31 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
         ]);
     });
 
+    test('compacts absolute diagnostic paths under the project checkout', () => {
+        const comparison = compareEcosystemBenchmarkReportData(
+            createEcosystemBenchmarkReport('2026-05-07T00:00:00.000Z', [
+                {
+                    projectName: 'attrs',
+                    diagnostics: [],
+                },
+            ]),
+            createEcosystemBenchmarkReport('2026-05-07T01:00:00.000Z', [
+                {
+                    projectName: 'attrs',
+                    diagnostics: [
+                        {
+                            file: '/home/runner/work/pyright/pyright/.ecosystem-projects/attrs/src/attr/__init__.py',
+                            severity: 'error',
+                            message: 'new diagnostic',
+                        },
+                    ],
+                },
+            ])
+        );
+
+        expect(comparison.diagnosticDiffs[0].added).toEqual(['.../attrs/src/attr/__init__.py - error: new diagnostic']);
+    });
+
     test('runs comparison mode end to end', () => {
         const reportsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pyright-ecosystem-report-main-'));
         const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pyright-ecosystem-compare-main-'));

--- a/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.test.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.test.ts
@@ -1035,7 +1035,7 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
             expect(comparison.diagnosticDiffs).toEqual([
                 {
                     projectName: 'black',
-                    added: ['warning | src/b.py:10:2 | new diagnostic'],
+                    added: ['src/b.py:10:2 - warning: new diagnostic'],
                     removed: [],
                 },
             ]);
@@ -1043,7 +1043,7 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
             expect(fs.readFileSync(artifactPaths.markdownPath, 'utf-8')).toContain('## Type Check Result Diff');
             expect(fs.readFileSync(artifactPaths.markdownPath, 'utf-8')).toContain('```diff');
             expect(fs.readFileSync(artifactPaths.markdownPath, 'utf-8')).toContain(
-                '+ warning | src/b.py:10:2 | new diagnostic'
+                '+   src/b.py:10:2 - warning: new diagnostic'
             );
         } finally {
             fs.rmSync(reportsDir, { force: true, recursive: true });
@@ -1081,8 +1081,8 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
         expect(comparison.diagnosticDiffs).toEqual([
             {
                 projectName: 'black',
-                added: ['information | src/b.py:3:4 | new diagnostic'],
-                removed: ['error | src/a.py | old diagnostic'],
+                added: ['src/b.py:3:4 - information: new diagnostic'],
+                removed: ['src/a.py - error: old diagnostic'],
             },
         ]);
     });
@@ -1117,8 +1117,8 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
         );
 
         expect(comparison.diagnosticDiffs[0].added).toEqual([
-            'error | src/repeated.py:1:1 | same diagnostic',
-            'error | src/repeated.py:2:1 | same diagnostic',
+            'src/repeated.py:1:1 - error: same diagnostic',
+            'src/repeated.py:2:1 - error: same diagnostic',
         ]);
     });
 

--- a/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
@@ -75,6 +75,12 @@ export interface EcosystemBenchmarkResult {
 
 export interface EcosystemBenchmarkDiagnostic {
     file?: string;
+    range?: {
+        start: {
+            line: number;
+            character: number;
+        };
+    };
     severity: string;
     message: string;
 }
@@ -111,8 +117,20 @@ export interface EcosystemBenchmarkExecutionArtifactPaths {
     comparisonArtifactPaths?: BenchmarkReportComparisonArtifactPaths;
 }
 
+interface PyrightJsonDiagnostic {
+    file?: string;
+    message?: string;
+    range?: {
+        start: {
+            line: number;
+            character: number;
+        };
+    };
+    severity: string;
+}
+
 interface PyrightJsonResults {
-    generalDiagnostics: { file?: string; message?: string; severity: string }[];
+    generalDiagnostics: PyrightJsonDiagnostic[];
     summary: {
         errorCount: number;
         warningCount: number;
@@ -176,6 +194,7 @@ const ecosystemBenchmarkComparisonMetrics: readonly BenchmarkMetricDefinition<Ec
 ];
 
 const maxSyncProcessBufferBytes = 16 * 1024 * 1024;
+const maxDiagnosticDiffLinesPerProject = 200;
 
 export function parseEcosystemBenchmarkArgs(args: string[]): EcosystemBenchmarkCommand {
     const parsedArgs = commandLineArgs(optionDefinitions, { argv: args }) as CommandLineOptions;
@@ -686,43 +705,61 @@ function compareEcosystemDiagnosticResults(
 ): EcosystemBenchmarkDiagnosticDiff[] {
     const candidateByProject = new Map(candidateResults.map((result) => [result.projectName, result]));
 
-    return baselineResults.flatMap((baselineResult) => {
-        const candidateResult = candidateByProject.get(baselineResult.projectName);
-        if (!candidateResult) {
-            return [];
-        }
+    return baselineResults
+        .flatMap((baselineResult) => {
+            const candidateResult = candidateByProject.get(baselineResult.projectName);
+            if (!candidateResult) {
+                return [];
+            }
 
-        const baselineDiagnostics = getDiagnosticSignatureSet(baselineResult);
-        const candidateDiagnostics = getDiagnosticSignatureSet(candidateResult);
-        const added = [...candidateDiagnostics].filter((entry) => !baselineDiagnostics.has(entry)).sort();
-        const removed = [...baselineDiagnostics].filter((entry) => !candidateDiagnostics.has(entry)).sort();
+            const baselineDiagnostics = getDiagnosticSignatureSet(baselineResult);
+            const candidateDiagnostics = getDiagnosticSignatureSet(candidateResult);
+            const added = [...candidateDiagnostics].filter((entry) => !baselineDiagnostics.has(entry)).sort();
+            const removed = [...baselineDiagnostics].filter((entry) => !candidateDiagnostics.has(entry)).sort();
 
-        return added.length > 0 || removed.length > 0
-            ? [{ projectName: baselineResult.projectName, added, removed }]
-            : [];
-    });
+            return added.length > 0 || removed.length > 0
+                ? [{ projectName: baselineResult.projectName, added, removed }]
+                : [];
+        })
+        .sort((left, right) => left.projectName.localeCompare(right.projectName));
 }
 
 function getDiagnosticSignatureSet(result: EcosystemBenchmarkResult): Set<string> {
     return new Set((result.diagnostics ?? []).map(formatDiagnosticSignature));
 }
 
-function normalizePyrightDiagnostic(
-    diagnostic: PyrightJsonResults['generalDiagnostics'][number]
-): EcosystemBenchmarkDiagnostic {
+function normalizePyrightDiagnostic(diagnostic: PyrightJsonDiagnostic): EcosystemBenchmarkDiagnostic {
     return {
         file: diagnostic.file,
+        range: diagnostic.range,
         severity: diagnostic.severity,
         message: diagnostic.message ?? '',
     };
 }
 
 function formatDiagnosticSignature(diagnostic: EcosystemBenchmarkDiagnostic): string {
-    return [diagnostic.severity, diagnostic.file ?? '<unknown>', diagnostic.message].join(' | ');
+    return [diagnostic.severity, formatDiagnosticLocation(diagnostic), diagnostic.message].join(' | ');
+}
+
+function formatDiagnosticLocation(diagnostic: EcosystemBenchmarkDiagnostic): string {
+    const location = diagnostic.file ?? '<unknown>';
+    const start = diagnostic.range?.start;
+    if (!start) {
+        return location;
+    }
+
+    return `${location}:${start.line + 1}:${start.character + 1}`;
 }
 
 function renderEcosystemBenchmarkComparisonMarkdown(comparison: EcosystemBenchmarkReportComparison): string {
-    const lines = [renderBenchmarkComparisonMarkdown(comparison).trimEnd(), '', '## Diagnostic Diffs', ''];
+    const lines = [
+        renderBenchmarkComparisonMarkdown(comparison).trimEnd(),
+        '',
+        '## Type Check Result Diff',
+        '',
+        'Diff from the custom ecosystem runner, showing the effect of this PR on Pyright diagnostics:',
+        '',
+    ];
 
     if (comparison.diagnosticDiffs.length === 0) {
         lines.push('None.');
@@ -731,26 +768,33 @@ function renderEcosystemBenchmarkComparisonMarkdown(comparison: EcosystemBenchma
 
     for (const diff of comparison.diagnosticDiffs) {
         lines.push(`### ${diff.projectName}`, '');
-        appendDiagnosticDiffList(lines, 'Added diagnostics', diff.added);
-        appendDiagnosticDiffList(lines, 'Removed diagnostics', diff.removed);
+        appendDiagnosticDiffBlock(lines, diff);
     }
 
     return `${lines.join('\n')}\n`;
 }
 
-function appendDiagnosticDiffList(lines: string[], heading: string, diagnostics: readonly string[]): void {
-    lines.push(`#### ${heading}`, '');
+function appendDiagnosticDiffBlock(lines: string[], diff: EcosystemBenchmarkDiagnosticDiff): void {
+    const diffLines = [
+        ...diff.removed.map((diagnostic) => `- ${diagnostic}`),
+        ...diff.added.map((diagnostic) => `+ ${diagnostic}`),
+    ];
 
-    if (diagnostics.length === 0) {
-        lines.push('None.', '');
-        return;
+    lines.push('```diff');
+
+    for (const diagnosticLine of diffLines.slice(0, maxDiagnosticDiffLinesPerProject)) {
+        lines.push(diagnosticLine);
     }
 
-    for (const diagnostic of diagnostics) {
-        lines.push(`- ${diagnostic}`);
+    if (diffLines.length > maxDiagnosticDiffLinesPerProject) {
+        lines.push(
+            `... ${
+                diffLines.length - maxDiagnosticDiffLinesPerProject
+            } additional diagnostic change(s) omitted; see comparison.json for the full diff.`
+        );
     }
 
-    lines.push('');
+    lines.push('```', '');
 }
 
 function createPyrightExecutionError(

--- a/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
@@ -738,7 +738,7 @@ function normalizePyrightDiagnostic(diagnostic: PyrightJsonDiagnostic): Ecosyste
 }
 
 function formatDiagnosticSignature(diagnostic: EcosystemBenchmarkDiagnostic): string {
-    return [diagnostic.severity, formatDiagnosticLocation(diagnostic), diagnostic.message].join(' | ');
+    return `${formatDiagnosticLocation(diagnostic)} - ${diagnostic.severity}: ${diagnostic.message}`;
 }
 
 function formatDiagnosticLocation(diagnostic: EcosystemBenchmarkDiagnostic): string {
@@ -766,21 +766,23 @@ function renderEcosystemBenchmarkComparisonMarkdown(comparison: EcosystemBenchma
         return `${lines.join('\n')}\n`;
     }
 
+    lines.push('```diff');
+
     for (const diff of comparison.diagnosticDiffs) {
-        lines.push(`### ${diff.projectName}`, '');
-        appendDiagnosticDiffBlock(lines, diff);
+        appendDiagnosticDiffProject(lines, diff);
     }
 
+    lines.push('```');
     return `${lines.join('\n')}\n`;
 }
 
-function appendDiagnosticDiffBlock(lines: string[], diff: EcosystemBenchmarkDiagnosticDiff): void {
+function appendDiagnosticDiffProject(lines: string[], diff: EcosystemBenchmarkDiagnosticDiff): void {
     const diffLines = [
-        ...diff.removed.map((diagnostic) => `- ${diagnostic}`),
-        ...diff.added.map((diagnostic) => `+ ${diagnostic}`),
+        ...diff.removed.flatMap((diagnostic) => formatSignedDiagnosticLines('-', diagnostic)),
+        ...diff.added.flatMap((diagnostic) => formatSignedDiagnosticLines('+', diagnostic)),
     ];
 
-    lines.push('```diff');
+    lines.push(diff.projectName);
 
     for (const diagnosticLine of diffLines.slice(0, maxDiagnosticDiffLinesPerProject)) {
         lines.push(diagnosticLine);
@@ -794,7 +796,11 @@ function appendDiagnosticDiffBlock(lines: string[], diff: EcosystemBenchmarkDiag
         );
     }
 
-    lines.push('```', '');
+    lines.push('');
+}
+
+function formatSignedDiagnosticLines(sign: '+' | '-', diagnostic: string): string[] {
+    return diagnostic.split(/\r?\n/).map((line) => `${sign}   ${line}`);
 }
 
 function createPyrightExecutionError(

--- a/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
@@ -725,7 +725,9 @@ function compareEcosystemDiagnosticResults(
 }
 
 function getDiagnosticSignatureSet(result: EcosystemBenchmarkResult): Set<string> {
-    return new Set((result.diagnostics ?? []).map(formatDiagnosticSignature));
+    return new Set(
+        (result.diagnostics ?? []).map((diagnostic) => formatDiagnosticSignature(result.projectName, diagnostic))
+    );
 }
 
 function normalizePyrightDiagnostic(diagnostic: PyrightJsonDiagnostic): EcosystemBenchmarkDiagnostic {
@@ -737,18 +739,33 @@ function normalizePyrightDiagnostic(diagnostic: PyrightJsonDiagnostic): Ecosyste
     };
 }
 
-function formatDiagnosticSignature(diagnostic: EcosystemBenchmarkDiagnostic): string {
-    return `${formatDiagnosticLocation(diagnostic)} - ${diagnostic.severity}: ${diagnostic.message}`;
+function formatDiagnosticSignature(projectName: string, diagnostic: EcosystemBenchmarkDiagnostic): string {
+    return `${formatDiagnosticLocation(projectName, diagnostic)} - ${diagnostic.severity}: ${diagnostic.message}`;
 }
 
-function formatDiagnosticLocation(diagnostic: EcosystemBenchmarkDiagnostic): string {
-    const location = diagnostic.file ?? '<unknown>';
+function formatDiagnosticLocation(projectName: string, diagnostic: EcosystemBenchmarkDiagnostic): string {
+    const location = formatProjectRelativeDiagnosticPath(projectName, diagnostic.file);
     const start = diagnostic.range?.start;
     if (!start) {
         return location;
     }
 
     return `${location}:${start.line + 1}:${start.character + 1}`;
+}
+
+function formatProjectRelativeDiagnosticPath(projectName: string, filePath: string | undefined): string {
+    if (!filePath) {
+        return '<unknown>';
+    }
+
+    const normalizedPath = filePath.replace(/\\/g, '/');
+    const projectSegment = `/${projectName}/`;
+    const projectSegmentIndex = normalizedPath.lastIndexOf(projectSegment);
+    if (projectSegmentIndex < 0) {
+        return normalizedPath;
+    }
+
+    return `.../${normalizedPath.slice(projectSegmentIndex + 1)}`;
 }
 
 function renderEcosystemBenchmarkComparisonMarkdown(comparison: EcosystemBenchmarkReportComparison): string {


### PR DESCRIPTION
This makes mypy_primer the only automatic benchmark for normal Pyright source changes, while keeping the custom ecosystem benchmark automatic for ecosystem benchmark infrastructure and manual/on-demand for other PRs.\n\nChanges:\n- Narrow ecosystem benchmark PR paths so mypy_primer workflow-only and normal Pyright changes no longer get a second ecosystem benchmark comment.\n- Exclude ecosystem benchmark sources from the mypy_primer PR workflow so ecosystem benchmark infrastructure PRs do not run both benchmark suites.\n- Render custom ecosystem diagnostic changes as a mypy_primer-style diff block with file/line/column locations.\n- Add a scheduled/manual sync workflow that fetches upstream mypy_primer project metadata, regenerates ecosystem metadata, and opens or updates a sync PR.\n\nValidation:\n- actionlint on changed workflows\n- prettier --check on changed files\n- packages/pyright-internal npm run build\n- PYRIGHT_RUN_BENCHMARKS=1 npx jest src/tests/benchmarks/runEcosystemBenchmark.test.ts src/tests/benchmarks/syncMypyPrimerProjects.test.ts --runInBand --forceExit --testTimeout=300000\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>