### PR TITLE
Make ecosystem benchmark summary threshold-aware

### DIFF
--- a/packages/pyright-internal/src/tests/benchmarks/benchmarkComparison.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/benchmarkComparison.ts
@@ -47,6 +47,11 @@ export interface BenchmarkComparisonSummary {
     largestImprovements: BenchmarkMetricComparisonSummaryEntry[];
 }
 
+export interface BenchmarkComparisonMarkdownOptions {
+    summary?: BenchmarkComparisonSummary;
+    status?: string;
+}
+
 export interface BenchmarkRegressionThresholds {
     warnRegressionPct?: number;
     failRegressionPct?: number;
@@ -209,12 +214,15 @@ export function getBenchmarkRegressionThresholdResults(
         .sort(compareThresholdResults);
 }
 
-export function renderBenchmarkComparisonMarkdown(comparison: BenchmarkResultSetComparison): string {
-    const summary = summarizeBenchmarkComparison(comparison);
+export function renderBenchmarkComparisonMarkdown(
+    comparison: BenchmarkResultSetComparison,
+    options?: BenchmarkComparisonMarkdownOptions
+): string {
+    const summary = options?.summary ?? summarizeBenchmarkComparison(comparison);
     const lines = [
         '## Summary',
         '',
-        `Status: ${formatSummaryStatus(summary)}`,
+        `Status: ${options?.status ?? formatSummaryStatus(summary)}`,
         `Compared cases: ${summary.comparedResultCount}`,
         `Compared metrics: ${summary.metricCount}`,
         `Regressions: ${formatCountWithColor(summary.regressionCount, 'regression')}`,

--- a/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.test.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.test.ts
@@ -1006,8 +1006,15 @@ benchmarkSuite('Ecosystem Benchmark Runner', () => {
             );
 
             const artifactPaths = compareEcosystemBenchmarkReports(baselinePath, candidatePath, outputDir);
-            expect(fs.readFileSync(artifactPaths.markdownPath, 'utf-8')).toContain(
-                'No warning or failure thresholds exceeded.'
+            const markdown = fs.readFileSync(artifactPaths.markdownPath, 'utf-8');
+            expect(markdown).toContain(
+                'Status: $\\textcolor{gray}{No\\ actionable\\ regressions;\\ raw\\ metric\\ changes\\ below\\ thresholds}$'
+            );
+            expect(markdown).toContain('Regressions: 0');
+            expect(markdown).toContain('## Largest Regressions\n\nNone.');
+            expect(markdown).toContain('No warning or failure thresholds exceeded.');
+            expect(markdown).toContain(
+                '| black | totalTimeMs | 1000.00 | 1040.00 | $\\textcolor{red}{40.00}$ | $\\textcolor{red}{4.00\\%}$ |'
             );
         } finally {
             fs.rmSync(reportsDir, { force: true, recursive: true });

--- a/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
+++ b/packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import { ensureTomlModuleLoaded, parse } from '../../common/tomlUtils';
 
 import {
+    BenchmarkComparisonSummary,
     BenchmarkMetricDefinition,
     BenchmarkRegressionThresholdResult,
     BenchmarkRegressionThresholds,
@@ -15,6 +16,7 @@ import {
     compareBenchmarkReports,
     loadBenchmarkReport,
     renderBenchmarkComparisonMarkdown,
+    summarizeBenchmarkComparison,
     writeBenchmarkReportComparisonArtifacts,
 } from './benchmarkComparison';
 import { BenchmarkReport, createBenchmarkReport } from './benchmarkUtils';
@@ -791,8 +793,12 @@ function formatProjectRelativeDiagnosticPath(projectName: string, filePath: stri
 }
 
 function renderEcosystemBenchmarkComparisonMarkdown(comparison: EcosystemBenchmarkReportComparison): string {
+    const thresholdResults = getEcosystemBenchmarkThresholdResults(comparison);
     const lines = [
-        renderBenchmarkComparisonMarkdown(comparison).trimEnd(),
+        renderBenchmarkComparisonMarkdown(comparison, {
+            summary: summarizeEcosystemBenchmarkComparison(comparison, thresholdResults),
+            status: formatEcosystemBenchmarkSummaryStatus(comparison, thresholdResults),
+        }).trimEnd(),
         '',
         renderEcosystemBenchmarkThresholdMarkdown(comparison).trimEnd(),
         '',
@@ -815,6 +821,45 @@ function renderEcosystemBenchmarkComparisonMarkdown(comparison: EcosystemBenchma
 
     lines.push('```');
     return `${lines.join('\n')}\n`;
+}
+
+function summarizeEcosystemBenchmarkComparison(
+    comparison: EcosystemBenchmarkReportComparison,
+    thresholdResults: BenchmarkRegressionThresholdResult[]
+): BenchmarkComparisonSummary {
+    const rawSummary = summarizeBenchmarkComparison(comparison);
+    const thresholdRegressionCount = thresholdResults.length;
+
+    return {
+        ...rawSummary,
+        regressionCount: thresholdRegressionCount,
+        unchangedCount: rawSummary.metricCount - thresholdRegressionCount - rawSummary.improvementCount,
+        largestRegressions: thresholdResults.slice(0, rawSummary.largestRegressions.length),
+    };
+}
+
+function formatEcosystemBenchmarkSummaryStatus(
+    comparison: EcosystemBenchmarkReportComparison,
+    thresholdResults: BenchmarkRegressionThresholdResult[]
+): string {
+    if (thresholdResults.some((result) => result.severity === 'failure')) {
+        return formatSummaryStatusText('Actionable regressions detected', 'red');
+    }
+
+    if (thresholdResults.some((result) => result.severity === 'warning')) {
+        return formatSummaryStatusText('Regression warnings detected', 'red');
+    }
+
+    const rawSummary = summarizeBenchmarkComparison(comparison);
+    if (rawSummary.improvementCount > 0) {
+        return formatSummaryStatusText('No actionable regressions; improvements detected', 'green');
+    }
+
+    if (rawSummary.regressionCount > 0) {
+        return formatSummaryStatusText('No actionable regressions; raw metric changes below thresholds', 'gray');
+    }
+
+    return formatSummaryStatusText('No benchmark changes', 'gray');
 }
 
 function renderEcosystemBenchmarkThresholdMarkdown(comparison: EcosystemBenchmarkReportComparison): string {
@@ -895,6 +940,14 @@ function formatThresholdMetric(value: number): string {
 
 function formatThresholdPercent(value: number | undefined): string {
     return value === undefined ? 'n/a' : `${value.toFixed(2)}%`;
+}
+
+function formatSummaryStatusText(text: string, color: 'green' | 'gray' | 'red'): string {
+    return `$\\textcolor{${color}}{${escapeSummaryStatusText(text)}}$`;
+}
+
+function escapeSummaryStatusText(text: string): string {
+    return text.replace(/\\/g, '\\backslash{}').replace(/ /g, '\\ ').replace(/%/g, '\\%').replace(/_/g, '\\_');
 }
 
 function appendDiagnosticDiffProject(lines: string[], diff: EcosystemBenchmarkDiagnosticDiff): void {


### PR DESCRIPTION
## Summary\n- make ecosystem benchmark summary status/counts use actionable regression thresholds\n- keep raw below-threshold metric changes visible in details without making them the headline regression status\n- add coverage for small timing changes that should be treated as threshold noise\n\n## Validation\n- PYRIGHT_RUN_BENCHMARKS=1 npx jest src/tests/benchmarks/runEcosystemBenchmark.test.ts --runInBand --forceExit --testTimeout=300000\n- npm run check:eslint -- packages/pyright-internal/src/tests/benchmarks/benchmarkComparison.ts packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.test.ts\n- npx prettier --check packages/pyright-internal/src/tests/benchmarks/benchmarkComparison.ts packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.ts packages/pyright-internal/src/tests/benchmarks/runEcosystemBenchmark.test.ts\n- cd packages/pyright-internal && npm run build