### PR TITLE
Improve ecosystem benchmark signal fidelity

### DIFF
--- a/packages/pyright-internal/src/tests/benchmarks/README.md
+++ b/packages/pyright-internal/src/tests/benchmarks/README.md
@@ -62,8 +62,8 @@ interface BenchmarkReport<ResultT> {
 
 Individual suites add case-specific fields such as token count, AST node count, median time, p95 time, and throughput.
 Ecosystem benchmark results additionally preserve per-project fields like `filesAnalyzed`, diagnostic counts, normalized
-diagnostics, and total runtime so report artifacts can distinguish execution-scope changes from pure performance
-regressions.
+diagnostics, total process runtime, and Pyright-reported analysis time. The analysis time comes from Pyright's JSON
+summary, so it is less sensitive to process startup, checkout, and runner noise than wall-clock process time.
 
 Generated per-project configs always own the benchmark `include` and `exclude` scope so local runs stay focused on source
 roots rather than tests. If a project has `pyrightconfig.json`, the generated config extends it. If a project only has

--- a/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.test.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.test.ts
@@ -398,7 +398,7 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
                     '  throw new Error(`unexpected include paths: ${JSON.stringify(config.include)}`);',
                     '}',
                     'const result = {',
-                    '  generalDiagnostics: [{ severity: "error" }, { severity: "warning" }],',
+                    '  generalDiagnostics: [{ severity: "error", rule: "reportSyntheticError" }, { severity: "warning" }],',
                     '  summary: {',
                     '    filesAnalyzed: 3,',
                     '    errorCount: 1,',
@@ -429,10 +429,17 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
             expect(result.warningCount).toBe(1);
             expect(result.informationCount).toBe(0);
             expect(result.diagnostics).toEqual([
-                { file: undefined, range: undefined, severity: 'error', message: '' },
-                { file: undefined, range: undefined, severity: 'warning', message: '' },
+                {
+                    file: undefined,
+                    range: undefined,
+                    severity: 'error',
+                    message: '',
+                    rule: 'reportSyntheticError',
+                },
+                { file: undefined, range: undefined, severity: 'warning', message: '', rule: undefined },
             ]);
             expect(result.totalTimeMs).toBeGreaterThanOrEqual(0);
+            expect(result.analysisTimeMs).toBe(250);
         } finally {
             fs.rmSync(tempDir, { force: true, recursive: true });
         }
@@ -1061,6 +1068,7 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
                                     range: { start: { line: 9, character: 1 } },
                                     severity: 'warning',
                                     message: 'new diagnostic',
+                                    rule: 'reportSyntheticWarning',
                                 },
                             ],
                         },
@@ -1082,7 +1090,7 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
             expect(comparison.diagnosticDiffs).toEqual([
                 {
                     projectName: 'black',
-                    added: ['src/b.py:10:2 - warning: new diagnostic'],
+                    added: ['src/b.py:10:2 - warning: new diagnostic (reportSyntheticWarning)'],
                     removed: [],
                 },
             ]);
@@ -1090,7 +1098,7 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
             expect(fs.readFileSync(artifactPaths.markdownPath, 'utf-8')).toContain('## Type Check Result Diff');
             expect(fs.readFileSync(artifactPaths.markdownPath, 'utf-8')).toContain('```diff');
             expect(fs.readFileSync(artifactPaths.markdownPath, 'utf-8')).toContain(
-                '+   src/b.py:10:2 - warning: new diagnostic'
+                '+   src/b.py:10:2 - warning: new diagnostic (reportSyntheticWarning)'
             );
         } finally {
             fs.rmSync(reportsDir, { force: true, recursive: true });

--- a/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
@@ -67,6 +67,7 @@ export interface EcosystemBenchmarkExecutionConfig {
 export interface EcosystemBenchmarkResult {
     projectName: string;
     totalTimeMs?: number;
+    analysisTimeMs?: number;
     maxMemoryMB?: number;
     filesAnalyzed?: number;
     diagnosticCount?: number;
@@ -86,6 +87,7 @@ export interface EcosystemBenchmarkDiagnostic {
     };
     severity: string;
     message: string;
+    rule?: string;
 }
 
 export interface EcosystemBenchmarkDiagnosticDiff {
@@ -130,6 +132,7 @@ interface PyrightJsonDiagnostic {
         };
     };
     severity: string;
+    rule?: string;
 }
 
 interface PyrightJsonResults {
@@ -188,6 +191,7 @@ const pyrightPathStringConfigKeys = new Set(['stubPath', 'typeshedPath', 'venvPa
 
 const ecosystemBenchmarkComparisonMetrics: readonly BenchmarkMetricDefinition<EcosystemBenchmarkResult>[] = [
     { name: 'totalTimeMs', getValue: (result) => result.totalTimeMs },
+    { name: 'analysisTimeMs', getValue: (result) => result.analysisTimeMs },
     { name: 'maxMemoryMB', getValue: (result) => result.maxMemoryMB },
     { name: 'filesAnalyzed', lowerIsBetter: false, getValue: (result) => result.filesAnalyzed },
     { name: 'diagnosticCount', getValue: (result) => result.diagnosticCount },
@@ -198,6 +202,7 @@ const ecosystemBenchmarkComparisonMetrics: readonly BenchmarkMetricDefinition<Ec
 
 const ecosystemBenchmarkRegressionThresholds = new Map<string, BenchmarkRegressionThresholds>([
     ['totalTimeMs', { warnRegressionPct: 10, failRegressionPct: 25, minAbsoluteRegression: 500 }],
+    ['analysisTimeMs', { warnRegressionPct: 10, failRegressionPct: 25, minAbsoluteRegression: 250 }],
     ['maxMemoryMB', { warnRegressionPct: 15, failRegressionPct: 35, minAbsoluteRegression: 100 }],
     ['diagnosticCount', { warnRegressionAbsolute: 1, failRegressionAbsolute: 5, minAbsoluteRegression: 1 }],
     ['errorCount', { warnRegressionAbsolute: 1, failRegressionAbsolute: 3, minAbsoluteRegression: 1 }],
@@ -656,6 +661,7 @@ export function executePyrightProjectCommand(
     return {
         projectName,
         totalTimeMs: Math.round(elapsedMs * 100) / 100,
+        analysisTimeMs: Math.round(jsonResults.summary.timeInSec * 100_000) / 100,
         filesAnalyzed: jsonResults.summary.filesAnalyzed,
         diagnosticCount,
         errorCount: jsonResults.summary.errorCount,
@@ -748,11 +754,15 @@ function normalizePyrightDiagnostic(diagnostic: PyrightJsonDiagnostic): Ecosyste
         range: diagnostic.range,
         severity: diagnostic.severity,
         message: diagnostic.message ?? '',
+        rule: diagnostic.rule,
     };
 }
 
 function formatDiagnosticSignature(projectName: string, diagnostic: EcosystemBenchmarkDiagnostic): string {
-    return `${formatDiagnosticLocation(projectName, diagnostic)} - ${diagnostic.severity}: ${diagnostic.message}`;
+    const ruleText = diagnostic.rule ? ` (${diagnostic.rule})` : '';
+    return `${formatDiagnosticLocation(projectName, diagnostic)} - ${diagnostic.severity}: ${
+        diagnostic.message
+    }${ruleText}`;
 }
 
 function formatDiagnosticLocation(projectName: string, diagnostic: EcosystemBenchmarkDiagnostic): string {


### PR DESCRIPTION
Adds lower-noise and more faithful custom ecosystem benchmark signals.\n\nChanges:\n- Capture Pyright-reported analysis time from JSON output as nalysisTimeMs, alongside wall-clock 	otalTimeMs.\n- Compare nalysisTimeMs with its own warning/failure thresholds so reviewers get a metric less sensitive to process startup and runner noise.\n- Preserve Pyright diagnostic rule names in custom ecosystem diagnostic diffs.\n\nValidation:\n- packages/pyright-internal npm run build\n- PYRIGHT_RUN_BENCHMARKS=1 npx jest src/tests/benchmarks/runEcosystemBenchmark.test.ts --runInBand --forceExit --testTimeout=300000\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>