### PR TITLE
Show ecosystem mypy_primer snapshot freshness

### DIFF
--- a/.github/workflows/pyright_ecosystem_benchmark.yaml
+++ b/.github/workflows/pyright_ecosystem_benchmark.yaml
@@ -195,6 +195,7 @@ jobs:
           path: |
             packages/pyright-internal/src/tests/benchmarks/.generated/benchmark-results/
             packages/pyright-internal/src/tests/benchmarks/baselines/ecosystem-smoke-main.json
+            packages/pyright-internal/src/tests/benchmarks/mypy_primer.snapshot.metadata.json
           if-no-files-found: warn
 
       - name: Post ecosystem benchmark PR comment
@@ -217,6 +218,7 @@ jobs:
 
             const marker = '<!-- pyright-ecosystem-benchmark-comment -->';
             const comparisonPath = process.env.COMPARISON_MARKDOWN;
+            const metadataPath = 'packages/pyright-internal/src/tests/benchmarks/mypy_primer.snapshot.metadata.json';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const maxCharacters = 60000;
             let body;
@@ -227,9 +229,17 @@ jobs:
                 comparison = `${comparison.slice(0, maxCharacters)}\n\n... benchmark report truncated; see workflow artifacts for the full comparison.`;
               }
 
-              body = [marker, '## Pyright ecosystem benchmark stats', '', comparison, '', `[Workflow run](${runUrl})`].join(
-                '\n'
-              );
+              const metadataSummary = readMypyPrimerMetadataSummary(metadataPath);
+              body = [
+                marker,
+                '## Pyright ecosystem benchmark stats',
+                '',
+                metadataSummary,
+                '',
+                comparison,
+                '',
+                `[Workflow run](${runUrl})`,
+              ].join('\n');
             } else if (process.env.BASELINE_READY !== 'true') {
               const reason = process.env.BASELINE_REASON || 'The checked-in ecosystem smoke baseline is not ready.';
               body = [
@@ -270,4 +280,20 @@ jobs:
                 issue_number: prNumber,
                 body,
               });
+            }
+
+            function readMypyPrimerMetadataSummary(metadataPath) {
+              if (!fs.existsSync(metadataPath)) {
+                return '_mypy_primer metadata snapshot: unavailable_';
+              }
+
+              const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+              const commit = metadata.upstreamCommit || 'unknown';
+              const commitText =
+                commit === 'unknown'
+                  ? '`unknown`'
+                  : `[\`${commit.slice(0, 12)}\`](https://github.com/${metadata.upstreamRepository}/commit/${commit})`;
+              return `_mypy_primer metadata snapshot: ${commitText}; projects: ${
+                metadata.projectCount ?? 'unknown'
+              }; synced: ${metadata.syncedAt || 'unknown'}_`;
             }

--- a/.github/workflows/sync_mypy_primer_ecosystem.yaml
+++ b/.github/workflows/sync_mypy_primer_ecosystem.yaml
@@ -25,6 +25,12 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Snapshot current ecosystem metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp packages/pyright-internal/src/tests/benchmarks/ecosystem-projects.generated.json "$RUNNER_TEMP/ecosystem-projects.generated.before.json"
+
       - name: Fetch upstream mypy_primer projects
         id: upstream
         shell: bash
@@ -44,6 +50,7 @@ jobs:
 
           {
             echo "sha=$upstream_ref"
+            echo "url=$url"
             echo "project_count=$project_count"
           } >> "$GITHUB_OUTPUT"
         env:
@@ -54,14 +61,55 @@ jobs:
           npm ci
           cd packages/pyright-internal
           npm run build
-          npm run bench:ecosystem:sync
+          npm run bench:ecosystem:sync -- \
+            --metadata-output ./src/tests/benchmarks/mypy_primer.snapshot.metadata.json \
+            --upstream-repo "$UPSTREAM_REPO" \
+            --upstream-commit "$UPSTREAM_REF" \
+            --upstream-url "$UPSTREAM_URL"
+        env:
+          UPSTREAM_REPO: hauntsaninja/mypy_primer
+          UPSTREAM_REF: ${{ steps.upstream.outputs.sha }}
+          UPSTREAM_URL: ${{ steps.upstream.outputs.url }}
+
+      - name: Detect smoke baseline impact
+        id: baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          node - "$RUNNER_TEMP/ecosystem-projects.generated.before.json" \
+            "packages/pyright-internal/src/tests/benchmarks/ecosystem-projects.generated.json" \
+            "packages/pyright-internal/src/tests/benchmarks/ecosystem-projects.overrides.json" <<'NODE'
+          const fs = require('fs');
+          const [beforePath, afterPath, overridesPath] = process.argv.slice(2);
+          const before = JSON.parse(fs.readFileSync(beforePath, 'utf8'));
+          const after = JSON.parse(fs.readFileSync(afterPath, 'utf8'));
+          const overrides = JSON.parse(fs.readFileSync(overridesPath, 'utf8'));
+          const beforeByName = new Map(before.map((project) => [project.name, project]));
+          const afterByName = new Map(after.map((project) => [project.name, project]));
+          const smokeProjectNames = Object.entries(overrides)
+            .filter(([, override]) => override.includeInSmoke)
+            .map(([name]) => name)
+            .sort();
+          const changedSmokeProjects = smokeProjectNames.filter((name) => {
+            return JSON.stringify(beforeByName.get(name) ?? null) !== JSON.stringify(afterByName.get(name) ?? null);
+          });
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            [
+              `refresh_required=${changedSmokeProjects.length > 0}`,
+              'changed_projects<<EOF',
+              changedSmokeProjects.join(', '),
+              'EOF',
+            ].join('\n') + '\n'
+          );
+          NODE
 
       - name: Check for changes
         id: changes
         shell: bash
         run: |
           set -euo pipefail
-          if git diff --quiet -- packages/pyright-internal/src/tests/benchmarks/mypy_primer.smoke_projects.snapshot.py packages/pyright-internal/src/tests/benchmarks/ecosystem-projects.generated.json; then
+          if git diff --quiet -- packages/pyright-internal/src/tests/benchmarks/mypy_primer.smoke_projects.snapshot.py packages/pyright-internal/src/tests/benchmarks/ecosystem-projects.generated.json packages/pyright-internal/src/tests/benchmarks/mypy_primer.snapshot.metadata.json; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -76,7 +124,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -C "$branch"
-          git add packages/pyright-internal/src/tests/benchmarks/mypy_primer.smoke_projects.snapshot.py packages/pyright-internal/src/tests/benchmarks/ecosystem-projects.generated.json
+          git add packages/pyright-internal/src/tests/benchmarks/mypy_primer.smoke_projects.snapshot.py packages/pyright-internal/src/tests/benchmarks/ecosystem-projects.generated.json packages/pyright-internal/src/tests/benchmarks/mypy_primer.snapshot.metadata.json
           git commit -m "Sync ecosystem mypy_primer metadata"
           git push --force-with-lease origin "$branch"
 
@@ -86,6 +134,8 @@ jobs:
             "" \
             "Upstream: https://github.com/hauntsaninja/mypy_primer/commit/${{ steps.upstream.outputs.sha }}" \
             "Project definitions fetched: ${{ steps.upstream.outputs.project_count }}" \
+            "Smoke baseline refresh required: ${{ steps.baseline.outputs.refresh_required }}" \
+            "Changed smoke projects: ${{ steps.baseline.outputs.changed_projects || 'none' }}" \
             "" \
             "After merge, run the ecosystem benchmark \`refresh-baseline\` workflow on main if the smoke project set changed." \
             "" \

--- a/packages/pyright-internal/src/tests/benchmarks/README.md
+++ b/packages/pyright-internal/src/tests/benchmarks/README.md
@@ -142,5 +142,8 @@ comments.
 
 The checked-in mypy_primer snapshot can be refreshed with the `Sync mypy_primer ecosystem metadata` workflow. It runs on
 a weekly schedule and can also be dispatched manually. When upstream project metadata changes, the workflow updates
-`mypy_primer.smoke_projects.snapshot.py` and `ecosystem-projects.generated.json` on an automation branch and opens or
-updates a PR. If the smoke project set changes, refresh the main ecosystem baseline after merging the sync PR.
+`mypy_primer.smoke_projects.snapshot.py`, `ecosystem-projects.generated.json`, and
+`mypy_primer.snapshot.metadata.json` on an automation branch and opens or updates a PR. The sync PR states whether any
+smoke project metadata changed, which indicates whether the main ecosystem baseline should be refreshed after merging.
+Ecosystem benchmark PR comments include the checked-in upstream mypy_primer commit from the metadata file so reviewers
+can see which project snapshot produced the comparison.

--- a/packages/pyright-internal/src/tests/benchmarks/mypy_primer.snapshot.metadata.json
+++ b/packages/pyright-internal/src/tests/benchmarks/mypy_primer.snapshot.metadata.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "upstreamRepository": "hauntsaninja/mypy_primer",
+  "upstreamCommit": "unknown",
+  "upstreamProjectsUrl": "mypy_primer.smoke_projects.snapshot.py",
+  "syncedAt": "unknown",
+  "projectCount": 10,
+  "sourceInputFile": "mypy_primer.smoke_projects.snapshot.py"
+}

--- a/packages/pyright-internal/src/tests/benchmarks/syncMypyPrimerProjects.test.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/syncMypyPrimerProjects.test.ts
@@ -15,6 +15,7 @@ import {
     parseMypyPrimerProjectSource,
     syncMypyPrimerProjects,
     writeGeneratedEcosystemProjects,
+    writeMypyPrimerSnapshotMetadata,
 } from './syncMypyPrimerProjects';
 
 const RUN_BENCHMARKS_ENV = 'PYRIGHT_RUN_BENCHMARKS';
@@ -149,10 +150,40 @@ benchmarkSuite('Sync Mypy Primer Projects', () => {
         }
     });
 
+    test('writes mypy_primer snapshot metadata', () => {
+        const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pyright-mypy-primer-metadata-'));
+        const outputPath = path.join(outputDir, 'mypy_primer.snapshot.metadata.json');
+
+        try {
+            writeMypyPrimerSnapshotMetadata(outputPath, {
+                schemaVersion: 1,
+                upstreamRepository: 'hauntsaninja/mypy_primer',
+                upstreamCommit: 'abc123',
+                upstreamProjectsUrl: 'https://example.com/projects.py',
+                syncedAt: '2026-05-19T00:00:00.000Z',
+                projectCount: 2,
+                sourceInputFile: 'mypy_primer.smoke_projects.snapshot.py',
+            });
+
+            expect(JSON.parse(fs.readFileSync(outputPath, 'utf-8'))).toEqual({
+                schemaVersion: 1,
+                upstreamRepository: 'hauntsaninja/mypy_primer',
+                upstreamCommit: 'abc123',
+                upstreamProjectsUrl: 'https://example.com/projects.py',
+                syncedAt: '2026-05-19T00:00:00.000Z',
+                projectCount: 2,
+                sourceInputFile: 'mypy_primer.smoke_projects.snapshot.py',
+            });
+        } finally {
+            fs.rmSync(outputDir, { force: true, recursive: true });
+        }
+    });
+
     test('syncs project definitions from an input file', () => {
         const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pyright-mypy-primer-cli-'));
         const inputPath = path.join(tempDir, 'projects.py');
         const outputPath = path.join(tempDir, 'ecosystem-projects.generated.json');
+        const metadataOutputPath = path.join(tempDir, 'mypy_primer.snapshot.metadata.json');
 
         try {
             fs.writeFileSync(
@@ -167,11 +198,30 @@ benchmarkSuite('Sync Mypy Primer Projects', () => {
                 'utf-8'
             );
 
-            const writtenPath = syncMypyPrimerProjects(['--input', inputPath, '--output', outputPath]);
+            const writtenPath = syncMypyPrimerProjects([
+                '--input',
+                inputPath,
+                '--output',
+                outputPath,
+                '--metadata-output',
+                metadataOutputPath,
+                '--upstream-repo',
+                'hauntsaninja/mypy_primer',
+                '--upstream-commit',
+                'abc123',
+                '--upstream-url',
+                'https://example.com/projects.py',
+            ]);
 
             expect(writtenPath).toBe(outputPath);
             expect(JSON.parse(fs.readFileSync(outputPath, 'utf-8'))[0].name).toBe('black');
             expect(path.isAbsolute(JSON.parse(fs.readFileSync(outputPath, 'utf-8'))[0].source.inputFile)).toBe(false);
+            expect(JSON.parse(fs.readFileSync(metadataOutputPath, 'utf-8'))).toMatchObject({
+                upstreamRepository: 'hauntsaninja/mypy_primer',
+                upstreamCommit: 'abc123',
+                upstreamProjectsUrl: 'https://example.com/projects.py',
+                projectCount: 1,
+            });
         } finally {
             fs.rmSync(tempDir, { force: true, recursive: true });
         }

--- a/packages/pyright-internal/src/tests/benchmarks/syncMypyPrimerProjects.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/syncMypyPrimerProjects.ts
@@ -18,9 +18,23 @@ export interface GeneratedEcosystemProject {
     cost?: number;
 }
 
+export interface MypyPrimerSnapshotMetadata {
+    schemaVersion: 1;
+    upstreamRepository: string;
+    upstreamCommit: string;
+    upstreamProjectsUrl: string;
+    syncedAt: string;
+    projectCount: number;
+    sourceInputFile: string;
+}
+
 const optionDefinitions: OptionDefinition[] = [
     { name: 'input', type: String },
     { name: 'output', type: String },
+    { name: 'metadata-output', type: String },
+    { name: 'upstream-repo', type: String },
+    { name: 'upstream-commit', type: String },
+    { name: 'upstream-url', type: String },
 ];
 
 const defaultMypyPrimerProjectSourcePath = getBenchmarkFilePath('mypy_primer.smoke_projects.snapshot.py');
@@ -49,13 +63,31 @@ export function syncMypyPrimerProjects(args: string[]): string {
     const inputPath = (parsedArgs.input as string | undefined) ?? defaultMypyPrimerProjectSourcePath;
     const outputPath =
         (parsedArgs.output as string | undefined) ?? getWritableBenchmarkFilePath('ecosystem-projects.generated.json');
+    const metadataOutputPath = parsedArgs['metadata-output'] as string | undefined;
 
     const sourceText = fs.readFileSync(inputPath, 'utf-8');
     const projects = parseMypyPrimerProjectSource(sourceText, inputPath);
     writeGeneratedEcosystemProjects(outputPath, projects);
+    if (metadataOutputPath) {
+        writeMypyPrimerSnapshotMetadata(metadataOutputPath, {
+            schemaVersion: 1,
+            upstreamRepository: (parsedArgs['upstream-repo'] as string | undefined) ?? 'hauntsaninja/mypy_primer',
+            upstreamCommit: (parsedArgs['upstream-commit'] as string | undefined) ?? 'unknown',
+            upstreamProjectsUrl:
+                (parsedArgs['upstream-url'] as string | undefined) ?? normalizeInputFileReference(inputPath),
+            syncedAt: new Date().toISOString(),
+            projectCount: projects.length,
+            sourceInputFile: normalizeInputFileReference(inputPath),
+        });
+    }
     console.log(`Wrote ${projects.length} ecosystem project definitions to ${outputPath}`);
 
     return outputPath;
+}
+
+export function writeMypyPrimerSnapshotMetadata(outputPath: string, metadata: MypyPrimerSnapshotMetadata): void {
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(metadata, undefined, 2)}\n`, 'utf-8');
 }
 
 export function getBenchmarkSourceDirectory(): string {


### PR DESCRIPTION
Adds visible freshness metadata for the custom ecosystem benchmark's checked-in mypy_primer snapshot.\n\nChanges:\n- Track a mypy_primer snapshot metadata file alongside the generated ecosystem project metadata.\n- Teach the sync script to write upstream repository, commit, URL, timestamp, and project count metadata.\n- Include that metadata in ecosystem benchmark PR comments and artifacts so reviewers can see which upstream snapshot produced a comparison.\n- Have the sync workflow compare smoke project metadata before/after sync and state whether a baseline refresh is required in the sync PR body.\n\nValidation:\n- actionlint on changed workflows\n- prettier --check on changed files\n- packages/pyright-internal npm run build\n- PYRIGHT_RUN_BENCHMARKS=1 npx jest src/tests/benchmarks/syncMypyPrimerProjects.test.ts --runInBand --forceExit --testTimeout=300000\n- npm run bench:ecosystem:sync with temp output and metadata paths\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>