### PR TITLE
DO NOT MERGE: Show benchmark comments

### DIFF
--- a/.github/workflows/mypy_primer_pr.yaml
+++ b/.github/workflows/mypy_primer_pr.yaml
@@ -10,6 +10,7 @@
 # mypy_primer are started in parallel. Each instance runs 1/n of the projects.
 # We use eight shards here so project checkout and type-checking work is
 # distributed across runners.
+# Disposable PRs can touch this comment to show benchmark comments.
 
 name: Run mypy_primer on PR
 


### PR DESCRIPTION
This disposable PR is intentionally left open so benchmark comments can be inspected.\n\nExpected comments:\n- **Pyright mypy_primer benchmark results** from the automatic PR workflow\n- **Pyright ecosystem benchmark stats** from a manual compare dispatch\n\nDo not merge.