### PR TITLE
DO NOT MERGE: Test PR benchmark workflows

### DIFF
--- a/.github/workflows/mypy_primer_pr.yaml
+++ b/.github/workflows/mypy_primer_pr.yaml
@@ -10,6 +10,7 @@
 # mypy_primer are started in parallel. Each instance runs 1/n of the projects.
 # We use eight shards here so project checkout and type-checking work is
 # distributed across runners.
+# Benchmark test PRs can touch this comment to exercise the PR workflow.
 
 name: Run mypy_primer on PR
 


### PR DESCRIPTION
This disposable PR exercises the PR benchmark automation.\n\nExpected checks/comments:\n- Run mypy_primer on PR shards complete and trigger the comment workflow.\n- The PR receives/updates the **Pyright mypy_primer benchmark results** comment using the new scrollable full-diff behavior.\n- A manual ecosystem benchmark dispatch can post/update the **Pyright ecosystem benchmark stats** comment against this PR.\n\nDo not merge; close after verification.