### PR TITLE
Add ecosystem benchmark regression thresholds

### DIFF
--- a/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.test.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.test.ts
@@ -929,7 +929,7 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
                 baselinePath,
                 JSON.stringify(
                     createEcosystemBenchmarkReport('2026-05-07T00:00:00.000Z', [
-                        { projectName: 'black', totalTimeMs: 100, maxMemoryMB: 250 },
+                        { projectName: 'black', totalTimeMs: 1000, maxMemoryMB: 250 },
                     ]),
                     undefined,
                     2
@@ -940,7 +940,7 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
                 candidatePath,
                 JSON.stringify(
                     createEcosystemBenchmarkReport('2026-05-07T01:00:00.000Z', [
-                        { projectName: 'black', totalTimeMs: 120, maxMemoryMB: 260 },
+                        { projectName: 'black', totalTimeMs: 1600, maxMemoryMB: 260 },
                     ]),
                     undefined,
                     2
@@ -952,8 +952,55 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
 
             expect(JSON.parse(fs.readFileSync(artifactPaths.jsonPath, 'utf-8')).compared[0].key).toBe('black');
             expect(fs.readFileSync(artifactPaths.markdownPath, 'utf-8')).toContain('Largest Regressions');
+            expect(fs.readFileSync(artifactPaths.markdownPath, 'utf-8')).toContain(
+                '## Actionable Regression Thresholds'
+            );
+            expect(fs.readFileSync(artifactPaths.markdownPath, 'utf-8')).toContain(
+                '| failure | black | totalTimeMs | 1000.00 | 1600.00 | 600.00 | 60.00% |'
+            );
             expect(JSON.parse(fs.readFileSync(artifactPaths.oldJsonPath, 'utf-8')).results[0].projectName).toBe(
                 'black'
+            );
+        } finally {
+            fs.rmSync(reportsDir, { force: true, recursive: true });
+            fs.rmSync(outputDir, { force: true, recursive: true });
+        }
+    });
+
+    test('ignores small ecosystem timing regressions below thresholds', () => {
+        const reportsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pyright-ecosystem-small-regression-'));
+        const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pyright-ecosystem-small-regression-compare-'));
+
+        try {
+            const baselinePath = path.join(reportsDir, 'old.json');
+            const candidatePath = path.join(reportsDir, 'new.json');
+
+            fs.writeFileSync(
+                baselinePath,
+                JSON.stringify(
+                    createEcosystemBenchmarkReport('2026-05-07T00:00:00.000Z', [
+                        { projectName: 'black', totalTimeMs: 1000 },
+                    ]),
+                    undefined,
+                    2
+                ),
+                'utf-8'
+            );
+            fs.writeFileSync(
+                candidatePath,
+                JSON.stringify(
+                    createEcosystemBenchmarkReport('2026-05-07T01:00:00.000Z', [
+                        { projectName: 'black', totalTimeMs: 1040 },
+                    ]),
+                    undefined,
+                    2
+                ),
+                'utf-8'
+            );
+
+            const artifactPaths = compareEcosystemBenchmarkReports(baselinePath, candidatePath, outputDir);
+            expect(fs.readFileSync(artifactPaths.markdownPath, 'utf-8')).toContain(
+                'No warning or failure thresholds exceeded.'
             );
         } finally {
             fs.rmSync(reportsDir, { force: true, recursive: true });

--- a/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
@@ -7,8 +7,11 @@ import { ensureTomlModuleLoaded, parse } from '../../common/tomlUtils';
 
 import {
     BenchmarkMetricDefinition,
+    BenchmarkRegressionThresholdResult,
+    BenchmarkRegressionThresholds,
     BenchmarkReportComparison,
     BenchmarkReportComparisonArtifactPaths,
+    classifyBenchmarkRegression,
     compareBenchmarkReports,
     loadBenchmarkReport,
     renderBenchmarkComparisonMarkdown,
@@ -192,6 +195,15 @@ const ecosystemBenchmarkComparisonMetrics: readonly BenchmarkMetricDefinition<Ec
     { name: 'warningCount', getValue: (result) => result.warningCount },
     { name: 'informationCount', getValue: (result) => result.informationCount },
 ];
+
+const ecosystemBenchmarkRegressionThresholds = new Map<string, BenchmarkRegressionThresholds>([
+    ['totalTimeMs', { warnRegressionPct: 10, failRegressionPct: 25, minAbsoluteRegression: 500 }],
+    ['maxMemoryMB', { warnRegressionPct: 15, failRegressionPct: 35, minAbsoluteRegression: 100 }],
+    ['diagnosticCount', { warnRegressionAbsolute: 1, failRegressionAbsolute: 5, minAbsoluteRegression: 1 }],
+    ['errorCount', { warnRegressionAbsolute: 1, failRegressionAbsolute: 3, minAbsoluteRegression: 1 }],
+    ['warningCount', { warnRegressionAbsolute: 1, failRegressionAbsolute: 5, minAbsoluteRegression: 1 }],
+    ['informationCount', { warnRegressionAbsolute: 1, failRegressionAbsolute: 5, minAbsoluteRegression: 1 }],
+]);
 
 const maxSyncProcessBufferBytes = 16 * 1024 * 1024;
 const maxDiagnosticDiffLinesPerProject = 200;
@@ -772,6 +784,8 @@ function renderEcosystemBenchmarkComparisonMarkdown(comparison: EcosystemBenchma
     const lines = [
         renderBenchmarkComparisonMarkdown(comparison).trimEnd(),
         '',
+        renderEcosystemBenchmarkThresholdMarkdown(comparison).trimEnd(),
+        '',
         '## Type Check Result Diff',
         '',
         'Diff from the custom ecosystem runner, showing the effect of this PR on Pyright diagnostics:',
@@ -791,6 +805,86 @@ function renderEcosystemBenchmarkComparisonMarkdown(comparison: EcosystemBenchma
 
     lines.push('```');
     return `${lines.join('\n')}\n`;
+}
+
+function renderEcosystemBenchmarkThresholdMarkdown(comparison: EcosystemBenchmarkReportComparison): string {
+    const thresholdResults = getEcosystemBenchmarkThresholdResults(comparison);
+    const lines = ['## Actionable Regression Thresholds', ''];
+
+    if (thresholdResults.length === 0) {
+        lines.push('No warning or failure thresholds exceeded.');
+        return `${lines.join('\n')}\n`;
+    }
+
+    lines.push(
+        '| Severity | Case | Metric | Baseline | Candidate | Delta | Delta % |',
+        '|---|---|---:|---:|---:|---:|---:|'
+    );
+
+    for (const result of thresholdResults) {
+        lines.push(
+            `| ${result.severity} | ${result.key} | ${result.metric} | ${formatThresholdMetric(
+                result.baselineValue
+            )} | ${formatThresholdMetric(result.candidateValue)} | ${formatThresholdMetric(
+                result.absoluteDelta
+            )} | ${formatThresholdPercent(result.percentDelta)} |`
+        );
+    }
+
+    return `${lines.join('\n')}\n`;
+}
+
+function getEcosystemBenchmarkThresholdResults(
+    comparison: EcosystemBenchmarkReportComparison
+): BenchmarkRegressionThresholdResult[] {
+    return comparison.compared
+        .flatMap((result) =>
+            result.metrics.flatMap((metric) => {
+                const thresholds = ecosystemBenchmarkRegressionThresholds.get(metric.metric);
+                if (!thresholds) {
+                    return [];
+                }
+
+                const severity = classifyBenchmarkRegression(metric, thresholds);
+                return severity === 'none' ? [] : [{ key: result.key, ...metric, severity }];
+            })
+        )
+        .sort(compareEcosystemThresholdResults);
+}
+
+function compareEcosystemThresholdResults(
+    left: BenchmarkRegressionThresholdResult,
+    right: BenchmarkRegressionThresholdResult
+): number {
+    const severityDelta = getThresholdSeverityRank(right.severity) - getThresholdSeverityRank(left.severity);
+    if (severityDelta !== 0) {
+        return severityDelta;
+    }
+
+    return getThresholdMagnitude(right) - getThresholdMagnitude(left);
+}
+
+function getThresholdSeverityRank(severity: BenchmarkRegressionThresholdResult['severity']): number {
+    switch (severity) {
+        case 'failure':
+            return 2;
+        case 'warning':
+            return 1;
+        case 'none':
+            return 0;
+    }
+}
+
+function getThresholdMagnitude(result: BenchmarkRegressionThresholdResult): number {
+    return Math.abs(result.percentDelta ?? result.absoluteDelta);
+}
+
+function formatThresholdMetric(value: number): string {
+    return value.toFixed(2);
+}
+
+function formatThresholdPercent(value: number | undefined): string {
+    return value === undefined ? 'n/a' : `${value.toFixed(2)}%`;
 }
 
 function appendDiagnosticDiffProject(lines: string[], diff: EcosystemBenchmarkDiagnosticDiff): void {


### PR DESCRIPTION
Adds an actionable threshold section to custom ecosystem benchmark comments so reviewers can distinguish small/noisy metric regressions from warning/failure-level changes.\n\nThresholds cover total time, memory, and diagnostic count metrics. Small timing regressions below absolute and percentage thresholds remain visible in the detailed table but no longer show as actionable threshold hits.\n\nValidation:\n- packages/pyright-internal npm run build\n- PYRIGHT_RUN_BENCHMARKS=1 npx jest src/tests/benchmarks/runEcosystemBenchmark.test.ts --runInBand --forceExit --testTimeout=300000\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>